### PR TITLE
extend update rules for mvnormal

### DIFF
--- a/src/rule.jl
+++ b/src/rule.jl
@@ -266,6 +266,11 @@ macro test_rules(options, on, test_sequence)
     @capture(options, [ option_entries__ ]) || error("Invalid options specification. Options should be in the form on an array.")
     
     with_float_conversions = false
+
+    float64_atol  = 1e-12
+    float32_atol  = 1e-6
+    bigfloat_atol = 1e-12
+
     
     foreach(option_entries) do option_entry 
         @capture(option_entry, (key_ = value_)) || error("Invalid option entry specification: $(option_entry). Option entry should be in the form of a 'key = value' pair.")
@@ -277,6 +282,12 @@ macro test_rules(options, on, test_sequence)
             else
                 error("Unknown value $(value) for option $(key). Can be either true or false.")
             end
+        elseif key === :float64_atol
+            float64_atol = float(value)
+        elseif key === :float32_atol
+            float32_atol = float(value)
+        elseif key === :bigfloat_atol
+            bigfloat_atol = float(value)
         else 
             error("Unknown option $(key)")
         end
@@ -294,7 +305,7 @@ macro test_rules(options, on, test_sequence)
             quote 
                 begin
                     local $test_output_s = ReactiveMP.@call_rule($on, $input)
-                    @test isapprox( $test_output_s, $output; atol = 1e-12) 
+                    @test isapprox( $test_output_s, $output; atol = $float64_atol) 
                     @test ReactiveMP.is_typeof_equal($test_output_s, $output)
                 end
             end
@@ -339,7 +350,7 @@ macro test_rules(options, on, test_sequence)
                 push!(test_rule.args, quote 
                     begin 
                         local $output_s = ReactiveMP.@call_rule($on, $(m_f32_input[1]))
-                        @test isapprox($output_s, $m_f32_output; atol = 1e-6)     
+                        @test isapprox($output_s, $m_f32_output; atol = $float32_atol)     
                         @test ReactiveMP.is_typeof_equal($output_s, $m_f32_output)
                     end
                 end)
@@ -360,7 +371,7 @@ macro test_rules(options, on, test_sequence)
                 push!(test_rule.args, quote
                     begin 
                         local $output_s = ReactiveMP.@call_rule($on, $(m_bigf_input[1]))
-                        @test isapprox($output_s, $m_bigf_output; atol = 1e-12)     
+                        @test isapprox($output_s, $m_bigf_output; atol = $bigfloat_atol)
                         @test ReactiveMP.is_typeof_equal($output_s, $m_bigf_output)
                     end
                 end)

--- a/src/rules/addition/in1.jl
+++ b/src/rules/addition/in1.jl
@@ -13,6 +13,7 @@ export rule
 end
 
 @rule typeof(+)(:in1, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_in2::MultivariateNormalDistributionsFamily) = begin
-    c1, c2 = cov(m_out), cov(m_in2)
-    return MvNormalMeanCovariance(mean(m_out) - mean(m_in2), c1 + c2)
+    mout, vout = mean_cov(m_out)
+    m2, v2 = mean_cov(m_in2)
+    return MvNormalMeanCovariance(mout- m2, vout + v2)
 end

--- a/src/rules/addition/in1.jl
+++ b/src/rules/addition/in1.jl
@@ -11,3 +11,8 @@ export rule
     p1, p2 = precision(m_out), precision(m_in2)
     return NormalMeanPrecision(mean(m_out) - mean(m_in2), p1 * p2 / (p1 + p2))
 end
+
+@rule typeof(+)(:in1, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_in2::MultivariateNormalDistributionsFamily) = begin
+    c1, c2 = cov(m_out), cov(m_in2)
+    return MvNormalMeanCovariance(mean(m_out) - mean(m_in2), c1 + c2)
+end

--- a/src/rules/addition/in2.jl
+++ b/src/rules/addition/in2.jl
@@ -12,6 +12,7 @@ export rule
 end
 
 @rule typeof(+)(:in2, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_in1::MultivariateNormalDistributionsFamily) = begin
-    c1, c2 = cov(m_out), cov(m_in1)
-    return MvNormalMeanCovariance(mean(m_out) - mean(m_in1), c1 + c2)
+    mout, vout = mean_cov(m_out)
+    m1, v1 = mean_cov(m_in1)
+    return MvNormalMeanCovariance(mout- m1, vout + v1)
 end

--- a/src/rules/addition/in2.jl
+++ b/src/rules/addition/in2.jl
@@ -10,3 +10,8 @@ export rule
     p1, p2 = precision(m_out), precision(m_in1)
     return NormalMeanPrecision(mean(m_out) - mean(m_in1), p1 * p2 / (p1 + p2))
 end
+
+@rule typeof(+)(:in2, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_in1::MultivariateNormalDistributionsFamily) = begin
+    c1, c2 = cov(m_out), cov(m_in1)
+    return MvNormalMeanCovariance(mean(m_out) - mean(m_in1), c1 + c2)
+end

--- a/src/rules/addition/out.jl
+++ b/src/rules/addition/out.jl
@@ -9,3 +9,5 @@ export rule
     p1, p2 = precision(m_in1), precision(m_in2)
     return NormalMeanPrecision(mean(m_in1) + mean(m_in2), p1 * p2 / (p1 + p2))
 end
+
+@rule typeof(+)(:out, Marginalisation) (m_in1::MultivariateNormalDistributionsFamily, m_in2::MultivariateNormalDistributionsFamily) = MvNormalMeanCovariance(mean(m_in1) + mean(m_in2), cov(m_in1) + cov(m_in2))

--- a/src/rules/addition/out.jl
+++ b/src/rules/addition/out.jl
@@ -10,4 +10,8 @@ export rule
     return NormalMeanPrecision(mean(m_in1) + mean(m_in2), p1 * p2 / (p1 + p2))
 end
 
-@rule typeof(+)(:out, Marginalisation) (m_in1::MultivariateNormalDistributionsFamily, m_in2::MultivariateNormalDistributionsFamily) = MvNormalMeanCovariance(mean(m_in1) + mean(m_in2), cov(m_in1) + cov(m_in2))
+@rule typeof(+)(:out, Marginalisation) (m_in1::MultivariateNormalDistributionsFamily, m_in2::MultivariateNormalDistributionsFamily) = begin
+    m1, v1 = mean_cov(m_in1)
+    m2, v2 = mean_cov(m_in2)
+    return MvNormalMeanCovariance(m1 + m2, v1 + v2)
+end

--- a/src/rules/mv_normal_mean_covariance/mean.jl
+++ b/src/rules/mv_normal_mean_covariance/mean.jl
@@ -1,12 +1,15 @@
-export rule
 
-@rule MvNormalMeanCovariance(:μ, Marginalisation) (m_out::PointMass, m_Σ::PointMass)                             = MvNormalMeanCovariance(mean(m_out), mean(m_Σ))
+# Belief Propagation                #
+# --------------------------------- #
+@rule MvNormalMeanCovariance(:μ, Marginalisation) (m_out::PointMass, m_Σ::PointMass) = MvNormalMeanCovariance(mean(m_out), mean(m_Σ))
 
 @rule MvNormalMeanCovariance(:μ, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_Σ::PointMass) = begin 
     m_out_mean, m_out_cov = mean_cov(m_out)
     return MvNormalMeanCovariance(m_out_mean, m_out_cov + mean(m_Σ))
 end
 
+# Variational                       # 
+# --------------------------------- #
 @rule MvNormalMeanCovariance(:μ, Marginalisation) (q_out::Any, q_Σ::Any) = MvNormalMeanCovariance(mean(q_out), mean(q_Σ))
 
 @rule MvNormalMeanCovariance(:μ, Marginalisation) (m_out::PointMass, q_Σ::Any) = MvNormalMeanCovariance(mean(m_out), mean(q_Σ))

--- a/src/rules/mv_normal_mean_covariance/out.jl
+++ b/src/rules/mv_normal_mean_covariance/out.jl
@@ -12,6 +12,8 @@ end
 # --------------------------------- #
 @rule MvNormalMeanCovariance(:out, Marginalisation) (q_μ::Any, q_Σ::Any) = MvNormalMeanCovariance(mean(q_μ), mean(q_Σ))
 
+@rule MvNormalMeanCovariance(:out, Marginalisation) (m_μ::PointMass, q_Σ::Any) = MvNormalMeanCovariance(mean(m_μ), mean(q_Σ))
+
 @rule MvNormalMeanCovariance(:out, Marginalisation) (m_μ::MultivariateNormalDistributionsFamily, q_Σ::Any) = begin 
     m_μ_mean, m_μ_cov = mean_cov(m_μ)
     return MvNormalMeanCovariance(m_μ_mean, m_μ_cov + mean(q_Σ))

--- a/src/rules/mv_normal_mean_covariance/out.jl
+++ b/src/rules/mv_normal_mean_covariance/out.jl
@@ -1,5 +1,6 @@
-export rule
 
+# Belief Propagation                #
+# --------------------------------- #
 @rule MvNormalMeanCovariance(:out, Marginalisation) (m_μ::PointMass, m_Σ::PointMass) = MvNormalMeanCovariance(mean(m_μ), mean(m_Σ))
 
 @rule MvNormalMeanCovariance(:out, Marginalisation) (m_μ::MultivariateNormalDistributionsFamily, m_Σ::PointMass) = begin 
@@ -7,6 +8,8 @@ export rule
     return MvNormalMeanCovariance(m_μ_mean, m_μ_cov + mean(m_Σ))
 end
 
+# Variational                       # 
+# --------------------------------- #
 @rule MvNormalMeanCovariance(:out, Marginalisation) (q_μ::Any, q_Σ::Any) = MvNormalMeanCovariance(mean(q_μ), mean(q_Σ))
 
 @rule MvNormalMeanCovariance(:out, Marginalisation) (m_μ::MultivariateNormalDistributionsFamily, q_Σ::Any) = begin 

--- a/src/rules/mv_normal_mean_precision/mean.jl
+++ b/src/rules/mv_normal_mean_precision/mean.jl
@@ -2,11 +2,11 @@ export rule
 
 @rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::PointMass, m_Λ::PointMass) = MvNormalMeanPrecision(mean(m_out), mean(m_Λ))
 
-@rule MvNormalMeanPrecision(:μ, Marginalisation) (q_out::Any, q_Λ::Any) = MvNormalMeanPrecision(mean(q_out), mean(q_Λ))
-
-@rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MvNormalMeanPrecision, q_Λ::Any) = MvNormalMeanPrecision(mean(m_out), cholinv(cov(m_out) + cholinv(mean(q_Λ))))
-
 @rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_Λ::PointMass) = begin
     mout, vout = mean_cov(m_out)
     return MvNormalMeanCovariance(mout, v_out + cholinv(mean(m_Λ)))
 end
+
+@rule MvNormalMeanPrecision(:μ, Marginalisation) (q_out::Any, q_Λ::Any) = MvNormalMeanPrecision(mean(q_out), mean(q_Λ))
+
+@rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MvNormalMeanPrecision, q_Λ::Any) = MvNormalMeanPrecision(mean(m_out), cholinv(cov(m_out) + cholinv(mean(q_Λ))))

--- a/src/rules/mv_normal_mean_precision/mean.jl
+++ b/src/rules/mv_normal_mean_precision/mean.jl
@@ -5,3 +5,5 @@ export rule
 @rule MvNormalMeanPrecision(:μ, Marginalisation) (q_out::Any, q_Λ::Any) = MvNormalMeanPrecision(mean(q_out), mean(q_Λ))
 
 @rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MvNormalMeanPrecision, q_Λ::Any) = MvNormalMeanPrecision(mean(m_out), cholinv(cov(m_out) + cholinv(mean(q_Λ))))
