### PR TITLE
Develop correction

### DIFF
--- a/src/ReactiveMP.jl
+++ b/src/ReactiveMP.jl
@@ -31,6 +31,7 @@ include("actors/score.jl")
 include("algebra/helpers.jl")
 include("algebra/cholinv.jl")
 include("algebra/companion_matrix.jl")
+include("algebra/correction.jl")
 
 include("approximations.jl")
 include("approximations/gausshermite.jl")

--- a/src/algebra/cholinv.jl
+++ b/src/algebra/cholinv.jl
@@ -10,3 +10,5 @@ cholinv(x::Real)     = inv(x)
 cholsqrt(x)           = Matrix(cholesky(PositiveFactorizations.Positive, x).L)
 cholsqrt(x::Diagonal) = Diagonal(sqrt.(diag(x)))
 cholsqrt(x::Real)     = sqrt(x)
+
+

--- a/src/algebra/correction.jl
+++ b/src/algebra/correction.jl
@@ -1,6 +1,4 @@
-export NoCorrection, TinyCorrection
-
-import LinearAlgebra: diagind
+export NoCorrection, TinyCorrection, FixedCorrection, ClampEigenValuesCorrection
 
 abstract type AbstractCorrection end
 
@@ -33,7 +31,7 @@ end
 
 One of the correction strategies for `correction!` function. Adds `ReactiveMP.tiny` term to the `matrix`'s diagonal.
 
