### PR TITLE
Extend Addition node rules

### DIFF
--- a/src/ReactiveMP.jl
+++ b/src/ReactiveMP.jl
@@ -1,5 +1,6 @@
 module ReactiveMP
 
+using Optim: UnivariateOptimizationResults
 using Base: kwarg_decl, NamedTuple
 include("rocket.jl")
 include("macrohelpers.jl")

--- a/src/ReactiveMP.jl
+++ b/src/ReactiveMP.jl
@@ -1,7 +1,5 @@
 module ReactiveMP
 
-using Optim: UnivariateOptimizationResults
-using Base: kwarg_decl, NamedTuple
 include("rocket.jl")
 include("macrohelpers.jl")
 include("helpers.jl")

--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -1,6 +1,6 @@
 export vague
 export mean, median, mode, shape, scale, rate, var, std, cov, invcov, entropy, pdf, logpdf, logdetcov
-export mean_cov, mean_invcov, mean_precision, weightedmean_cov, weightedmean_invcov, weightedmean_precision
+export mean_cov, mean_var, mean_invcov, mean_precision, weightedmean_cov, weightedmean_var, weightedmean_invcov, weightedmean_precision
 export weightedmean, probvec, logmean, meanlogmean, inversemean, mirroredlogmean, loggammamean
 export variate_form, value_support, promote_variate_type, convert_eltype
 
@@ -17,10 +17,12 @@ import Base: prod
 function vague end
 
 mean_cov(something)         = (mean(something), cov(something))
+mean_var(something)         = (mean(something), var(something))
 mean_invcov(something)      = (mean(something), invcov(something))
 mean_precision(something)   = mean_invcov(something)
 
 weightedmean_cov(something)       = (weightedmean(something), cov(something))
+weightedmean_var(something)       = (weightedmean(something), var(something))
 weightedmean_invcov(something)    = (weightedmean(something), invcov(something))
 weightedmean_precision(something) = weightedmean_invcov(something)
 

--- a/src/rules/addition/in1.jl
+++ b/src/rules/addition/in1.jl
@@ -12,6 +12,10 @@ export rule
     return NormalMeanPrecision(mean(m_out) - mean(m_in2), p1 * p2 / (p1 + p2))
 end
 
+@rule typeof(+)(:in1, Marginalisation) (m_out::UnivariateNormalDistributionsFamily, m_in2::UnivariateNormalDistributionsFamily) = begin
+    return NormalMeanVariance(mean(m_out) - mean(m_in2), var(m_out) + var(m_in2))
+end
+
 @rule typeof(+)(:in1, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_in2::MultivariateNormalDistributionsFamily) = begin
     mout, vout = mean_cov(m_out)
     m2, v2 = mean_cov(m_in2)

--- a/src/rules/addition/in1.jl
+++ b/src/rules/addition/in1.jl
@@ -1,23 +1,31 @@
-export rule
 
 @rule typeof(+)(:in1, Marginalisation) (m_out::PointMass, m_in2::PointMass) = PointMass(mean(m_out) - mean(m_in2))
 
-@rule typeof(+)(:in1, Marginalisation) (m_out::NormalMeanVariance, m_in2::PointMass) = NormalMeanVariance(mean(m_out) - mean(m_in2), var(m_out))
-@rule typeof(+)(:in1, Marginalisation) (m_out::PointMass, m_in2::NormalMeanVariance) = NormalMeanVariance(mean(m_out) - mean(m_in2), var(m_in2))
+@rule typeof(+)(:in1, Marginalisation) (m_out::UnivariateNormalDistributionsFamily, m_in2::PointMass) = NormalMeanVariance(mean(m_out) - mean(m_in2), var(m_out))
+@rule typeof(+)(:in1, Marginalisation) (m_out::PointMass, m_in2::UnivariateNormalDistributionsFamily) = NormalMeanVariance(mean(m_out) - mean(m_in2), var(m_in2))
 
+@rule typeof(+)(:in1, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_in2::PointMass) = MvNormalMeanCovariance(mean(m_out) - mean(m_in2), cov(m_out))
+@rule typeof(+)(:in1, Marginalisation) (m_out::PointMass, m_in2::MultivariateNormalDistributionsFamily) = MvNormalMeanCovariance(mean(m_out) - mean(m_in2), cov(m_in2))
+
+# TODO: Do we need it?
+# Specific case for precision parametrisation
 @rule typeof(+)(:in1, Marginalisation) (m_out::NormalMeanPrecision, m_in2::PointMass) = NormalMeanPrecision(mean(m_out) - mean(m_in2), precision(m_out))
 @rule typeof(+)(:in1, Marginalisation) (m_out::PointMass, m_in2::NormalMeanPrecision) = NormalMeanPrecision(mean(m_out) - mean(m_in2), precision(m_in2))