+
+@rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_Λ::PointMass) = MvNormalMeanPrecision(mean(m_out), cholinv(cov(m_out) + cholinv(mean(m_Λ))))

--- a/src/rules/mv_normal_mean_precision/mean.jl
+++ b/src/rules/mv_normal_mean_precision/mean.jl
@@ -1,12 +1,18 @@
-export rule
 
+# Belief Propagation                #
+# --------------------------------- #
 @rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::PointMass, m_Λ::PointMass) = MvNormalMeanPrecision(mean(m_out), mean(m_Λ))
 
 @rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_Λ::PointMass) = begin
-    mout, vout = mean_cov(m_out)
-    return MvNormalMeanCovariance(mout, vout + cholinv(mean(m_Λ)))
+    m_out_mean, m_out_cov = mean_cov(m_out)
+    return MvNormalMeanCovariance(m_out_mean, m_out_cov + cholinv(mean(m_Λ)))
 end
 
+# Variational                       # 
+# --------------------------------- #
 @rule MvNormalMeanPrecision(:μ, Marginalisation) (q_out::Any, q_Λ::Any) = MvNormalMeanPrecision(mean(q_out), mean(q_Λ))
 
-@rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MvNormalMeanPrecision, q_Λ::Any) = MvNormalMeanCovariance(mean(m_out), cov(m_out) + cholinv(mean(q_Λ)))
+@rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, q_Λ::Any) = begin 
+    m_out_mean, m_out_cov = mean_cov(m_out)
+    return MvNormalMeanCovariance(m_out_mean, m_out_cov + cholinv(mean(q_Λ)))
+end

--- a/src/rules/mv_normal_mean_precision/mean.jl
+++ b/src/rules/mv_normal_mean_precision/mean.jl
@@ -4,9 +4,9 @@ export rule
 
 @rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_Λ::PointMass) = begin
     mout, vout = mean_cov(m_out)
-    return MvNormalMeanCovariance(mout, v_out + cholinv(mean(m_Λ)))
+    return MvNormalMeanCovariance(mout, vout + cholinv(mean(m_Λ)))
 end
 
 @rule MvNormalMeanPrecision(:μ, Marginalisation) (q_out::Any, q_Λ::Any) = MvNormalMeanPrecision(mean(q_out), mean(q_Λ))
 
-@rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MvNormalMeanPrecision, q_Λ::Any) = MvNormalMeanPrecision(mean(m_out), cholinv(cov(m_out) + cholinv(mean(q_Λ))))
+@rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MvNormalMeanPrecision, q_Λ::Any) = MvNormalMeanCovariance(mean(m_out), cov(m_out) + cholinv(mean(q_Λ)))

--- a/src/rules/mv_normal_mean_precision/mean.jl
+++ b/src/rules/mv_normal_mean_precision/mean.jl
@@ -6,4 +6,7 @@ export rule
 
 @rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MvNormalMeanPrecision, q_Λ::Any) = MvNormalMeanPrecision(mean(m_out), cholinv(cov(m_out) + cholinv(mean(q_Λ))))
 
-@rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_Λ::PointMass) = MvNormalMeanPrecision(mean(m_out), cholinv(cov(m_out) + cholinv(mean(m_Λ))))
+@rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_Λ::PointMass) = begin
+    mout, vout = mean_cov(m_out)
+    return MvNormalMeanCovariance(mout, v_out + cholinv(mean(m_Λ)))
+end

--- a/src/rules/mv_normal_mean_precision/mean.jl
+++ b/src/rules/mv_normal_mean_precision/mean.jl
@@ -12,6 +12,8 @@ end
 # --------------------------------- #
 @rule MvNormalMeanPrecision(:μ, Marginalisation) (q_out::Any, q_Λ::Any) = MvNormalMeanPrecision(mean(q_out), mean(q_Λ))
 
+@rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::PointMass, q_Λ::Any) = MvNormalMeanPrecision(mean(q_out), mean(q_Λ))
+
 @rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, q_Λ::Any) = begin 
     m_out_mean, m_out_cov = mean_cov(m_out)
     return MvNormalMeanCovariance(m_out_mean, m_out_cov + cholinv(mean(q_Λ)))

--- a/src/rules/mv_normal_mean_precision/mean.jl
+++ b/src/rules/mv_normal_mean_precision/mean.jl
@@ -12,7 +12,7 @@ end
 # --------------------------------- #
 @rule MvNormalMeanPrecision(:μ, Marginalisation) (q_out::Any, q_Λ::Any) = MvNormalMeanPrecision(mean(q_out), mean(q_Λ))
 
-@rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::PointMass, q_Λ::Any) = MvNormalMeanPrecision(mean(q_out), mean(q_Λ))
+@rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::PointMass, q_Λ::Any) = MvNormalMeanPrecision(mean(m_out), mean(q_Λ))
 
 @rule MvNormalMeanPrecision(:μ, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, q_Λ::Any) = begin 
     m_out_mean, m_out_cov = mean_cov(m_out)

--- a/src/rules/mv_normal_mean_precision/out.jl
+++ b/src/rules/mv_normal_mean_precision/out.jl
@@ -1,12 +1,18 @@
-export rule
 
+# Belief Propagation                #
+# --------------------------------- #
 @rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::PointMass, m_Λ::PointMass) = MvNormalMeanPrecision(mean(m_μ), mean(m_Λ))
 
 @rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MultivariateNormalDistributionsFamily, m_Λ::PointMass) = begin
-    mμ, vμ = mean_cov(m_μ)
-    return MvNormalMeanCovariance(mμ, vμ + cholinv(mean(m_Λ)))
+    m_μ_mean, m_μ_cov = mean_cov(m_μ)
+    return MvNormalMeanCovariance(m_μ_mean, m_μ_cov + cholinv(mean(m_Λ)))
 end
 
+# Variational                       # 
+# --------------------------------- #
 @rule MvNormalMeanPrecision(:out, Marginalisation) (q_μ::Any, q_Λ::Any) = MvNormalMeanPrecision(mean(q_μ), mean(q_Λ))
 
-@rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MvNormalMeanPrecision, q_Λ::Any) = MvNormalMeanCovariance(mean(m_μ), cov(m_μ) + cholinv(mean(q_Λ)))
+@rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MultivariateNormalDistributionsFamily, q_Λ::Any) = begin 
+    m_μ_mean, m_μ_cov = mean_cov(m_μ)
+    return MvNormalMeanCovariance(m_μ_mean, m_μ_cov + cholinv(mean(q_Λ)))
+end

--- a/src/rules/mv_normal_mean_precision/out.jl
+++ b/src/rules/mv_normal_mean_precision/out.jl
@@ -12,6 +12,8 @@ end
 # --------------------------------- #
 @rule MvNormalMeanPrecision(:out, Marginalisation) (q_μ::Any, q_Λ::Any) = MvNormalMeanPrecision(mean(q_μ), mean(q_Λ))
 
+@rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::PointMass, q_Λ::Any) = MvNormalMeanPrecision(mean(q_μ), mean(q_Λ))
+
 @rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MultivariateNormalDistributionsFamily, q_Λ::Any) = begin 
     m_μ_mean, m_μ_cov = mean_cov(m_μ)
     return MvNormalMeanCovariance(m_μ_mean, m_μ_cov + cholinv(mean(q_Λ)))

--- a/src/rules/mv_normal_mean_precision/out.jl
+++ b/src/rules/mv_normal_mean_precision/out.jl
@@ -5,3 +5,5 @@ export rule
 @rule MvNormalMeanPrecision(:out, Marginalisation) (q_μ::Any, q_Λ::Any) = MvNormalMeanPrecision(mean(q_μ), mean(q_Λ))
 
 @rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MvNormalMeanPrecision, q_Λ::Any) = MvNormalMeanPrecision(mean(m_μ), cholinv(cov(m_μ) + cholinv(mean(q_Λ))))
+
+@rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MultivariateNormalDistributionsFamily, m_Λ::PointMass) = MvNormalMeanPrecision(mean(m_μ), cholinv(cov(m_μ) + cholinv(mean(m_Λ))))

--- a/src/rules/mv_normal_mean_precision/out.jl
+++ b/src/rules/mv_normal_mean_precision/out.jl
@@ -2,11 +2,11 @@ export rule
 
 @rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::PointMass, m_Λ::PointMass) = MvNormalMeanPrecision(mean(m_μ), mean(m_Λ))
 
-@rule MvNormalMeanPrecision(:out, Marginalisation) (q_μ::Any, q_Λ::Any) = MvNormalMeanPrecision(mean(q_μ), mean(q_Λ))
-
-@rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MvNormalMeanPrecision, q_Λ::Any) = MvNormalMeanPrecision(mean(m_μ), cholinv(cov(m_μ) + cholinv(mean(q_Λ))))
-
 @rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MultivariateNormalDistributionsFamily, m_Λ::PointMass) = begin
     mμ, vμ = mean_cov(m_μ)
     return MvNormalMeanCovariance(mμ, vμ + cholinv(mean(m_Λ)))
 end
+
+@rule MvNormalMeanPrecision(:out, Marginalisation) (q_μ::Any, q_Λ::Any) = MvNormalMeanPrecision(mean(q_μ), mean(q_Λ))
+
+@rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MvNormalMeanPrecision, q_Λ::Any) = MvNormalMeanPrecision(mean(m_μ), cholinv(cov(m_μ) + cholinv(mean(q_Λ))))

--- a/src/rules/mv_normal_mean_precision/out.jl
+++ b/src/rules/mv_normal_mean_precision/out.jl
@@ -9,4 +9,4 @@ end
 
 @rule MvNormalMeanPrecision(:out, Marginalisation) (q_μ::Any, q_Λ::Any) = MvNormalMeanPrecision(mean(q_μ), mean(q_Λ))
 
-@rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MvNormalMeanPrecision, q_Λ::Any) = MvNormalMeanPrecision(mean(m_μ), cholinv(cov(m_μ) + cholinv(mean(q_Λ))))
+@rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MvNormalMeanPrecision, q_Λ::Any) = MvNormalMeanCovariance(mean(m_μ), cov(m_μ) + cholinv(mean(q_Λ)))

--- a/src/rules/mv_normal_mean_precision/out.jl
+++ b/src/rules/mv_normal_mean_precision/out.jl
@@ -6,4 +6,7 @@ export rule
 
 @rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MvNormalMeanPrecision, q_Λ::Any) = MvNormalMeanPrecision(mean(m_μ), cholinv(cov(m_μ) + cholinv(mean(q_Λ))))
 
-@rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MultivariateNormalDistributionsFamily, m_Λ::PointMass) = MvNormalMeanPrecision(mean(m_μ), cholinv(cov(m_μ) + cholinv(mean(m_Λ))))
+@rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MultivariateNormalDistributionsFamily, m_Λ::PointMass) = begin
+    mμ, vμ = mean_cov(m_μ)
+    return MvNormalMeanCovariance(mμ, vμ + cholinv(mean(m_Λ)))
+end

--- a/src/rules/mv_normal_mean_precision/out.jl
+++ b/src/rules/mv_normal_mean_precision/out.jl
@@ -12,7 +12,7 @@ end
 # --------------------------------- #
 @rule MvNormalMeanPrecision(:out, Marginalisation) (q_μ::Any, q_Λ::Any) = MvNormalMeanPrecision(mean(q_μ), mean(q_Λ))
 
