### PR TITLE
Improve numerical stability Gauss-Laguerre quadrature

### DIFF
--- a/src/approximations/gausslaguerre.jl
+++ b/src/approximations/gausslaguerre.jl
@@ -6,17 +6,56 @@ using FastGaussQuadrature
 import Base: ==
 
 
-struct GaussLaguerreQuadrature{ R <: DomainIntegrals.HalfLineRule } <: AbstractApproximationMethod
+struct GaussLaguerreQuadrature{ R <: DomainIntegrals.HalfLineRule, W <: AbstractVector } <: AbstractApproximationMethod
     rule :: R
+    logw :: W
 end
 
-GaussLaguerreQuadrature(::Type{T}, n::Int) where T = GaussLaguerreQuadrature(DomainIntegrals.HalfLineRule(FastGaussQuadrature.gausslaguerre(n, zero(T))...))
-GaussLaguerreQuadrature(n::Int)                    = GaussLaguerreQuadrature(DomainIntegrals.HalfLineRule(FastGaussQuadrature.gausslaguerre(n)...))
+GaussLaguerreQuadrature(n::Int) = GaussLaguerreQuadrature(Float64, n)
 
-approximation_name(approx::GaussLaguerreQuadrature)       = "GaussLaguerre($(approx.rule))"
-approximation_short_name(approx::GaussLaguerreQuadrature) = "GL$(approx.rule)"
+function GaussLaguerreQuadrature(::Type{T}, n::Int) where T 
+    x, w = FastGaussQuadrature.gausslaguerre(n, zero(T))
+    logw = log.(w)
+    return GaussLaguerreQuadrature(DomainIntegrals.HalfLineRule(x, w), logw)
+end
+
+getpoints(approximation::GaussLaguerreQuadrature)     = points(approximation.rule)
+getweights(approximation::GaussLaguerreQuadrature)    = weights(approximation.rule)
+getlogweights(approximation::GaussLaguerreQuadrature) = approximation.logw
+getlength(approximation::GaussLaguerreQuadrature)     = length(getweights(approximation))
+
+approximation_name(approximation::GaussLaguerreQuadrature)       = "GaussLaguerre($(getlength(approximation)))"
+approximation_short_name(approximation::GaussLaguerreQuadrature) = "GL$(getlength(approximation))"
 
 approximate(approximation::GaussLaguerreQuadrature, fn::Function) = integral(approximation.rule, fn)
+
+"""
+This function calculates the log of the Gauss-laguerre integral by making use of the log of the integrable function.
+    ln ( ∫ exp(-x)f(x) dx ) 
+    ≈ ln ( ∑ wi * f(xi) ) 
+    = ln ( ∑ exp( ln(wi) + logf(xi) ) )
+    = ln ( ∑ exp( yi ) )
+    = max(yi) + ln ( ∑ exp( yi - max(yi) ) )
+    where we make use of the numerically stable log-sum-exp trick: https://en.wikipedia.org/wiki/LogSumExp
+"""
+function log_approximate(approximation::GaussLaguerreQuadrature, fn::Function)
+    # get weights and points
+    p    = getlength(approximation)
+    x    = getpoints(approximation)
+    logw = getlogweights(approximation)
+
+    # calculate the ln(wi) + logf(xi) terms
+    logresult = Vector{Float64}(undef, p)
+    for i = 1:p
+        logresult[i] = logw[i] + fn(x[i])
+    end
+
+    # log-sum-exp trick, calculate maximum
+    max_logresult = maximum(logresult)
+
+    # return log sum exp
+    return max_logresult + log(sum(exp.(logresult .- max_logresult)))
+end
 
 function Base.:(==)(left::GaussLaguerreQuadrature{R}, right::GaussLaguerreQuadrature{R}) where R 
     return length(weights(left.rule)) == length(weights(right.rule))


### PR DESCRIPTION
Transformed the Gauss-Laguerre quadrature integration methodology for moment matching, such that calculations only involve the log of the normalization constant to improve numerical stability.