+
 @rule typeof(+)(:in1, Marginalisation) (m_out::NormalMeanPrecision, m_in2::NormalMeanPrecision) = begin
-    p1, p2 = precision(m_out), precision(m_in2)
-    return NormalMeanPrecision(mean(m_out) - mean(m_in2), p1 * p2 / (p1 + p2))
+    mout, pout = mean_precision(m_out)
+    min2, pin2 = mean_precision(m_in2)
+    return NormalMeanPrecision(mout - min2, pout * pin2 / (pout + pin2))
 end
 
 @rule typeof(+)(:in1, Marginalisation) (m_out::UnivariateNormalDistributionsFamily, m_in2::UnivariateNormalDistributionsFamily) = begin
-    return NormalMeanVariance(mean(m_out) - mean(m_in2), var(m_out) + var(m_in2))
+    mout, vout = mean_var(m_out)
+    min2, vin2 = mean_var(m_in2)
+    return NormalMeanVariance(mout - min2, vout + vin2)
 end
 
 @rule typeof(+)(:in1, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_in2::MultivariateNormalDistributionsFamily) = begin
     mout, vout = mean_cov(m_out)
-    m2, v2 = mean_cov(m_in2)
-    return MvNormalMeanCovariance(mout- m2, vout + v2)
+    min2, vin2 = mean_cov(m_in2)
+    return MvNormalMeanCovariance(mout - min2, vout + vin2)
 end

--- a/src/rules/addition/in2.jl
+++ b/src/rules/addition/in2.jl
@@ -11,6 +11,10 @@ export rule
     return NormalMeanPrecision(mean(m_out) - mean(m_in1), p1 * p2 / (p1 + p2))
 end
 
+@rule typeof(+)(:in2, Marginalisation) (m_out::UnivariateNormalDistributionsFamily, m_in1::UnivariateNormalDistributionsFamily) = begin
+    return NormalMeanVariance(mean(m_out) - mean(m_in1), var(m_out) + var(m_in1))
+end
+
 @rule typeof(+)(:in2, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_in1::MultivariateNormalDistributionsFamily) = begin
     mout, vout = mean_cov(m_out)
     m1, v1 = mean_cov(m_in1)

--- a/src/rules/addition/in2.jl
+++ b/src/rules/addition/in2.jl
@@ -1,22 +1,31 @@
-export rule
 
 @rule typeof(+)(:in2, Marginalisation) (m_out::PointMass, m_in1::PointMass) = PointMass(mean(m_out) - mean(m_in1))
-@rule typeof(+)(:in2, Marginalisation) (m_out::PointMass, m_in1::NormalMeanVariance) = NormalMeanVariance(mean(m_out) - mean(m_in1), var(m_in1))
-@rule typeof(+)(:in2, Marginalisation) (m_out::NormalMeanVariance, m_in1::PointMass) = NormalMeanVariance(mean(m_out) - mean(m_in1), var(m_out))
-@rule typeof(+)(:in2, Marginalisation) (m_out::NormalMeanVariance, m_in1::NormalMeanVariance) = NormalMeanVariance(mean(m_out) - mean(m_in1), var(m_out) + var(m_in1))
 
+@rule typeof(+)(:in2, Marginalisation) (m_out::UnivariateNormalDistributionsFamily, m_in1::PointMass) = NormalMeanVariance(mean(m_out) - mean(m_in1), var(m_out))
+@rule typeof(+)(:in2, Marginalisation) (m_out::PointMass, m_in1::UnivariateNormalDistributionsFamily) = NormalMeanVariance(mean(m_out) - mean(m_in1), var(m_in1))
+
+@rule typeof(+)(:in2, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_in1::PointMass) = MvNormalMeanCovariance(mean(m_out) - mean(m_in1), cov(m_out))
+@rule typeof(+)(:in2, Marginalisation) (m_out::PointMass, m_in1::MultivariateNormalDistributionsFamily) = MvNormalMeanCovariance(mean(m_out) - mean(m_in1), cov(m_in1))
+
+# TODO: Do we need it?
+# Specific case for precision parametrisation
+@rule typeof(+)(:in2, Marginalisation) (m_out::NormalMeanPrecision, m_in1::PointMass) = NormalMeanPrecision(mean(m_out) - mean(m_in1), precision(m_out))
 @rule typeof(+)(:in2, Marginalisation) (m_out::PointMass, m_in1::NormalMeanPrecision) = NormalMeanPrecision(mean(m_out) - mean(m_in1), precision(m_in1))