-@rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::PointMass, q_Λ::Any) = MvNormalMeanPrecision(mean(q_μ), mean(q_Λ))
+@rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::PointMass, q_Λ::Any) = MvNormalMeanPrecision(mean(m_μ), mean(q_Λ))
 
 @rule MvNormalMeanPrecision(:out, Marginalisation) (m_μ::MultivariateNormalDistributionsFamily, q_Λ::Any) = begin 
     m_μ_mean, m_μ_cov = mean_cov(m_μ)

--- a/src/rules/mv_normal_mean_precision/precision.jl
+++ b/src/rules/mv_normal_mean_precision/precision.jl
@@ -1,8 +1,8 @@
 export rule
 
-@rule MvNormalMeanPrecision(:Λ, Marginalisation) (q_out::PointMass, q_μ::MvNormalMeanPrecision) = begin
-    (m_mean, v_mean) = mean(q_μ), cov(q_μ)
-    (m_out, v_out)   = mean(q_out), cov(q_out)
+@rule MvNormalMeanPrecision(:Λ, Marginalisation) (q_out::PointMass, q_μ::MultivariateNormalDistributionsFamily) = begin
+    m_mean, v_mean = mean_cov(q_μ)
+    m_out, v_out   = mean_cov(q_out)
 
     df = ndims(q_μ) + 2.0
     S  = Matrix(Hermitian(cholinv(v_mean + v_out + (m_mean - m_out)*(m_mean - m_out)')))

--- a/src/rules/mv_normal_mean_precision/precision.jl
+++ b/src/rules/mv_normal_mean_precision/precision.jl
@@ -1,7 +1,7 @@
 
 # Variational                       # 
 # --------------------------------- #
-@rule MvNormalMeanPrecision(:Λ, Marginalisation) (q_out::PointMass, q_μ::MultivariateNormalDistributionsFamily) = begin
+@rule MvNormalMeanPrecision(:Λ, Marginalisation) (q_out::Any, q_μ::Any) = begin
     m_out, v_out   = mean_cov(q_out)
     m_mean, v_mean = mean_cov(q_μ)
 

--- a/src/rules/mv_normal_mean_precision/precision.jl
+++ b/src/rules/mv_normal_mean_precision/precision.jl
@@ -1,11 +1,12 @@
-export rule
 
+# Variational                       # 
+# --------------------------------- #
 @rule MvNormalMeanPrecision(:Λ, Marginalisation) (q_out::PointMass, q_μ::MultivariateNormalDistributionsFamily) = begin
-    m_mean, v_mean = mean_cov(q_μ)
     m_out, v_out   = mean_cov(q_out)
+    m_mean, v_mean = mean_cov(q_μ)
 
-    df = ndims(q_μ) + 2.0
-    S  = Matrix(Hermitian(cholinv(v_mean + v_out + (m_mean - m_out)*(m_mean - m_out)')))
+    df = ndims(q_μ) + 2
+    S  = Matrix(Hermitian(cholinv(v_mean + v_out + (m_mean - m_out) * (m_mean - m_out)')))
 
     return Wishart(df, S)
 end

--- a/test/rules/mv_normal_mean_covariance/test_mean.jl
+++ b/test/rules/mv_normal_mean_covariance/test_mean.jl
@@ -1,0 +1,76 @@
+module RulesMvNormalMeanCovarianceMeanTest
+
+using Test
+using ReactiveMP
+using Random
+
+import ReactiveMP: @test_rules
+
+@testset "rules:MvNormalMeanCovariance:mean" begin
+
+    @testset "Belief Propagation: (m_out::PointMass, m_Σ::PointMass)" begin
+        
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
+            (input = (m_out = PointMass([-1.0]), m_Σ = PointMass([2.0])), output = MvNormalMeanCovariance([-1.0], [2.0])),
+            (input = (m_out = PointMass([1.0]), m_Σ = PointMass([2.0])),  output = MvNormalMeanCovariance([1.0], [2.0])),
+            (input = (m_out = PointMass([2.0]), m_Σ = PointMass([1.0])),  output = MvNormalMeanCovariance([2.0], [1.0])),
+            (input = (m_out = PointMass([1.0; 3.0]), m_Σ = PointMass([3.0 2.0; 2.0 4.0])),  output = MvNormalMeanCovariance([1.0; 3.0], [3.0 2.0; 2.0 4.0]))
+        ]
+
+    end
+
+    @testset "Belief Propagation: (m_out::MultivariateNormalDistributionsFamily, m_Σ::PointMass)" begin
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
+            (input = (m_out = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]),  m_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
+            (input = (m_out = MvNormalMeanPrecision([2.0; 1.0], [0.5 -0.25; -0.25 0.375]),  m_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
+            (input = (m_out = MvNormalWeightedMeanPrecision([0.75; -0.125], [0.5 -0.25; -0.25 0.375]),  m_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0])),
+        ]
+
+    end
+
+    @testset "Variational: (q_out::Any, q_Σ::Any)" begin
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
+            (input = (q_out = PointMass([2.0; 1.0]), q_Σ = PointMass([2.0 1.0; 5.0 5.0])), output = MvNormalMeanCovariance([2.0; 1.0], [2.0 1.0; 5.0 5.0]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
+            (input = (q_out = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [6.0 4.0; 4.0 8.0]))
+        ]
+
+    end
+
+    @testset "Structured variational: (m_out::PointMass, q_Σ::Any)" begin
+        
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
+            (input = (m_out = PointMass([2.0; 1.0]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [6.0 4.0; 4.0 8.0]))
+        ]
+        
+    end
+
+    @testset "Structured variational: (m_out::MultivariateNormalDistributionsFamily, q_Σ::Any)" begin
+        
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
+            (input = (m_out = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+        ]
+       
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
+            (input = (m_out = MvNormalMeanPrecision([2.0; 1.0], [0.5 -0.25; -0.25 0.375]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
+            (input = (m_out = MvNormalWeightedMeanPrecision([0.75; -0.125], [0.5 -0.25; -0.25 0.375]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+        ]
+        
+    end
+
+end
+
+end

--- a/test/rules/mv_normal_mean_covariance/test_mean.jl
+++ b/test/rules/mv_normal_mean_covariance/test_mean.jl
@@ -76,15 +76,21 @@ import ReactiveMP: @test_rules
     @testset "Structured variational: (m_out::MultivariateNormalDistributionsFamily, q_Σ::Any)" begin
         
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
-            (input = (m_out = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+            (input = (m_out = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   q_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 13/2 15/4; 15/4 67/8 ])),
+            (input = (m_out = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Σ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 753/62 -123/62; -123/62 441/62 ])),
+            (input = (m_out = MvNormalMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
         ]
        
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
-            (input = (m_out = MvNormalMeanPrecision([2.0; 1.0], [0.5 -0.25; -0.25 0.375]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+            (input = (m_out = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),  q_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])),     output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 9.0 6.0; 6.0 12.0 ])),
+            (input = (m_out = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Σ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 19.0 -3.0; -3.0 16.0 ])),
+            (input = (m_out = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ]))
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
-            (input = (m_out = MvNormalWeightedMeanPrecision([0.75; -0.125], [0.5 -0.25; -0.25 0.375]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   q_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 3/4, -1/8 ], [ 13/2 15/4; 15/4 67/8 ])),
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Σ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 753/62 -123/62; -123/62 441/62 ])),
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
         ]
         
     end

--- a/test/rules/mv_normal_mean_covariance/test_mean.jl
+++ b/test/rules/mv_normal_mean_covariance/test_mean.jl
@@ -11,10 +11,12 @@ import ReactiveMP: @test_rules
     @testset "Belief Propagation: (m_out::PointMass, m_Σ::PointMass)" begin
         
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
-            (input = (m_out = PointMass([-1.0]), m_Σ = PointMass([2.0])), output = MvNormalMeanCovariance([-1.0], [2.0])),
-            (input = (m_out = PointMass([1.0]), m_Σ = PointMass([2.0])),  output = MvNormalMeanCovariance([1.0], [2.0])),
-            (input = (m_out = PointMass([2.0]), m_Σ = PointMass([1.0])),  output = MvNormalMeanCovariance([2.0], [1.0])),
-            (input = (m_out = PointMass([1.0; 3.0]), m_Σ = PointMass([3.0 2.0; 2.0 4.0])),  output = MvNormalMeanCovariance([1.0; 3.0], [3.0 2.0; 2.0 4.0]))
+            (input = (m_out = PointMass([ -1.0 ]), m_Σ = PointMass([ 2.0 ])), output = MvNormalMeanCovariance([ -1.0 ], [ 2.0 ])),
+            (input = (m_out = PointMass([  1.0 ]), m_Σ = PointMass([ 2.0 ])), output = MvNormalMeanCovariance([  1.0 ], [ 2.0 ])),
+            (input = (m_out = PointMass([ 2.0 ]),  m_Σ = PointMass([ 1.0 ])), output = MvNormalMeanCovariance([  2.0 ], [ 1.0 ])),
+            (input = (m_out = PointMass([ 1.0, 3.0 ]),  m_Σ = PointMass([ 3.0 2.0; 2.0 4.0 ])),   output = MvNormalMeanCovariance([ 1.0, 3.0 ], [ 3.0 2.0; 2.0 4.0 ])),
+            (input = (m_out = PointMass([ -1.0, 2.0 ]), m_Σ = PointMass([ 7.0 -1.0; -1.0 9.0 ])), output = MvNormalMeanCovariance([ -1.0, 2.0 ], [ 7.0 -1.0; -1.0 9.0 ])),
+            (input = (m_out = PointMass([ 0.0, 0.0 ]),  m_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),   output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 1.0 0.0; 0.0 1.0 ]))
         ]
 
     end
@@ -22,15 +24,22 @@ import ReactiveMP: @test_rules
     @testset "Belief Propagation: (m_out::MultivariateNormalDistributionsFamily, m_Σ::PointMass)" begin
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
-            (input = (m_out = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]),  m_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+            (input = (m_out = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   m_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 13/2 15/4; 15/4 67/8 ])),
+            (input = (m_out = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), m_Σ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 753/62 -123/62; -123/62 441/62 ])),
+            (input = (m_out = MvNormalMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  m_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
+            
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
-            (input = (m_out = MvNormalMeanPrecision([2.0; 1.0], [0.5 -0.25; -0.25 0.375]),  m_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+            (input = (m_out = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),  m_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])),     output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 9.0 6.0; 6.0 12.0 ])),
+            (input = (m_out = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), m_Σ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 19.0 -3.0; -3.0 16.0 ])),
+            (input = (m_out = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  m_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ]))
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
-            (input = (m_out = MvNormalWeightedMeanPrecision([0.75; -0.125], [0.5 -0.25; -0.25 0.375]),  m_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0])),
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   m_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 3/4, -1/8 ], [ 13/2 15/4; 15/4 67/8 ])),
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), m_Σ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 753/62 -123/62; -123/62 441/62 ])),
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  m_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
         ]
 
     end

