### PR TITLE
add Aqua tests, get them to pass

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,6 @@ FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 PositiveFactorizations = "85a6dd25-e78a-55b7-8502-1745935b8125"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -30,7 +29,6 @@ DomainSets = "0.5.2"
 FastGaussQuadrature = "0.4"
 ForwardDiff = "0.10"
 MacroTools = "0.5"
-NLsolve = "4.0.0"
 Optim = "1.0.0"
 PositiveFactorizations = "0.2"
 Rocket = "1.3.10"
@@ -41,6 +39,7 @@ TupleTools = "1.2.0"
 julia = "1.5.0"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkCI = "20533458-34a3-403d-a444-e18f38190b5b"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
@@ -50,4 +49,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestSetExtensions = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
 
 [targets]
-test = ["Test", "TestSetExtensions", "Coverage", "Documenter", "BenchmarkCI", "BenchmarkTools", "PkgBenchmark"]
+test = ["Test", "TestSetExtensions", "Coverage", "Documenter", "BenchmarkCI", "BenchmarkTools", "PkgBenchmark", "Aqua"]

--- a/src/marginal.jl
+++ b/src/marginal.jl
@@ -1,5 +1,4 @@
 export Marginal, getdata, is_clamped, is_initial, as_marginal
-export InitialMarginal, MarginalOrInitialMarginal
 export SkipClamped, SkipInitial, SkipClampedAndInitial, IncludeAll
 
 using Distributions

--- a/src/node.jl
+++ b/src/node.jl
@@ -2,8 +2,8 @@ export NodeInterface, IndexedNodeInterface, name, tag, messageout, messagein
 export FactorNode, functionalform, interfaces, factorisation, localmarginals, localmarginalnames, metadata
 export iscontain, isfactorised, getinterface
 export clusters, clusterindex
-export deps, connect!, activate!
-export make_node, on_make_node, AutoVar
+export connect!, activate!
+export make_node, AutoVar
 export ValidNodeFunctionalForm, UndefinedNodeFunctionalForm, as_node_functional_form
 export sdtype, Deterministic, Stochastic, isdeterministic, isstochastic
 export MeanField, FullFactorisation, collect_factorisation

--- a/src/nodes/gamma_mixture.jl
+++ b/src/nodes/gamma_mixture.jl
@@ -1,4 +1,4 @@
-export GammaMixture, GammaMixtureNode, GammaMixtureNodeMetadata
+export GammaMixture, GammaMixtureNode
 
 # Gamma Mixture Functional Form
 struct GammaMixture{N} end

--- a/src/variables/random.jl
+++ b/src/variables/random.jl
@@ -1,4 +1,4 @@
-export RandomVariable, randomvar, simplerandomvar
+export RandomVariable, randomvar
 
 ## Random variable implementation
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,9 @@ module ReactiveMPTest
 using Test, Documenter, ReactiveMP
 using TestSetExtensions
 
+using Aqua
+Aqua.test_all(ReactiveMP; ambiguities=false)
+
 include("test_helpers.jl")
 
 using .ReactiveMPTestingHelpers


### PR DESCRIPTION
[Aqua.jl](https://github.com/JuliaTesting/Aqua.jl) is a package that makes it easy to do some consistency checks.

This PR adds Aqua as a test dependency, and makes some small changes to make Aqua happy.

Note that ambiguity tests are disabled. Currently there are 148 ambiguities, for example
```julia
Ambiguity #148
make_node(fform::Function, autovar::ReactiveMP.AutoVar, args::ReactiveMP.ConstVariable...; kwargs...) in ReactiveMP at /home/chad/git/ReactiveMP.jl/src/node.jl:683
make_node(fform::typeof(+), autovar::ReactiveMP.AutoVar, args::ReactiveMP.AbstractVariable...; kwargs...) in ReactiveMP at /home/chad/git/ReactiveMP.jl/src/node.jl:845
```