+
 @rule typeof(+)(:in2, Marginalisation) (m_out::NormalMeanPrecision, m_in1::NormalMeanPrecision) = begin
-    p1, p2 = precision(m_out), precision(m_in1)
-    return NormalMeanPrecision(mean(m_out) - mean(m_in1), p1 * p2 / (p1 + p2))
+    mout, pout = mean_precision(m_out)
+    min1, pin1 = mean_precision(m_in1)
+    return NormalMeanPrecision(mout - min1, pout * pin1 / (pout + pin1))
 end
 
 @rule typeof(+)(:in2, Marginalisation) (m_out::UnivariateNormalDistributionsFamily, m_in1::UnivariateNormalDistributionsFamily) = begin
-    return NormalMeanVariance(mean(m_out) - mean(m_in1), var(m_out) + var(m_in1))
+    mout, vout = mean_var(m_out)
+    min1, vin1 = mean_var(m_in1)
+    return NormalMeanVariance(mout - min1, vout + vin1)
 end
 
 @rule typeof(+)(:in2, Marginalisation) (m_out::MultivariateNormalDistributionsFamily, m_in1::MultivariateNormalDistributionsFamily) = begin
     mout, vout = mean_cov(m_out)
-    m1, v1 = mean_cov(m_in1)
-    return MvNormalMeanCovariance(mout- m1, vout + v1)
+    min1, vin1 = mean_cov(m_in1)
+    return MvNormalMeanCovariance(mout - min1, vout + vin1)
 end

--- a/src/rules/addition/marginals.jl
+++ b/src/rules/addition/marginals.jl
@@ -3,3 +3,14 @@ export marginalrule
 @marginalrule typeof(+)(:in1_in2) (m_out::NormalMeanVariance, m_in1::NormalMeanVariance, m_in2::PointMass) = begin
     (in1 = prod(ProdAnalytical(), NormalMeanVariance(mean(m_out) - mean(m_in2), var(m_out)), m_in1), in2 = m_in2)
 end
+
+@marginalrule typeof(+)(:in1_in2) (m_out::UnivariateNormalDistributionsFamily, m_in1::UnivariateNormalDistributionsFamily, m_in2::UnivariateNormalDistributionsFamily) = begin
+    xi_out = weightedmean(m_out)
+    W_out  = precision(m_out)
+    xi_in1 = weightedmean(m_in1)
+    W_in1  = precision(m_in1)
+    xi_in2 = weightedmean(m_in2)
+    W_in2  = precision(m_in2)
+    
+    return MvNormalWeightedMeanPrecision([xi_in1+xi_out; xi_in2+xi_out], [W_in1+W_out W_out; W_out W_in2+W_out])
+end

--- a/src/rules/addition/marginals.jl
+++ b/src/rules/addition/marginals.jl
@@ -1,16 +1,12 @@
-export marginalrule
 
-@marginalrule typeof(+)(:in1_in2) (m_out::NormalMeanVariance, m_in1::NormalMeanVariance, m_in2::PointMass) = begin
-    (in1 = prod(ProdAnalytical(), NormalMeanVariance(mean(m_out) - mean(m_in2), var(m_out)), m_in1), in2 = m_in2)
+@marginalrule typeof(+)(:in1_in2) (m_out::UnivariateNormalDistributionsFamily, m_in1::UnivariateNormalDistributionsFamily, m_in2::PointMass) = begin
+    return (in1 = prod(ProdAnalytical(), NormalMeanVariance(mean(m_out) - mean(m_in2), var(m_out)), m_in1), in2 = m_in2)
 end
 
 @marginalrule typeof(+)(:in1_in2) (m_out::UnivariateNormalDistributionsFamily, m_in1::UnivariateNormalDistributionsFamily, m_in2::UnivariateNormalDistributionsFamily) = begin