--- a/test/rules/mv_normal_mean_covariance/test_mean.jl
+++ b/test/rules/mv_normal_mean_covariance/test_mean.jl
@@ -47,11 +47,18 @@ import ReactiveMP: @test_rules
     @testset "Variational: (q_out::Any, q_Σ::Any)" begin
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
-            (input = (q_out = PointMass([2.0; 1.0]), q_Σ = PointMass([2.0 1.0; 5.0 5.0])), output = MvNormalMeanCovariance([2.0; 1.0], [2.0 1.0; 5.0 5.0]))
+            (input = (q_out = PointMass([ -1.0 ]), q_Σ = PointMass([ 2.0 ])), output = MvNormalMeanCovariance([ -1.0 ], [ 2.0 ])),
+            (input = (q_out = PointMass([  1.0 ]), q_Σ = PointMass([ 2.0 ])), output = MvNormalMeanCovariance([  1.0 ], [ 2.0 ])),
+            (input = (q_out = PointMass([ 2.0 ]),  q_Σ = PointMass([ 1.0 ])), output = MvNormalMeanCovariance([  2.0 ], [ 1.0 ])),
+            (input = (q_out = PointMass([ 1.0, 3.0 ]),  q_Σ = PointMass([ 3.0 2.0; 2.0 4.0 ])),   output = MvNormalMeanCovariance([ 1.0, 3.0 ], [ 3.0 2.0; 2.0 4.0 ])),
+            (input = (q_out = PointMass([ -1.0, 2.0 ]), q_Σ = PointMass([ 7.0 -1.0; -1.0 9.0 ])), output = MvNormalMeanCovariance([ -1.0, 2.0 ], [ 7.0 -1.0; -1.0 9.0 ])),
+            (input = (q_out = PointMass([ 0.0, 0.0 ]),  q_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),   output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 1.0 0.0; 0.0 1.0 ]))
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
-            (input = (q_out = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [6.0 4.0; 4.0 8.0]))
+            (input = (q_out = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]), q_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])), output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 6.0 4.0; 4.0 8.0 ])),
+            (input = (q_out = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]), q_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])), output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 6.0 4.0; 4.0 8.0 ])),
+            (input = (q_out = MvNormalWeightedMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]), q_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])), output = MvNormalMeanCovariance([ 3/4, -1/8 ], [ 6.0 4.0; 4.0 8.0 ])),
         ]
 
     end
@@ -59,7 +66,9 @@ import ReactiveMP: @test_rules
     @testset "Structured variational: (m_out::PointMass, q_Σ::Any)" begin
         
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:μ, Marginalisation) [
-            (input = (m_out = PointMass([2.0; 1.0]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [6.0 4.0; 4.0 8.0]))
+            (input = (m_out = PointMass([ 1.0, 3.0 ]),  q_Σ = PointMass([ 3.0 2.0; 2.0 4.0 ])),   output = MvNormalMeanCovariance([ 1.0, 3.0 ], [ 3.0 2.0; 2.0 4.0 ])),
+            (input = (m_out = PointMass([ -1.0, 2.0 ]), q_Σ = PointMass([ 7.0 -1.0; -1.0 9.0 ])), output = MvNormalMeanCovariance([ -1.0, 2.0 ], [ 7.0 -1.0; -1.0 9.0 ])),
+            (input = (m_out = PointMass([ 0.0, 0.0 ]),  q_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),   output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 1.0 0.0; 0.0 1.0 ])),
         ]
         
     end

--- a/test/rules/mv_normal_mean_covariance/test_out.jl
+++ b/test/rules/mv_normal_mean_covariance/test_out.jl
@@ -11,10 +11,12 @@ import ReactiveMP: @test_rules
     @testset "Belief Propagation: (m_μ::PointMass, m_Σ::PointMass)" begin
         
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
-            (input = (m_μ = PointMass([-1.0]), m_Σ = PointMass([2.0])), output = MvNormalMeanCovariance([-1.0], [2.0])),
-            (input = (m_μ = PointMass([1.0]), m_Σ = PointMass([2.0])),  output = MvNormalMeanCovariance([1.0], [2.0])),
-            (input = (m_μ = PointMass([2.0]), m_Σ = PointMass([1.0])),  output = MvNormalMeanCovariance([2.0], [1.0])),
-            (input = (m_μ = PointMass([1.0; 3.0]), m_Σ = PointMass([3.0 2.0; 2.0 4.0])),  output = MvNormalMeanCovariance([1.0; 3.0], [3.0 2.0; 2.0 4.0]))
+            (input = (m_μ = PointMass([ -1.0 ]), m_Σ = PointMass([ 2.0 ])), output = MvNormalMeanCovariance([ -1.0 ], [ 2.0 ])),
+            (input = (m_μ = PointMass([  1.0 ]), m_Σ = PointMass([ 2.0 ])), output = MvNormalMeanCovariance([  1.0 ], [ 2.0 ])),
+            (input = (m_μ = PointMass([ 2.0 ]),  m_Σ = PointMass([ 1.0 ])), output = MvNormalMeanCovariance([  2.0 ], [ 1.0 ])),
+            (input = (m_μ = PointMass([ 1.0, 3.0 ]),  m_Σ = PointMass([ 3.0 2.0; 2.0 4.0 ])),   output = MvNormalMeanCovariance([ 1.0, 3.0 ], [ 3.0 2.0; 2.0 4.0 ])),
+            (input = (m_μ = PointMass([ -1.0, 2.0 ]), m_Σ = PointMass([ 7.0 -1.0; -1.0 9.0 ])), output = MvNormalMeanCovariance([ -1.0, 2.0 ], [ 7.0 -1.0; -1.0 9.0 ])),
+            (input = (m_μ = PointMass([ 0.0, 0.0 ]),  m_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),   output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 1.0 0.0; 0.0 1.0 ]))
         ]
 
     end
@@ -22,15 +24,22 @@ import ReactiveMP: @test_rules
     @testset "Belief Propagation: (m_μ::MultivariateNormalDistributionsFamily, m_Σ::PointMass)" begin
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
-            (input = (m_μ = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]),  m_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+            (input = (m_μ = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   m_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 13/2 15/4; 15/4 67/8 ])),
+            (input = (m_μ = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), m_Σ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 753/62 -123/62; -123/62 441/62 ])),
+            (input = (m_μ = MvNormalMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  m_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
+            
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
-            (input = (m_μ = MvNormalMeanPrecision([2.0; 1.0], [0.5 -0.25; -0.25 0.375]),  m_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+            (input = (m_μ = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),  m_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])),     output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 9.0 6.0; 6.0 12.0 ])),
+            (input = (m_μ = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), m_Σ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 19.0 -3.0; -3.0 16.0 ])),
+            (input = (m_μ = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  m_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ]))
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
-            (input = (m_μ = MvNormalWeightedMeanPrecision([0.75; -0.125], [0.5 -0.25; -0.25 0.375]),  m_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0])),
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   m_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 3/4, -1/8 ], [ 13/2 15/4; 15/4 67/8 ])),
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), m_Σ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 753/62 -123/62; -123/62 441/62 ])),
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  m_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
         ]
 
     end

--- a/test/rules/mv_normal_mean_covariance/test_out.jl
+++ b/test/rules/mv_normal_mean_covariance/test_out.jl
@@ -1,0 +1,68 @@
+module RulesMvNormalMeanCovarianceOutTest
+
+using Test
+using ReactiveMP
+using Random
+
+import ReactiveMP: @test_rules
+
+@testset "rules:MvNormalMeanCovariance:out" begin
+
+    @testset "Belief Propagation: (m_μ::PointMass, m_Σ::PointMass)" begin
+        
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
+            (input = (m_μ = PointMass([-1.0]), m_Σ = PointMass([2.0])), output = MvNormalMeanCovariance([-1.0], [2.0])),
+            (input = (m_μ = PointMass([1.0]), m_Σ = PointMass([2.0])),  output = MvNormalMeanCovariance([1.0], [2.0])),
+            (input = (m_μ = PointMass([2.0]), m_Σ = PointMass([1.0])),  output = MvNormalMeanCovariance([2.0], [1.0])),
+            (input = (m_μ = PointMass([1.0; 3.0]), m_Σ = PointMass([3.0 2.0; 2.0 4.0])),  output = MvNormalMeanCovariance([1.0; 3.0], [3.0 2.0; 2.0 4.0]))
+        ]
+
+    end
+
+    @testset "Belief Propagation: (m_μ::MultivariateNormalDistributionsFamily, m_Σ::PointMass)" begin
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
+            (input = (m_μ = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]),  m_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
+            (input = (m_μ = MvNormalMeanPrecision([2.0; 1.0], [0.5 -0.25; -0.25 0.375]),  m_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
+            (input = (m_μ = MvNormalWeightedMeanPrecision([0.75; -0.125], [0.5 -0.25; -0.25 0.375]),  m_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0])),
+        ]
+
+    end
+
+    @testset "Variational: (q_μ::Any, q_Σ::Any)" begin
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
+            (input = (q_μ = PointMass([2.0; 1.0]), q_Σ = PointMass([2.0 1.0; 5.0 5.0])), output = MvNormalMeanCovariance([2.0; 1.0], [2.0 1.0; 5.0 5.0]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
+            (input = (q_μ = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [6.0 4.0; 4.0 8.0]))
+        ]
+
+    end
+
+    @testset "Structured variational: (m_μ::MultivariateNormalDistributionsFamily, q_Σ::Any)" begin
+        
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
+            (input = (m_μ = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+        ]
+       
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
+            (input = (m_μ = MvNormalMeanPrecision([2.0; 1.0], [0.5 -0.25; -0.25 0.375]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
+            (input = (m_μ = MvNormalWeightedMeanPrecision([0.75; -0.125], [0.5 -0.25; -0.25 0.375]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+        ]
+        
+    end
+
+end
+
+end

--- a/test/rules/mv_normal_mean_covariance/test_out.jl
+++ b/test/rules/mv_normal_mean_covariance/test_out.jl
@@ -27,7 +27,6 @@ import ReactiveMP: @test_rules
             (input = (m_μ = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   m_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 13/2 15/4; 15/4 67/8 ])),
             (input = (m_μ = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), m_Σ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 753/62 -123/62; -123/62 441/62 ])),
             (input = (m_μ = MvNormalMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  m_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
-            
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
@@ -76,15 +75,21 @@ import ReactiveMP: @test_rules
     @testset "Structured variational: (m_μ::MultivariateNormalDistributionsFamily, q_Σ::Any)" begin
         
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
-            (input = (m_μ = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+            (input = (m_μ = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   q_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 13/2 15/4; 15/4 67/8 ])),
+            (input = (m_μ = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Σ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 753/62 -123/62; -123/62 441/62 ])),
+            (input = (m_μ = MvNormalMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
         ]
        
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
-            (input = (m_μ = MvNormalMeanPrecision([2.0; 1.0], [0.5 -0.25; -0.25 0.375]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+            (input = (m_μ = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),  q_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])),     output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 9.0 6.0; 6.0 12.0 ])),
+            (input = (m_μ = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Σ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 19.0 -3.0; -3.0 16.0 ])),
+            (input = (m_μ = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ]))
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
-            (input = (m_μ = MvNormalWeightedMeanPrecision([0.75; -0.125], [0.5 -0.25; -0.25 0.375]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [9.0 6.0; 6.0 12.0]))
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   q_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 3/4, -1/8 ], [ 13/2 15/4; 15/4 67/8 ])),
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Σ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 753/62 -123/62; -123/62 441/62 ])),
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
         ]
         
     end

