### PR TITLE
Fix loggammamean

### DIFF
--- a/src/distributions/gamma.jl
+++ b/src/distributions/gamma.jl
@@ -14,7 +14,7 @@ end
 
 function loggammamean(dist::GammaShapeScale)
     k, θ = params(dist)
-    return 0.5 * (log2π - (digamma(k) + log(θ))) - mean(dist) * (1 + digamma(k + 1) + log(θ))
+    return 0.5 * (log2π - (digamma(k) + log(θ))) + mean(dist) * (-1 + digamma(k + 1) + log(θ))
 end
 
 function meanlogmean(dist::GammaShapeScale)

--- a/src/distributions/gamma_shape_rate.jl
+++ b/src/distributions/gamma_shape_rate.jl
@@ -33,7 +33,7 @@ end
 
 function loggammamean(dist::GammaShapeRate)
     a, b = params(dist)
-    return 0.5 * (log2π - (digamma(a) - log(b))) - mean(dist) * (1 + digamma(a + 1) - log(b))
+    return 0.5 * (log2π - (digamma(a) - log(b))) + mean(dist) * (-1 + digamma(a + 1) - log(b))
 end
 
 function meanlogmean(dist::GammaShapeRate)

--- a/src/nodes/gamma.jl
+++ b/src/nodes/gamma.jl
@@ -6,5 +6,5 @@
 end
 
 @average_energy Gamma (q_out::Any, q_α::GammaDistributionsFamily, q_θ::Any) = begin
-    meanlogmean(q_α) - mean(q_α) + 0.5 * (log2π - logmean(q_α)) + mean(q_α) * logmean(q_θ) - (mean(q_α) - 1.0) * logmean(q_out) + mean(q_out)/mean(q_θ)
+    loggammamean(q_α) + mean(q_α) * logmean(q_θ) - (mean(q_α) - 1.0) * logmean(q_out) + mean(q_out)/mean(q_θ)
 end

--- a/src/nodes/gamma_shape_rate.jl
+++ b/src/nodes/gamma_shape_rate.jl
@@ -8,5 +8,5 @@ import StatsFuns: log2π
 end
 
 @average_energy GammaShapeRate (q_out::Any, q_α::GammaDistributionsFamily, q_β::Any) = begin
-    meanlogmean(q_α) - mean(q_α) + 0.5 * (log2π - logmean(q_α)) - mean(q_α) * logmean(q_β) - (mean(q_α) - 1.0) * logmean(q_out) + mean(q_β) * mean(q_out)
+    loggammamean(q_α) - mean(q_α) * logmean(q_β) - (mean(q_α) - 1.0) * logmean(q_out) + mean(q_β) * mean(q_out)
 end


### PR DESCRIPTION
The last fix for the `loggammamean` function was not entirely correct. The `loggammamean` function is now correct under the Stirling approximation. Furthermore this PR simplifies the average energies as there were no terms in the current version that cancelled out.