-    xi_out = weightedmean(m_out)
-    W_out  = precision(m_out)
-    xi_in1 = weightedmean(m_in1)
-    W_in1  = precision(m_in1)
-    xi_in2 = weightedmean(m_in2)
-    W_in2  = precision(m_in2)
+    xi_out, W_out = weightedmean_precision(m_out)
+    xi_in1, W_in1 = weightedmean_precision(m_in1)
+    xi_in2, W_in2 = weightedmean_precision(m_in2)
     
-    return MvNormalWeightedMeanPrecision([xi_in1+xi_out; xi_in2+xi_out], [W_in1+W_out W_out; W_out W_in2+W_out])
+    return MvNormalWeightedMeanPrecision([ xi_in1 + xi_out; xi_in2 + xi_out ], [ W_in1 + W_out W_out; W_out W_in2 + W_out])
 end

--- a/src/rules/addition/out.jl
+++ b/src/rules/addition/out.jl
@@ -1,13 +1,27 @@
-export rule
 
 @rule typeof(+)(:out, Marginalisation) (m_in1::PointMass, m_in2::PointMass) = PointMass(mean(m_in1) + mean(m_in2))
-@rule typeof(+)(:out, Marginalisation) (m_in1::NormalMeanVariance, m_in2::PointMass) = NormalMeanVariance(mean(m_in1) + mean(m_in2), var(m_in1))
-@rule typeof(+)(:out, Marginalisation) (m_in1::PointMass, m_in2::NormalMeanVariance) = NormalMeanVariance(mean(m_in1) + mean(m_in2), var(m_in2))
-@rule typeof(+)(:out, Marginalisation) (m_in1::NormalMeanVariance, m_in2::NormalMeanVariance) = NormalMeanVariance(mean(m_in1) + mean(m_in2), var(m_in1) + var(m_in2))
+
+@rule typeof(+)(:out, Marginalisation) (m_in1::PointMass, m_in2::UnivariateNormalDistributionsFamily) = NormalMeanVariance(mean(m_in1) + mean(m_in2), var(m_in2))
+@rule typeof(+)(:out, Marginalisation) (m_in1::UnivariateNormalDistributionsFamily, m_in2::PointMass) = NormalMeanVariance(mean(m_in1) + mean(m_in2), var(m_in1))
+
+@rule typeof(+)(:out, Marginalisation) (m_in1::PointMass, m_in2::MultivariateNormalDistributionsFamily) = MvNormalMeanCovariance(mean(m_in1) + mean(m_in2), cov(m_in2))
+@rule typeof(+)(:out, Marginalisation) (m_in1::MultivariateNormalDistributionsFamily, m_in2::PointMass) = MvNormalMeanCovariance(mean(m_in1) + mean(m_in2), cov(m_in1))
+
+# TODO: Do we need it?
+# Specific case for precision parametrisation
+@rule typeof(+)(:out, Marginalisation) (m_in1::NormalMeanPrecision, m_in2::PointMass) = NormalMeanPrecision(mean(m_in1) + mean(m_in2), precision(m_in1))
+@rule typeof(+)(:out, Marginalisation) (m_in1::PointMass, m_in2::NormalMeanPrecision) = NormalMeanPrecision(mean(m_in1) + mean(m_in2), precision(m_in2))
 
 @rule typeof(+)(:out, Marginalisation) (m_in1::NormalMeanPrecision, m_in2::NormalMeanPrecision) = begin
-    p1, p2 = precision(m_in1), precision(m_in2)
-    return NormalMeanPrecision(mean(m_in1) + mean(m_in2), p1 * p2 / (p1 + p2))
+    min1, pin1 = mean_precision(m_in1)
+    min2, pin2 = mean_precision(m_in2)
+    return NormalMeanPrecision(min1 + min2, pin1 * pin2 / (pin1 + pin2))
+end
+
+@rule typeof(+)(:out, Marginalisation) (m_in1::UnivariateNormalDistributionsFamily, m_in2::UnivariateNormalDistributionsFamily) = begin 
+    m1, v1 = mean_var(m_in1)
+    m2, v2 = mean_var(m_in2)
+    return NormalMeanVariance(m1 + m2, v1 + v2)
 end
 
 @rule typeof(+)(:out, Marginalisation) (m_in1::MultivariateNormalDistributionsFamily, m_in2::MultivariateNormalDistributionsFamily) = begin


### PR DESCRIPTION
This PR includes new rules for computing the marginal and messages when all "interfaces" are of `UnivariateNormalDistributionsFamily` type.