--- a/test/rules/mv_normal_mean_covariance/test_out.jl
+++ b/test/rules/mv_normal_mean_covariance/test_out.jl
@@ -47,13 +47,30 @@ import ReactiveMP: @test_rules
     @testset "Variational: (q_μ::Any, q_Σ::Any)" begin
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
-            (input = (q_μ = PointMass([2.0; 1.0]), q_Σ = PointMass([2.0 1.0; 5.0 5.0])), output = MvNormalMeanCovariance([2.0; 1.0], [2.0 1.0; 5.0 5.0]))
+            (input = (q_μ = PointMass([ -1.0 ]), q_Σ = PointMass([ 2.0 ])), output = MvNormalMeanCovariance([ -1.0 ], [ 2.0 ])),
+            (input = (q_μ = PointMass([  1.0 ]), q_Σ = PointMass([ 2.0 ])), output = MvNormalMeanCovariance([  1.0 ], [ 2.0 ])),
+            (input = (q_μ = PointMass([ 2.0 ]),  q_Σ = PointMass([ 1.0 ])), output = MvNormalMeanCovariance([  2.0 ], [ 1.0 ])),
+            (input = (q_μ = PointMass([ 1.0, 3.0 ]),  q_Σ = PointMass([ 3.0 2.0; 2.0 4.0 ])),   output = MvNormalMeanCovariance([ 1.0, 3.0 ], [ 3.0 2.0; 2.0 4.0 ])),
+            (input = (q_μ = PointMass([ -1.0, 2.0 ]), q_Σ = PointMass([ 7.0 -1.0; -1.0 9.0 ])), output = MvNormalMeanCovariance([ -1.0, 2.0 ], [ 7.0 -1.0; -1.0 9.0 ])),
+            (input = (q_μ = PointMass([ 0.0, 0.0 ]),  q_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),   output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 1.0 0.0; 0.0 1.0 ]))
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
-            (input = (q_μ = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Σ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [6.0 4.0; 4.0 8.0]))
+            (input = (q_μ = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]), q_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])), output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 6.0 4.0; 4.0 8.0 ])),
+            (input = (q_μ = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]), q_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])), output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 6.0 4.0; 4.0 8.0 ])),
+            (input = (q_μ = MvNormalWeightedMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]), q_Σ = PointMass([ 6.0 4.0; 4.0 8.0 ])), output = MvNormalMeanCovariance([ 3/4, -1/8 ], [ 6.0 4.0; 4.0 8.0 ])),
         ]
 
+    end
+
+    @testset "Structured variational: (m_μ::PointMass, q_Σ::Any)" begin
+        
+        @test_rules [ with_float_conversions = true ] MvNormalMeanCovariance(:out, Marginalisation) [
+            (input = (m_μ = PointMass([ 1.0, 3.0 ]),  q_Σ = PointMass([ 3.0 2.0; 2.0 4.0 ])),   output = MvNormalMeanCovariance([ 1.0, 3.0 ], [ 3.0 2.0; 2.0 4.0 ])),
+            (input = (m_μ = PointMass([ -1.0, 2.0 ]), q_Σ = PointMass([ 7.0 -1.0; -1.0 9.0 ])), output = MvNormalMeanCovariance([ -1.0, 2.0 ], [ 7.0 -1.0; -1.0 9.0 ])),
+            (input = (m_μ = PointMass([ 0.0, 0.0 ]),  q_Σ = PointMass([ 1.0 0.0; 0.0 1.0 ])),   output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 1.0 0.0; 0.0 1.0 ])),
+        ]
+        
     end
 
     @testset "Structured variational: (m_μ::MultivariateNormalDistributionsFamily, q_Σ::Any)" begin

--- a/test/rules/mv_normal_mean_precision/test_mean.jl
+++ b/test/rules/mv_normal_mean_precision/test_mean.jl
@@ -27,7 +27,6 @@ import ReactiveMP: @test_rules
             (input = (m_out = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   m_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 0.75 -0.375; -0.375 0.5625 ])),
             (input = (m_out = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), m_Λ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 577/2480 51/1240; 51/1240 163/620 ])),
             (input = (m_out = MvNormalMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  m_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
-            
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
@@ -47,27 +46,68 @@ import ReactiveMP: @test_rules
     @testset "Variational: (q_out::Any, q_Λ::Any)" begin
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
-            (input = (q_out = PointMass([2.0; 1.0]), q_Λ = PointMass([2.0 1.0; 5.0 5.0])), output = MvNormalMeanPrecision([2.0; 1.0], [2.0 1.0; 5.0 5.0]))
+            (input = (q_out = PointMass([ -1.0 ]), q_Λ = PointMass([ 2.0 ])), output = MvNormalMeanPrecision([ -1.0 ], [ 2.0 ])),
+            (input = (q_out = PointMass([  1.0 ]), q_Λ = PointMass([ 2.0 ])), output = MvNormalMeanPrecision([  1.0 ], [ 2.0 ])),
+            (input = (q_out = PointMass([ 2.0 ]),  q_Λ = PointMass([ 1.0 ])), output = MvNormalMeanPrecision([  2.0 ], [ 1.0 ])),
+            (input = (q_out = PointMass([ 1.0, 3.0 ]),  q_Λ = PointMass([ 3.0 2.0; 2.0 4.0 ])),   output = MvNormalMeanPrecision([ 1.0, 3.0 ], [ 3.0 2.0; 2.0 4.0 ])),
+            (input = (q_out = PointMass([ -1.0, 2.0 ]), q_Λ = PointMass([ 7.0 -1.0; -1.0 9.0 ])), output = MvNormalMeanPrecision([ -1.0, 2.0 ], [ 7.0 -1.0; -1.0 9.0 ])),
+            (input = (q_out = PointMass([ 0.0, 0.0 ]),  q_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),   output = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 1.0 0.0; 0.0 1.0 ]))
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
-            (input = (q_out = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanPrecision([2.0; 1.0], [6.0 4.0; 4.0 8.0]))
+            (input = (q_out = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]), q_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])), output = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 6.0 4.0; 4.0 8.0 ])),
+            (input = (q_out = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]), q_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])), output = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 6.0 4.0; 4.0 8.0 ])),
+            (input = (q_out = MvNormalWeightedMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]), q_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])), output = MvNormalMeanPrecision([ 3/4, -1/8 ], [ 6.0 4.0; 4.0 8.0 ])),
         ]
 
+    end
+
+    @testset "Structured variational: (m_out::PointMass, q_Σ::Any)" begin
+        
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
-            (input = (q_out = PointMass([2.0; 1.0]), q_Λ = Wishart(5, [3.0 2.0; 2.0 4.0])), output = MvNormalMeanPrecision([2.0; 1.0], [15.0 10.0; 10.0 20.0]))
+            (input = (m_out = PointMass([ 1.0, 3.0 ]),  q_Λ = PointMass([ 3.0 2.0; 2.0 4.0 ])),   output = MvNormalMeanPrecision([ 1.0, 3.0 ], [ 3.0 2.0; 2.0 4.0 ])),
+            (input = (m_out = PointMass([ -1.0, 2.0 ]), q_Λ = PointMass([ 7.0 -1.0; -1.0 9.0 ])), output = MvNormalMeanPrecision([ -1.0, 2.0 ], [ 7.0 -1.0; -1.0 9.0 ])),
+            (input = (m_out = PointMass([ 0.0, 0.0 ]),  q_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),   output = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 1.0 0.0; 0.0 1.0 ])),
         ]
-
+        
     end
 
     @testset "Structured variational: (m_out::MvNormalMeanPrecision, q_Λ::Any)" begin
         
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
-            (input = (m_out = MvNormalMeanPrecision([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625]))
+            (input = (m_out = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   q_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 0.75 -0.375; -0.375 0.5625 ])),
+            (input = (m_out = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Λ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 577/2480 51/1240; 51/1240 163/620 ])),
+            (input = (m_out = MvNormalMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
-            (input = (m_out = MvNormalMeanPrecision([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Λ = Wishart(5, [3.0 2.0; 2.0 4.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.6 -0.3; -0.3 0.45]))
+            (input = (m_out = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),  q_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])),     output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 13/4 15/8; 15/8 67/16])),
+            (input = (m_out = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Λ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 567/80 -39/40; -39/40 183/20 ])),
+            (input = (m_out = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ]))
+        ]
+        
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   q_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 3/4, -1/8 ], [ 0.75 -0.375; -0.375 0.5625 ])),
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Λ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 577/2480 51/1240; 51/1240 163/620 ])),
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
+            (input = (m_out = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   q_Λ = Wishart(2.0, [ 6.0 4.0; 4.0 8.0 ] ./ 2.0)),    output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 0.75 -0.375; -0.375 0.5625 ])),
+            (input = (m_out = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Λ = Wishart(3.0, [ 12.0 -2.0; -2.0 7.0 ] ./ 3.0)), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 577/2480 51/1240; 51/1240 163/620 ])),
+            (input = (m_out = MvNormalMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Λ = Wishart(4.0, [ 1.0 0.0; 0.0 1.0 ] ./ 4.0)),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
+            (input = (m_out = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),  q_Λ = Wishart(2.0, [ 6.0 4.0; 4.0 8.0 ] ./ 2.0)),     output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 13/4 15/8; 15/8 67/16])),
+            (input = (m_out = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Λ = Wishart(3.0, [ 12.0 -2.0; -2.0 7.0 ] ./ 3.0)), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 567/80 -39/40; -39/40 183/20 ])),
+            (input = (m_out = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Λ = Wishart(4.0, [ 1.0 0.0; 0.0 1.0 ] ./ 4.0)),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ]))
+        ]
+        
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   q_Λ = Wishart(2.0, [ 6.0 4.0; 4.0 8.0 ] ./ 2.0)),    output = MvNormalMeanCovariance([ 3/4, -1/8 ], [ 0.75 -0.375; -0.375 0.5625 ])),
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Λ = Wishart(3.0, [ 12.0 -2.0; -2.0 7.0 ] ./ 3.0)), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 577/2480 51/1240; 51/1240 163/620 ])),
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Λ = Wishart(4.0, [ 1.0 0.0; 0.0 1.0 ] ./ 4.0)),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
         ]
         
     end