-See also: [`correction!`](@ref), [`NoCorrection`](@ref)
+See also: [`correction!`](@ref), [`NoCorrection`](@ref), [`FixedCorrection`](@ref), [`ClampEigenValuesCorrection`](@ref)
 """
 struct TinyCorrection <: AbstractCorrection end
 
@@ -41,7 +39,57 @@ function correction!(::TinyCorrection, matrix)
     s = size(matrix)
     @assert length(s) == 2 && s[1] === s[2]
     for i in 1:s[1]
-        @inbounds matrix[i, i] = matrix[i, i] + tiny
+        @inbounds matrix[i, i] += tiny
     end
     return matrix
 end
+
+"""
+    FixedCorrection
+
+One of the correction strategies for `correction!` function. Adds fixed `v` term to the `matrix`'s diagonal.
+
+# Arguments
+- `v`: fixed value to add to the matrix diagonal
+
+See also: [`correction!`](@ref), [`NoCorrection`](@ref), [`TinyCorrection`](@ref), [`ClampEigenValuesCorrection`](@ref)
+"""
+struct FixedCorrection{T} <: AbstractCorrection 
+    v :: T
+end
+
+function correction!(correction::FixedCorrection, matrix)
+    s = size(matrix)
+    @assert length(s) == 2 && s[1] === s[2]
+    for i in 1:s[1]
+        @inbounds matrix[i, i] += correction.v
+    end
+    return matrix
+end
+
+"""
+    ClampEigenValuesCorrection
+
+One of the correction strategies for `correction!` function. Clamps eigen values of matrix to be equal or greater than fixed `v` term.
+
+# Arguments
+- `v`: fixed value used to clamp eigen values
+
+See also: [`correction!`](@ref), [`NoCorrection`](@ref), [`FixedCorrection`](@ref), [`TinyCorrection`](@ref)
+"""
+struct ClampEigenValuesCorrection{T} <: AbstractCorrection
+    v :: T
+end
+
+function correction!(correction::ClampEigenValuesCorrection, matrix)
+    s = size(matrix)
+    @assert length(s) == 2 && s[1] === s[2]
+
+    F = svd(matrix)
+    clamp!(F.S, correction.v, Inf)
+    R = lmul!(Diagonal(F.S), F.Vt)
+    M = mul!(matrix, F.U, R)
+
+    return M
+end
+

--- a/src/algebra/correction.jl
+++ b/src/algebra/correction.jl
@@ -1,0 +1,47 @@
+export NoCorrection, TinyCorrection
+
+import LinearAlgebra: diagind
+
+abstract type AbstractCorrection end
+
+# Correction regularization terms for matrices
+
+"""
+    correction!(strategy, matrix)
+
+Modifies the `matrix` with a specified correction strategy. Matrix must be squared.
+See also: [`NoCorrection`](@ref), [`TinyCorrection`](@ref)
+"""
+function correction! end
+
+"""
+    NoCorrection
+
+One of the correction strategies for `correction!` function. Does not modify matrix and returns an original one.
+
+See also: [`correction!`](@ref), [`TinyCorrection`](@ref)
+"""
+struct NoCorrection <: AbstractCorrection end
+
+function correction!(::NoCorrection, matrix)
+    return matrix
+end
+
+
+"""
+    TinyCorrection
+
+One of the correction strategies for `correction!` function. Adds `ReactiveMP.tiny` term to the `matrix`'s diagonal.
+
+See also: [`correction!`](@ref), [`NoCorrection`](@ref)
+"""
+struct TinyCorrection <: AbstractCorrection end
+
+function correction!(::TinyCorrection, matrix)
+    s = size(matrix)
+    @assert length(s) == 2 && s[1] === s[2]
+    for i in 1:s[1]
+        @inbounds matrix[i, i] = matrix[i, i] + tiny
+    end
+    return matrix
+end

--- a/src/nodes/dot_product.jl
+++ b/src/nodes/dot_product.jl
@@ -1,3 +1,6 @@
 export make_node
 
 @node typeof(dot) Deterministic [ out, in1, in2 ]
+
+# By default dot-product node uses TinyCorrection() strategy for precision matrix on `in1` and `in2` edges to ensure precision is always invertible
+default_meta(::typeof(dot)) = TinyCorrection()

--- a/src/nodes/multiplication.jl
+++ b/src/nodes/multiplication.jl
@@ -1,2 +1,5 @@
 
 @node typeof(*) Deterministic [ out, A, in ]
+
+# By default multiplication node uses TinyCorrection() strategy for precision matrix on `in` edge to ensure precision is always invertible
+default_meta(::typeof(*)) = TinyCorrection()

--- a/src/rules/dot_product/in1.jl
+++ b/src/rules/dot_product/in1.jl
@@ -1,8 +1,8 @@
 export rule
 
-@rule typeof(dot)(:in1, Marginalisation) (m_out::UnivariateNormalDistributionsFamily, m_in2::PointMass{ <: AbstractVector }) = begin
-    x = mean(m_in2)
+@rule typeof(dot)(:in1, Marginalisation) (m_out::UnivariateNormalDistributionsFamily, m_in2::PointMass{ <: AbstractVector }, meta::AbstractCorrection) = begin
+    x  = mean(m_in2)
     xi = x * weightedmean(m_out)
-    w = x * precision(m_out) * x'
+    w  = correction!(meta, x * precision(m_out) * x')
     return MvGaussianWeightedMeanPrecision(xi, w)
 end

--- a/src/rules/dot_product/in2.jl
+++ b/src/rules/dot_product/in2.jl
@@ -1,8 +1,8 @@
 export rule
 
-@rule typeof(dot)(:in2, Marginalisation) (m_out::UnivariateNormalDistributionsFamily, m_in1::PointMass{ <: AbstractVector }) = begin
-    x = mean(m_in1)
+@rule typeof(dot)(:in2, Marginalisation) (m_out::UnivariateNormalDistributionsFamily, m_in1::PointMass{ <: AbstractVector }, meta::AbstractCorrection) = begin
+    x  = mean(m_in1)
     xi = x * weightedmean(m_out)
-    w = x * precision(m_out) * x'
+    w  = correction!(meta, x * precision(m_out) * x')
     return MvGaussianWeightedMeanPrecision(xi, w)
 end

--- a/src/rules/multiplication/in.jl
+++ b/src/rules/multiplication/in.jl
@@ -2,8 +2,8 @@ export rule
 
 @rule typeof(*)(:in, Marginalisation) (m_out::PointMass, m_A::PointMass) = PointMass(mean(m_in1) * mean(m_in2))
 
-@rule typeof(*)(:in, Marginalisation) (m_out::F, m_A::PointMass) where { F <: NormalDistributionsFamily } = begin
+@rule typeof(*)(:in, Marginalisation) (m_out::F, m_A::PointMass, meta::AbstractCorrection) where { F <: NormalDistributionsFamily } = begin
     A = mean(m_A)
-    W = A' * precision(m_out) * A
+    W = correction!(meta, A' * precision(m_out) * A)
     return convert(promote_variate_type(F, NormalWeightedMeanPrecision), A' * weightedmean(m_out), W)
 end

--- a/src/variables/random.jl
+++ b/src/variables/random.jl
@@ -44,7 +44,7 @@ _form_check_strategy(form_check_strategy, randomvar::RandomVariable)            
 messages_prod_fn(randomvar::RandomVariable) = messages_prod_fn(prod_strategy(randomvar), prod_constraint(randomvar), UnspecifiedFormConstraint(), default_form_check_strategy(UnspecifiedFormConstraint()))
 marginal_prod_fn(randomvar::RandomVariable) = marginal_prod_fn(prod_strategy(randomvar), prod_constraint(randomvar), form_constraint(randomvar), form_check_strategy(randomvar))
 
-getlastindex(randomvar::RandomVariable) = length(randomvar.inputmsgs) + 1
+getlastindex(randomvar::RandomVariable) = degree(randomvar) + 1
 
 messagein(randomvar::RandomVariable, index::Int)  = @inbounds randomvar.inputmsgs[index]
 messageout(randomvar::RandomVariable, index::Int) = collectLatest(AbstractMessage, Message, skipindex(randomvar.inputmsgs, index), messages_prod_fn(randomvar))
@@ -57,9 +57,12 @@ _setmarginal!(randomvar::RandomVariable, marginal::MarginalObservable) = randomv
 _makemarginal(randomvar::RandomVariable)                               = collectLatest(AbstractMessage, Marginal, randomvar.inputmsgs, marginal_prod_fn(randomvar))
 
 function setmessagein!(randomvar::RandomVariable, index::Int, messagein)
-    if index === length(randomvar.inputmsgs) + 1
+    if index === degree(randomvar) + 1
         push!(randomvar.inputmsgs, messagein)
     else
-        throw("TODO error message: setmessagein! in ::RandomVariable")
+        throw_setmessagein!(randomvar, index)
     end
 end
+
+# https://github.com/JuliaLang/julia/issues/29688
+throw_setmessagein!(randomvar, index) = throw("Inconsistent state in setmessagein! function for random variable $(randomvar). `index` should be equal to `degree(randomvar) + 1 = $(degree(randomvar) + 1)`, $(index) is given instead")

--- a/test/algebra/test_correction.jl
+++ b/test/algebra/test_correction.jl
@@ -1,0 +1,33 @@
+module ReactiveMPCorrectionTest
+
+using Test
+using ReactiveMP 
+using Random
+
+using LinearAlgebra
+
+@testset "Correction" begin
+
+    rng = MersenneTwister(1234)
+
+    for n in [ 3, 5, 10 ]
+        A = rand(rng, n, n)
+
+        B = ReactiveMP.correction!(NoCorrection(), A)
+
+        @test A == B
+        @test A === B
+
+        C = ReactiveMP.correction!(TinyCorrection(), copy(A))
+
+        @test A ≈ C
+        @test mapreduce((d) -> d[1] + ReactiveMP.tiny === d[2], &, zip(diag(A), diag(C)))
+
+        D = rand(rng, n, n)
+        E = ReactiveMP.correction!(TinyCorrection(), D)
+        @test D === E
+    end
+    
+end
+
+end

--- a/test/algebra/test_correction.jl
+++ b/test/algebra/test_correction.jl
@@ -26,6 +26,24 @@ using LinearAlgebra
         D = rand(rng, n, n)
         E = ReactiveMP.correction!(TinyCorrection(), D)
         @test D === E
+
+
+        v = 1e-10 * rand(rng)
+        F = ReactiveMP.correction!(FixedCorrection(v), copy(A))
+        @test A ≈ F
+        @test mapreduce((d) -> d[1] + v === d[2], &, zip(diag(A), diag(F)))
+
+        G = rand(rng, n, n)
+        H = ReactiveMP.correction!(FixedCorrection(v), G)
+        @test G === H
+
+        J   = ReactiveMP.correction!(ClampEigenValuesCorrection(10.0), copy(A))
+        S_J = svd(J)
+
+        @test mapreduce((d) -> d >= 10.0 || d ≈ 10.0, &, S_J.S)
+
+        K = ReactiveMP.correction!(ClampEigenValuesCorrection(1e-12), copy(A))
+        @test K ≈ A
     end
     
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,8 @@ using .ReactiveMPTestingHelpers
         @test filename_to_key(key_to_filename("message")) == "message"
     end
 
+    addtests("algebra/test_correction.jl")
+
     addtests("test_distributions.jl")
     addtests("distributions/test_common.jl")
     addtests("distributions/test_bernoulli.jl")


### PR DESCRIPTION
This PR implements two precision matrices correction strategies for `::typeof(*)` and `::typeof(dot)` factor nodes: `NoCorrection()` and `TinyCorrection()`. By default `TinyCorrection()` is used, but this behaviour can be changed with `meta` object.

Edit: Two more strategies have been added to the initial PR: `FixedCorrection` and `ClampEigenValuesCorrection`