### PR TITLE
Marginal constraint

### DIFF
--- a/src/constraints/form/form_fixed_marginal.jl
+++ b/src/constraints/form/form_fixed_marginal.jl
@@ -1,0 +1,27 @@
+export FixedMarginalConstraint
+
+"""
+FixedMarginalConstraint
+
+One of the form constraint objects. 
+Enables fixing the marginal distribution to remain fixed during inference. 
+Can be viewed as blocking of updates of a specific edge associated with the marginal. 
+
+See also: [`constrain_form`](@ref), [`DistProduct`](@ref)
+"""
+
+mutable struct FixedMarginalConstraint <: ReactiveMP.AbstractFormConstraint
+    fixed_value :: Any
+end
+
+default_form_check_strategy(::FixedMarginalConstraint) = FormConstraintCheckLast()
+
+is_point_mass_form_constraint(::FixedMarginalConstraint) = false
+
+function constrain_form(constraint::FixedMarginalConstraint, something)
+    if constraint.fixed_value !== nothing
+        return Message(constraint.fixed_value, false, false)
+    else 
+        return something
+    end
+end 

--- a/src/constraints/form/form_fixed_marginal.jl
+++ b/src/constraints/form/form_fixed_marginal.jl
@@ -4,7 +4,7 @@ export FixedMarginalConstraint
 FixedMarginalConstraint
 
 One of the form constraint objects. 
-Enables fixing the marginal distribution to remain fixed during inference. 
+Provides a constraint on the marginal distribution such that it remains fixed during inference. 
 Can be viewed as blocking of updates of a specific edge associated with the marginal. 
 
 See also: [`constrain_form`](@ref), [`DistProduct`](@ref)


### PR DESCRIPTION
Here is a small PR that enables immobilizing the marginal distribution such that it remains fixed during inference. 