--- a/test/rules/mv_normal_mean_precision/test_mean.jl
+++ b/test/rules/mv_normal_mean_precision/test_mean.jl
@@ -1,0 +1,70 @@
+module RulesMvNormalMeanPrecisionMeanTest
+
+using Test
+using ReactiveMP
+using Random
+
+import ReactiveMP: @test_rules
+
+@testset "rules:MvNormalMeanPrecision:mean" begin
+
+    @testset "Belief Propagation: (m_out::PointMass, m_Λ::PointMass)" begin
+        
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
+            (input = (m_out = PointMass([-1.0]), m_Λ = PointMass([2.0])), output = MvNormalMeanPrecision([-1.0], [2.0])),
+            (input = (m_out = PointMass([1.0]), m_Λ = PointMass([2.0])),  output = MvNormalMeanPrecision([1.0], [2.0])),
+            (input = (m_out = PointMass([2.0]), m_Λ = PointMass([1.0])),  output = MvNormalMeanPrecision([2.0], [1.0])),
+            (input = (m_out = PointMass([1.0; 3.0]), m_Λ = PointMass([3.0 2.0; 2.0 4.0])),  output = MvNormalMeanPrecision([1.0; 3.0], [3.0 2.0; 2.0 4.0]))
+        ]
+
+    end
+
+    @testset "Belief Propagation: (m_out::MultivariateNormalDistributionsFamily, m_Λ::PointMass)" begin
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
+            (input = (m_out = MvNormalMeanPrecision([2.0; 1.0], [3.0 2.0; 2.0 4.0]),  m_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
+            (input = (m_out = MvNormalMeanCovariance([2.0; 1.0], [0.5 -0.25; -0.25 0.375]),  m_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
+            (input = (m_out = MvNormalWeightedMeanPrecision([8.0; 8.0], [3.0 2.0; 2.0 4.0]),  m_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625])),
+        ]
+
+    end
+
+    @testset "Variational: (q_out::Any, q_Λ::Any)" begin
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
+            (input = (q_out = PointMass([2.0; 1.0]), q_Λ = PointMass([2.0 1.0; 5.0 5.0])), output = MvNormalMeanPrecision([2.0; 1.0], [2.0 1.0; 5.0 5.0]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
+            (input = (q_out = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanPrecision([2.0; 1.0], [6.0 4.0; 4.0 8.0]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
+            (input = (q_out = PointMass([2.0; 1.0]), q_Λ = Wishart(5, [3.0 2.0; 2.0 4.0])), output = MvNormalMeanPrecision([2.0; 1.0], [15.0 10.0; 10.0 20.0]))
+        ]
+
+    end
+
+    @testset "Structured variational: (m_out::MvNormalMeanPrecision, q_Λ::Any)" begin
+        
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
+            (input = (m_out = MvNormalMeanPrecision([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
+            (input = (m_out = MvNormalMeanPrecision([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Λ = Wishart(5, [3.0 2.0; 2.0 4.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.6 -0.3; -0.3 0.45]))
+        ]
+        
+    end
+
+end
+
+
+
+end

--- a/test/rules/mv_normal_mean_precision/test_mean.jl
+++ b/test/rules/mv_normal_mean_precision/test_mean.jl
@@ -11,10 +11,12 @@ import ReactiveMP: @test_rules
     @testset "Belief Propagation: (m_out::PointMass, m_Λ::PointMass)" begin
         
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
-            (input = (m_out = PointMass([-1.0]), m_Λ = PointMass([2.0])), output = MvNormalMeanPrecision([-1.0], [2.0])),
-            (input = (m_out = PointMass([1.0]), m_Λ = PointMass([2.0])),  output = MvNormalMeanPrecision([1.0], [2.0])),
-            (input = (m_out = PointMass([2.0]), m_Λ = PointMass([1.0])),  output = MvNormalMeanPrecision([2.0], [1.0])),
-            (input = (m_out = PointMass([1.0; 3.0]), m_Λ = PointMass([3.0 2.0; 2.0 4.0])),  output = MvNormalMeanPrecision([1.0; 3.0], [3.0 2.0; 2.0 4.0]))
+            (input = (m_out = PointMass([ -1.0 ]), m_Λ = PointMass([ 2.0 ])), output = MvNormalMeanPrecision([ -1.0 ], [ 2.0 ])),
+            (input = (m_out = PointMass([  1.0 ]), m_Λ = PointMass([ 2.0 ])), output = MvNormalMeanPrecision([  1.0 ], [ 2.0 ])),
+            (input = (m_out = PointMass([ 2.0 ]),  m_Λ = PointMass([ 1.0 ])), output = MvNormalMeanPrecision([  2.0 ], [ 1.0 ])),
+            (input = (m_out = PointMass([ 1.0, 3.0 ]),  m_Λ = PointMass([ 3.0 2.0; 2.0 4.0 ])),   output = MvNormalMeanPrecision([ 1.0, 3.0 ], [ 3.0 2.0; 2.0 4.0 ])),
+            (input = (m_out = PointMass([ -1.0, 2.0 ]), m_Λ = PointMass([ 7.0 -1.0; -1.0 9.0 ])), output = MvNormalMeanPrecision([ -1.0, 2.0 ], [ 7.0 -1.0; -1.0 9.0 ])),
+            (input = (m_out = PointMass([ 0.0, 0.0 ]),  m_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),   output = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 1.0 0.0; 0.0 1.0 ]))
         ]
 
     end
@@ -22,15 +24,22 @@ import ReactiveMP: @test_rules
     @testset "Belief Propagation: (m_out::MultivariateNormalDistributionsFamily, m_Λ::PointMass)" begin
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
-            (input = (m_out = MvNormalMeanPrecision([2.0; 1.0], [3.0 2.0; 2.0 4.0]),  m_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625]))
+            (input = (m_out = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   m_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 0.75 -0.375; -0.375 0.5625 ])),
+            (input = (m_out = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), m_Λ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 577/2480 51/1240; 51/1240 163/620 ])),
+            (input = (m_out = MvNormalMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  m_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
+            
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
-            (input = (m_out = MvNormalMeanCovariance([2.0; 1.0], [0.5 -0.25; -0.25 0.375]),  m_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625]))
+            (input = (m_out = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),  m_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])),     output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 13/4 15/8; 15/8 67/16])),
+            (input = (m_out = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), m_Λ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 567/80 -39/40; -39/40 183/20 ])),
+            (input = (m_out = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  m_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ]))
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:μ, Marginalisation) [
-            (input = (m_out = MvNormalWeightedMeanPrecision([8.0; 8.0], [3.0 2.0; 2.0 4.0]),  m_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625])),
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   m_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 3/4, -1/8 ], [ 0.75 -0.375; -0.375 0.5625 ])),
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), m_Λ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 577/2480 51/1240; 51/1240 163/620 ])),
+            (input = (m_out = MvNormalWeightedMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  m_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
         ]
 
     end

--- a/test/rules/mv_normal_mean_precision/test_out.jl
+++ b/test/rules/mv_normal_mean_precision/test_out.jl
@@ -44,30 +44,71 @@ import ReactiveMP: @test_rules
 
     end
 
-    @testset "Variational: (q_μ::Any, q_Λ::Any)" begin
+    @testset "Variational: (q_out::Any, q_Λ::Any)" begin
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
-            (input = (q_μ = PointMass([2.0; 1.0]), q_Λ = PointMass([2.0 1.0; 5.0 5.0])), output = MvNormalMeanPrecision([2.0; 1.0], [2.0 1.0; 5.0 5.0]))
+            (input = (q_μ = PointMass([ -1.0 ]), q_Λ = PointMass([ 2.0 ])), output = MvNormalMeanPrecision([ -1.0 ], [ 2.0 ])),
+            (input = (q_μ = PointMass([  1.0 ]), q_Λ = PointMass([ 2.0 ])), output = MvNormalMeanPrecision([  1.0 ], [ 2.0 ])),
+            (input = (q_μ = PointMass([ 2.0 ]),  q_Λ = PointMass([ 1.0 ])), output = MvNormalMeanPrecision([  2.0 ], [ 1.0 ])),
+            (input = (q_μ = PointMass([ 1.0, 3.0 ]),  q_Λ = PointMass([ 3.0 2.0; 2.0 4.0 ])),   output = MvNormalMeanPrecision([ 1.0, 3.0 ], [ 3.0 2.0; 2.0 4.0 ])),
+            (input = (q_μ = PointMass([ -1.0, 2.0 ]), q_Λ = PointMass([ 7.0 -1.0; -1.0 9.0 ])), output = MvNormalMeanPrecision([ -1.0, 2.0 ], [ 7.0 -1.0; -1.0 9.0 ])),
+            (input = (q_μ = PointMass([ 0.0, 0.0 ]),  q_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),   output = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 1.0 0.0; 0.0 1.0 ]))
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
-            (input = (q_μ = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanPrecision([2.0; 1.0], [6.0 4.0; 4.0 8.0]))
+            (input = (q_μ = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]), q_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])), output = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 6.0 4.0; 4.0 8.0 ])),
+            (input = (q_μ = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]), q_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])), output = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 6.0 4.0; 4.0 8.0 ])),
+            (input = (q_μ = MvNormalWeightedMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]), q_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])), output = MvNormalMeanPrecision([ 3/4, -1/8 ], [ 6.0 4.0; 4.0 8.0 ])),
         ]
 
+    end
+
+    @testset "Structured variational: (m_μ::PointMass, q_Σ::Any)" begin
+        
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
-            (input = (q_μ = PointMass([2.0; 1.0]), q_Λ = Wishart(5, [3.0 2.0; 2.0 4.0])), output = MvNormalMeanPrecision([2.0; 1.0], [15.0 10.0; 10.0 20.0]))
+            (input = (q_μ = PointMass([ 1.0, 3.0 ]),  q_Λ = PointMass([ 3.0 2.0; 2.0 4.0 ])),   output = MvNormalMeanPrecision([ 1.0, 3.0 ], [ 3.0 2.0; 2.0 4.0 ])),
+            (input = (q_μ = PointMass([ -1.0, 2.0 ]), q_Λ = PointMass([ 7.0 -1.0; -1.0 9.0 ])), output = MvNormalMeanPrecision([ -1.0, 2.0 ], [ 7.0 -1.0; -1.0 9.0 ])),
+            (input = (q_μ = PointMass([ 0.0, 0.0 ]),  q_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),   output = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 1.0 0.0; 0.0 1.0 ])),
         ]
-
+        
     end
 
     @testset "Structured variational: (m_μ::MvNormalMeanPrecision, q_Λ::Any)" begin
         
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
-            (input = (m_μ = MvNormalMeanPrecision([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625]))
+            (input = (m_μ = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   q_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 0.75 -0.375; -0.375 0.5625 ])),
+            (input = (m_μ = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Λ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 577/2480 51/1240; 51/1240 163/620 ])),
+            (input = (m_μ = MvNormalMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
-            (input = (m_μ = MvNormalMeanPrecision([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Λ = Wishart(5, [3.0 2.0; 2.0 4.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.6 -0.3; -0.3 0.45]))
+            (input = (m_μ = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),  q_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])),     output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 13/4 15/8; 15/8 67/16])),
+            (input = (m_μ = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Λ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 567/80 -39/40; -39/40 183/20 ])),
+            (input = (m_μ = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ]))
+        ]
+        
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   q_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 3/4, -1/8 ], [ 0.75 -0.375; -0.375 0.5625 ])),
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Λ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 577/2480 51/1240; 51/1240 163/620 ])),
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
+            (input = (m_μ = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   q_Λ = Wishart(2.0, [ 6.0 4.0; 4.0 8.0 ] ./ 2.0)),    output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 0.75 -0.375; -0.375 0.5625 ])),
+            (input = (m_μ = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Λ = Wishart(3.0, [ 12.0 -2.0; -2.0 7.0 ] ./ 3.0)), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 577/2480 51/1240; 51/1240 163/620 ])),
+            (input = (m_μ = MvNormalMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Λ = Wishart(4.0, [ 1.0 0.0; 0.0 1.0 ] ./ 4.0)),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
+            (input = (m_μ = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),  q_Λ = Wishart(2.0, [ 6.0 4.0; 4.0 8.0 ] ./ 2.0)),     output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 13/4 15/8; 15/8 67/16])),
+            (input = (m_μ = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Λ = Wishart(3.0, [ 12.0 -2.0; -2.0 7.0 ] ./ 3.0)), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 567/80 -39/40; -39/40 183/20 ])),
+            (input = (m_μ = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Λ = Wishart(4.0, [ 1.0 0.0; 0.0 1.0 ] ./ 4.0)),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ]))
+        ]
+        
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   q_Λ = Wishart(2.0, [ 6.0 4.0; 4.0 8.0 ] ./ 2.0)),    output = MvNormalMeanCovariance([ 3/4, -1/8 ], [ 0.75 -0.375; -0.375 0.5625 ])),
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), q_Λ = Wishart(3.0, [ 12.0 -2.0; -2.0 7.0 ] ./ 3.0)), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 577/2480 51/1240; 51/1240 163/620 ])),
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  q_Λ = Wishart(4.0, [ 1.0 0.0; 0.0 1.0 ] ./ 4.0)),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
         ]
         
     end

--- a/test/rules/mv_normal_mean_precision/test_out.jl
+++ b/test/rules/mv_normal_mean_precision/test_out.jl
@@ -11,10 +11,12 @@ import ReactiveMP: @test_rules
     @testset "Belief Propagation: (m_μ::PointMass, m_Λ::PointMass)" begin
         
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
-            (input = (m_μ = PointMass([-1.0]), m_Λ = PointMass([2.0])), output = MvNormalMeanPrecision([-1.0], [2.0])),
-            (input = (m_μ = PointMass([1.0]), m_Λ = PointMass([2.0])),  output = MvNormalMeanPrecision([1.0], [2.0])),
-            (input = (m_μ = PointMass([2.0]), m_Λ = PointMass([1.0])),  output = MvNormalMeanPrecision([2.0], [1.0])),
-            (input = (m_μ = PointMass([1.0; 3.0]), m_Λ = PointMass([3.0 2.0; 2.0 4.0])),  output = MvNormalMeanPrecision([1.0; 3.0], [3.0 2.0; 2.0 4.0]))
+            (input = (m_μ = PointMass([ -1.0 ]), m_Λ = PointMass([ 2.0 ])), output = MvNormalMeanPrecision([ -1.0 ], [ 2.0 ])),
+            (input = (m_μ = PointMass([  1.0 ]), m_Λ = PointMass([ 2.0 ])), output = MvNormalMeanPrecision([  1.0 ], [ 2.0 ])),
+            (input = (m_μ = PointMass([ 2.0 ]),  m_Λ = PointMass([ 1.0 ])), output = MvNormalMeanPrecision([  2.0 ], [ 1.0 ])),
+            (input = (m_μ = PointMass([ 1.0, 3.0 ]),  m_Λ = PointMass([ 3.0 2.0; 2.0 4.0 ])),   output = MvNormalMeanPrecision([ 1.0, 3.0 ], [ 3.0 2.0; 2.0 4.0 ])),
+            (input = (m_μ = PointMass([ -1.0, 2.0 ]), m_Λ = PointMass([ 7.0 -1.0; -1.0 9.0 ])), output = MvNormalMeanPrecision([ -1.0, 2.0 ], [ 7.0 -1.0; -1.0 9.0 ])),
+            (input = (m_μ = PointMass([ 0.0, 0.0 ]),  m_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),   output = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 1.0 0.0; 0.0 1.0 ]))
         ]
 
     end
@@ -22,15 +24,22 @@ import ReactiveMP: @test_rules
     @testset "Belief Propagation: (m_μ::MultivariateNormalDistributionsFamily, m_Λ::PointMass)" begin
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
-            (input = (m_μ = MvNormalMeanPrecision([2.0; 1.0], [3.0 2.0; 2.0 4.0]),  m_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625]))
+            (input = (m_μ = MvNormalMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   m_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 0.75 -0.375; -0.375 0.5625 ])),
+            (input = (m_μ = MvNormalMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), m_Λ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 577/2480 51/1240; 51/1240 163/620 ])),
+            (input = (m_μ = MvNormalMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  m_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
+            
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
-            (input = (m_μ = MvNormalMeanCovariance([2.0; 1.0], [0.5 -0.25; -0.25 0.375]),  m_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625]))
+            (input = (m_μ = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),  m_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])),     output = MvNormalMeanCovariance([ 2.0, 1.0 ], [ 13/4 15/8; 15/8 67/16])),
+            (input = (m_μ = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), m_Λ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 567/80 -39/40; -39/40 183/20 ])),
+            (input = (m_μ = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  m_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ]))
         ]
 
         @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
-            (input = (m_μ = MvNormalWeightedMeanPrecision([8.0; 8.0], [3.0 2.0; 2.0 4.0]),  m_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625])),
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 2.0, 1.0 ], [ 3.0 2.0; 2.0 4.0 ]),   m_Λ = PointMass([ 6.0 4.0; 4.0 8.0 ])),    output = MvNormalMeanCovariance([ 3/4, -1/8 ], [ 0.75 -0.375; -0.375 0.5625 ])),
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 0.0, 0.0 ], [ 7.0 -1.0; -1.0 9.0 ]), m_Λ = PointMass([ 12.0 -2.0; -2.0 7.0 ])), output = MvNormalMeanCovariance([ 0.0, 0.0 ], [ 577/2480 51/1240; 51/1240 163/620 ])),
+            (input = (m_μ = MvNormalWeightedMeanPrecision([ 3.0, -1.0 ], [ 1.0 0.0; 0.0 1.0 ]),  m_Λ = PointMass([ 1.0 0.0; 0.0 1.0 ])),    output = MvNormalMeanCovariance([ 3.0, -1.0 ], [ 2.0 0.0; 0.0 2.0 ])),
         ]
 
     end

--- a/test/rules/mv_normal_mean_precision/test_out.jl
+++ b/test/rules/mv_normal_mean_precision/test_out.jl
@@ -1,0 +1,70 @@
+module RulesMvNormalMeanPrecisionOutTest
+
+using Test
+using ReactiveMP
+using Random
+
+import ReactiveMP: @test_rules
+
+@testset "rules:MvNormalMeanPrecision:out" begin
+
+    @testset "Belief Propagation: (m_μ::PointMass, m_Λ::PointMass)" begin
+        
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
+            (input = (m_μ = PointMass([-1.0]), m_Λ = PointMass([2.0])), output = MvNormalMeanPrecision([-1.0], [2.0])),
+            (input = (m_μ = PointMass([1.0]), m_Λ = PointMass([2.0])),  output = MvNormalMeanPrecision([1.0], [2.0])),
+            (input = (m_μ = PointMass([2.0]), m_Λ = PointMass([1.0])),  output = MvNormalMeanPrecision([2.0], [1.0])),
+            (input = (m_μ = PointMass([1.0; 3.0]), m_Λ = PointMass([3.0 2.0; 2.0 4.0])),  output = MvNormalMeanPrecision([1.0; 3.0], [3.0 2.0; 2.0 4.0]))
+        ]
+
+    end
+
+    @testset "Belief Propagation: (m_μ::MultivariateNormalDistributionsFamily, m_Λ::PointMass)" begin
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
+            (input = (m_μ = MvNormalMeanPrecision([2.0; 1.0], [3.0 2.0; 2.0 4.0]),  m_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
+            (input = (m_μ = MvNormalMeanCovariance([2.0; 1.0], [0.5 -0.25; -0.25 0.375]),  m_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
+            (input = (m_μ = MvNormalWeightedMeanPrecision([8.0; 8.0], [3.0 2.0; 2.0 4.0]),  m_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625])),
+        ]
+
+    end
+
+    @testset "Variational: (q_μ::Any, q_Λ::Any)" begin
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
+            (input = (q_μ = PointMass([2.0; 1.0]), q_Λ = PointMass([2.0 1.0; 5.0 5.0])), output = MvNormalMeanPrecision([2.0; 1.0], [2.0 1.0; 5.0 5.0]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
+            (input = (q_μ = MvNormalMeanCovariance([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanPrecision([2.0; 1.0], [6.0 4.0; 4.0 8.0]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
+            (input = (q_μ = PointMass([2.0; 1.0]), q_Λ = Wishart(5, [3.0 2.0; 2.0 4.0])), output = MvNormalMeanPrecision([2.0; 1.0], [15.0 10.0; 10.0 20.0]))
+        ]
+
+    end
+
+    @testset "Structured variational: (m_μ::MvNormalMeanPrecision, q_Λ::Any)" begin
+        
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
+            (input = (m_μ = MvNormalMeanPrecision([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Λ = PointMass([6.0 4.0; 4.0 8.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.75 -0.375; -0.375 0.5625]))
+        ]
+
+        @test_rules [ with_float_conversions = true ] MvNormalMeanPrecision(:out, Marginalisation) [
+            (input = (m_μ = MvNormalMeanPrecision([2.0; 1.0], [3.0 2.0; 2.0 4.0]), q_Λ = Wishart(5, [3.0 2.0; 2.0 4.0])), output = MvNormalMeanCovariance([2.0; 1.0], [0.6 -0.3; -0.3 0.45]))
+        ]
+        
+    end
+
+end
+
+
+
+end

--- a/test/rules/mv_normal_mean_precision/test_precision.jl
+++ b/test/rules/mv_normal_mean_precision/test_precision.jl
@@ -12,13 +12,22 @@ import ReactiveMP: @test_rules
     @testset "Variational: (q_out::PointMass, q_μ::MultivariateNormalDistributionsFamily)" begin
 
         @test_rules [ with_float_conversions = false ] MvNormalMeanPrecision(:Λ, Marginalisation) [
-            (input = (q_out = PointMass([1.0; 2.0]), q_μ = MvNormalMeanPrecision([3.0; 5.0], [3.0 2.0; 2.0 4.0])), output = Wishart(4.0, cholinv(cholinv([3.0 2.0; 2.0 4.0]) + ([3.0; 5.0] - [1.0; 2.0])*([3.0; 5.0] - [1.0; 2.0])')))
+            (input = (q_out = PointMass([ 1.0, 2.0 ]), q_μ = MvNormalMeanPrecision([ 3.0, 5.0 ], [ 3.0 2.0; 2.0 4.0 ])), output = Wishart(4.0, [ 75/73 -46/73; -46/73 36/73 ])),
+            (input = (q_out = MvNormalMeanPrecision([1.0; 2.0], [3.0 2.0; 2.0 4.0]), q_μ = PointMass([3.0; 5.0])), output = Wishart(4.0, [ 75/73 -46/73; -46/73 36/73 ])),
+            (input = (q_out = MvNormalMeanPrecision([1.0; 2.0], [3.0 2.0; 2.0 4.0]), q_μ = MvNormalMeanPrecision([3.0; 5.0], [3.0 2.0; 2.0 4.0])), output = Wishart(4.0, [ 39/74 -11/37; -11/37 10/37 ])),
+            (input = (q_out = MvNormalMeanPrecision([1.0; 2.0; 3.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0]), q_μ = MvNormalMeanPrecision([3.0; 5.0; -2.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0])), output = Wishart(5.0, [ 15/11 -3/22 5/11; -3/22 19/22 5/11; 5/11 5/11 16/33 ]))
         ]
         @test_rules [ with_float_conversions = false ] MvNormalMeanPrecision(:Λ, Marginalisation) [
-            (input = (q_out = PointMass([1.0; 2.0]), q_μ = MvNormalMeanCovariance([3.0; 5.0], cholinv([3.0 2.0; 2.0 4.0]))), output = Wishart(4.0, cholinv(cholinv([3.0 2.0; 2.0 4.0]) + ([3.0; 5.0] - [1.0; 2.0])*([3.0; 5.0] - [1.0; 2.0])')))
+            (input = (q_out = PointMass([ 1.0, 2.0 ]), q_μ = MvNormalMeanCovariance([ 3.0, 5.0 ], [ 3.0 2.0; 2.0 4.0 ])), output = Wishart(4.0, [ 13/27 -8/27; -8/27 7/27 ])),
+            (input = (q_out = MvNormalMeanCovariance([1.0; 2.0], [3.0 2.0; 2.0 4.0]), q_μ = PointMass([3.0; 5.0])), output = Wishart(4.0, [ 13/27 -8/27; -8/27 7/27 ])),
+            (input = (q_out = MvNormalMeanCovariance([1.0; 2.0], [3.0 2.0; 2.0 4.0]), q_μ = MvNormalMeanCovariance([3.0; 5.0], [3.0 2.0; 2.0 4.0])), output = Wishart(4.0, [ 17/70 -1/7; -1/7 1/7 ])),
+            (input = (q_out = MvNormalMeanCovariance([1.0; 2.0; 3.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0]), q_μ = MvNormalMeanCovariance([3.0; 5.0; -2.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0])), output = Wishart(5.0, [ 51/338 -6/169 5/169; -6/169 115/676 45/676; 5/169 45/676 47/676 ]))
         ]
         @test_rules [ with_float_conversions = false ] MvNormalMeanPrecision(:Λ, Marginalisation) [
-            (input = (q_out = PointMass([1.0; 2.0]), q_μ = MvNormalWeightedMeanPrecision([19.0; 26.0], [3.0 2.0; 2.0 4.0])), output = Wishart(4.0, cholinv(cholinv([3.0 2.0; 2.0 4.0]) + ([3.0; 5.0] - [1.0; 2.0])*([3.0; 5.0] - [1.0; 2.0])')))
+            (input = (q_out = PointMass([ 1.0, 2.0 ]), q_μ = MvNormalWeightedMeanPrecision([ 3.0, 5.0 ], [ 3.0 2.0; 2.0 4.0 ])), output = Wishart(4.0, [ 73/67 -26/67; -26/67 68/67 ])),
+            (input = (q_out = MvNormalWeightedMeanPrecision([1.0; 2.0], [3.0 2.0; 2.0 4.0]), q_μ = PointMass([3.0; 5.0])), output = Wishart(4.0, [ 165/163 -106/163; -106/163 76/163 ])),
+            (input = (q_out = MvNormalWeightedMeanPrecision([1.0; 2.0], [3.0 2.0; 2.0 4.0]), q_μ = MvNormalWeightedMeanPrecision([3.0; 5.0], [3.0 2.0; 2.0 4.0])), output = Wishart(4.0, [ 73/70 11/35; 11/35 34/35 ])),
+            (input = (q_out = MvNormalWeightedMeanPrecision([1.0; 2.0; 3.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0]), q_μ = MvNormalWeightedMeanPrecision([3.0; 5.0; -2.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0])), output = Wishart(5.0, [ 459/338 -36/169 60/169; -36/169 115/169 90/169; 60/169 90/169 188/169 ]))
         ]
 
     end

--- a/test/rules/mv_normal_mean_precision/test_precision.jl
+++ b/test/rules/mv_normal_mean_precision/test_precision.jl
@@ -1,0 +1,30 @@
+module RulesMvNormalMeanPrecisionPrecisionTest
+
+using Test
+using ReactiveMP
+using Random
+
+
+import ReactiveMP: @test_rules
+
+@testset "rules:MvNormalMeanPrecision:precision" begin
+
+    @testset "Variational: (q_out::PointMass, q_μ::MultivariateNormalDistributionsFamily)" begin
+
+        @test_rules [ with_float_conversions = false ] MvNormalMeanPrecision(:Λ, Marginalisation) [
+            (input = (q_out = PointMass([1.0; 2.0]), q_μ = MvNormalMeanPrecision([3.0; 5.0], [3.0 2.0; 2.0 4.0])), output = Wishart(4.0, cholinv(cholinv([3.0 2.0; 2.0 4.0]) + ([3.0; 5.0] - [1.0; 2.0])*([3.0; 5.0] - [1.0; 2.0])')))
+        ]
+        @test_rules [ with_float_conversions = false ] MvNormalMeanPrecision(:Λ, Marginalisation) [
+            (input = (q_out = PointMass([1.0; 2.0]), q_μ = MvNormalMeanCovariance([3.0; 5.0], inv([3.0 2.0; 2.0 4.0]))), output = Wishart(4.0, cholinv(cholinv([3.0 2.0; 2.0 4.0]) + ([3.0; 5.0] - [1.0; 2.0])*([3.0; 5.0] - [1.0; 2.0])')))
+        ]
+        @test_rules [ with_float_conversions = false ] MvNormalMeanPrecision(:Λ, Marginalisation) [
+            (input = (q_out = PointMass([1.0; 2.0]), q_μ = MvNormalWeightedMeanPrecision([19.0; 26.0], [3.0 2.0; 2.0 4.0])), output = Wishart(4.0, cholinv(cholinv([3.0 2.0; 2.0 4.0]) + ([3.0; 5.0] - [1.0; 2.0])*([3.0; 5.0] - [1.0; 2.0])')))
+        ]
+
+    end
+
+end
+
+
+
+end

--- a/test/rules/mv_normal_mean_precision/test_precision.jl
+++ b/test/rules/mv_normal_mean_precision/test_precision.jl
@@ -11,19 +11,19 @@ import ReactiveMP: @test_rules
 
     @testset "Variational: (q_out::PointMass, q_μ::MultivariateNormalDistributionsFamily)" begin
 
-        @test_rules [ with_float_conversions = false ] MvNormalMeanPrecision(:Λ, Marginalisation) [
+        @test_rules [ with_float_conversions = true, float32_atol = 1e-5 ] MvNormalMeanPrecision(:Λ, Marginalisation) [
             (input = (q_out = PointMass([ 1.0, 2.0 ]), q_μ = MvNormalMeanPrecision([ 3.0, 5.0 ], [ 3.0 2.0; 2.0 4.0 ])), output = Wishart(4.0, [ 75/73 -46/73; -46/73 36/73 ])),
             (input = (q_out = MvNormalMeanPrecision([1.0; 2.0], [3.0 2.0; 2.0 4.0]), q_μ = PointMass([3.0; 5.0])), output = Wishart(4.0, [ 75/73 -46/73; -46/73 36/73 ])),
             (input = (q_out = MvNormalMeanPrecision([1.0; 2.0], [3.0 2.0; 2.0 4.0]), q_μ = MvNormalMeanPrecision([3.0; 5.0], [3.0 2.0; 2.0 4.0])), output = Wishart(4.0, [ 39/74 -11/37; -11/37 10/37 ])),
             (input = (q_out = MvNormalMeanPrecision([1.0; 2.0; 3.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0]), q_μ = MvNormalMeanPrecision([3.0; 5.0; -2.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0])), output = Wishart(5.0, [ 15/11 -3/22 5/11; -3/22 19/22 5/11; 5/11 5/11 16/33 ]))
         ]
-        @test_rules [ with_float_conversions = false ] MvNormalMeanPrecision(:Λ, Marginalisation) [
+        @test_rules [ with_float_conversions = true, float32_atol = 1e-5 ] MvNormalMeanPrecision(:Λ, Marginalisation) [
             (input = (q_out = PointMass([ 1.0, 2.0 ]), q_μ = MvNormalMeanCovariance([ 3.0, 5.0 ], [ 3.0 2.0; 2.0 4.0 ])), output = Wishart(4.0, [ 13/27 -8/27; -8/27 7/27 ])),
             (input = (q_out = MvNormalMeanCovariance([1.0; 2.0], [3.0 2.0; 2.0 4.0]), q_μ = PointMass([3.0; 5.0])), output = Wishart(4.0, [ 13/27 -8/27; -8/27 7/27 ])),
             (input = (q_out = MvNormalMeanCovariance([1.0; 2.0], [3.0 2.0; 2.0 4.0]), q_μ = MvNormalMeanCovariance([3.0; 5.0], [3.0 2.0; 2.0 4.0])), output = Wishart(4.0, [ 17/70 -1/7; -1/7 1/7 ])),
             (input = (q_out = MvNormalMeanCovariance([1.0; 2.0; 3.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0]), q_μ = MvNormalMeanCovariance([3.0; 5.0; -2.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0])), output = Wishart(5.0, [ 51/338 -6/169 5/169; -6/169 115/676 45/676; 5/169 45/676 47/676 ]))
         ]
-        @test_rules [ with_float_conversions = false ] MvNormalMeanPrecision(:Λ, Marginalisation) [
+        @test_rules [ with_float_conversions = true, float32_atol = 1e-5 ] MvNormalMeanPrecision(:Λ, Marginalisation) [
             (input = (q_out = PointMass([ 1.0, 2.0 ]), q_μ = MvNormalWeightedMeanPrecision([ 3.0, 5.0 ], [ 3.0 2.0; 2.0 4.0 ])), output = Wishart(4.0, [ 73/67 -26/67; -26/67 68/67 ])),
             (input = (q_out = MvNormalWeightedMeanPrecision([1.0; 2.0], [3.0 2.0; 2.0 4.0]), q_μ = PointMass([3.0; 5.0])), output = Wishart(4.0, [ 165/163 -106/163; -106/163 76/163 ])),
             (input = (q_out = MvNormalWeightedMeanPrecision([1.0; 2.0], [3.0 2.0; 2.0 4.0]), q_μ = MvNormalWeightedMeanPrecision([3.0; 5.0], [3.0 2.0; 2.0 4.0])), output = Wishart(4.0, [ 73/70 11/35; 11/35 34/35 ])),

--- a/test/rules/mv_normal_mean_precision/test_precision.jl
+++ b/test/rules/mv_normal_mean_precision/test_precision.jl
@@ -15,7 +15,7 @@ import ReactiveMP: @test_rules
             (input = (q_out = PointMass([1.0; 2.0]), q_μ = MvNormalMeanPrecision([3.0; 5.0], [3.0 2.0; 2.0 4.0])), output = Wishart(4.0, cholinv(cholinv([3.0 2.0; 2.0 4.0]) + ([3.0; 5.0] - [1.0; 2.0])*([3.0; 5.0] - [1.0; 2.0])')))
         ]
         @test_rules [ with_float_conversions = false ] MvNormalMeanPrecision(:Λ, Marginalisation) [
-            (input = (q_out = PointMass([1.0; 2.0]), q_μ = MvNormalMeanCovariance([3.0; 5.0], inv([3.0 2.0; 2.0 4.0]))), output = Wishart(4.0, cholinv(cholinv([3.0 2.0; 2.0 4.0]) + ([3.0; 5.0] - [1.0; 2.0])*([3.0; 5.0] - [1.0; 2.0])')))
+            (input = (q_out = PointMass([1.0; 2.0]), q_μ = MvNormalMeanCovariance([3.0; 5.0], cholinv([3.0 2.0; 2.0 4.0]))), output = Wishart(4.0, cholinv(cholinv([3.0 2.0; 2.0 4.0]) + ([3.0; 5.0] - [1.0; 2.0])*([3.0; 5.0] - [1.0; 2.0])')))
         ]
         @test_rules [ with_float_conversions = false ] MvNormalMeanPrecision(:Λ, Marginalisation) [
             (input = (q_out = PointMass([1.0; 2.0]), q_μ = MvNormalWeightedMeanPrecision([19.0; 26.0], [3.0 2.0; 2.0 4.0])), output = Wishart(4.0, cholinv(cholinv([3.0 2.0; 2.0 4.0]) + ([3.0; 5.0] - [1.0; 2.0])*([3.0; 5.0] - [1.0; 2.0])')))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,9 +76,12 @@ using .ReactiveMPTestingHelpers
     addtests("rules/normal_mean_precision/test_mean.jl")
     addtests("rules/normal_mean_precision/test_precision.jl")
 
+    addtests("rules/mv_normal_mean_covariance/test_out.jl")
+    addtests("rules/mv_normal_mean_covariance/test_mean.jl")
+
     addtests("rules/mv_normal_mean_precision/test_out.jl")
     addtests("rules/mv_normal_mean_precision/test_mean.jl")
-    addtests("rules/mv_normal_mean_precision/test_precision.jl")    
+    addtests("rules/mv_normal_mean_precision/test_precision.jl")  
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,7 +75,10 @@ using .ReactiveMPTestingHelpers
     addtests("rules/normal_mean_precision/test_out.jl")
     addtests("rules/normal_mean_precision/test_mean.jl")
     addtests("rules/normal_mean_precision/test_precision.jl")
-    
+
+    addtests("rules/mv_normal_mean_precision/test_out.jl")
+    addtests("rules/mv_normal_mean_precision/test_mean.jl")
+    Raddtests("rules/mv_normal_mean_precision/test_precision.jl")    
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,7 +78,7 @@ using .ReactiveMPTestingHelpers
 
     addtests("rules/mv_normal_mean_precision/test_out.jl")
     addtests("rules/mv_normal_mean_precision/test_mean.jl")
-    Raddtests("rules/mv_normal_mean_precision/test_precision.jl")    
+    addtests("rules/mv_normal_mean_precision/test_precision.jl")    
 
 end
 


### PR DESCRIPTION
This PR adds update rules for the multivariate normal node. It optimizes some rules to potentially reduce the number of matrix inversions. Furthermore it includes tests for the added rules.