### PR TITLE
feat: add more rules for Transition node

### DIFF
--- a/src/nodes/transition.jl
+++ b/src/nodes/transition.jl
@@ -17,9 +17,14 @@ end
 end
 
 @average_energy Transition (q_out_in::Contingency, q_a::PointMass) = begin
-    return -tr(contingency_matrix(q_out_in)' * mean(log, q_a))
+    # `map(d -> log(clamp(d, tiny, huge)), mean(q_a))` is an equivalent of `mean(log, q_a)` with an extra `clamp(el, tiny, huge)` operation
+    # The reason is that we don't want to take log of zeros in the matrix `q_a` (if there are any)
+    # The trick here is that if RHS matrix has zero inputs, than the corresponding entries of the `contingency_matrix` matrix 
+    # should also be zeros (see corresponding @marginalrule), so at the end `log(tiny) * 0` should not influence the result.
+    return -ReactiveMP.mul_trace(ReactiveMP.contingency_matrix(q_out_in)', map(d -> log(clamp(d, tiny, huge)), mean(q_a)))
 end
 
 @average_energy Transition (q_out::Any, q_in::Any, q_a::PointMass) = begin
     return -probvec(q_out)' * mean(log,q_a) * probvec(q_in)
 end
+

--- a/src/rules/transition/in.jl
+++ b/src/rules/transition/in.jl
@@ -9,7 +9,17 @@ end
     return Categorical(a ./ sum(a))
 end
 
-@rule Transition(:in, Marginalisation) (m_out::Any, m_a::PointMass, ) = begin 
+@rule Transition(:in, Marginalisation) (m_out::Categorical, q_a::PointMass, meta::Any) = begin 
+    return @call_rule Transition(:in, Marginalisation) (m_out = m_out, m_a = q_a, meta = meta)
+end
+
+@rule Transition(:in, Marginalisation) (q_out::PointMass, q_a::PointMass, ) = begin 
+    p = mean(q_a)' * mean(q_out)
+    normalize!(p, 1)
+    return Categorical(p)
+end
+
+@rule Transition(:in, Marginalisation) (m_out::Categorical, m_a::PointMass, ) = begin 
     p = mean(m_a)' * probvec(m_out)
     normalize!(p, 1)
     return Categorical(p)

--- a/src/rules/transition/marginals.jl
+++ b/src/rules/transition/marginals.jl
@@ -4,6 +4,11 @@
     return Contingency(B ./ sum(B))
 end
 
+@marginalrule Transition(:out_in) (m_out::Categorical, m_in::Categorical, q_a::PointMass) = begin 
+    B = Diagonal(probvec(m_out)) * mean(q_a) * Diagonal(probvec(m_in))
+    return Contingency(B ./ sum(B))
+end
+
 @marginalrule Transition(:out_in_a) (m_out::Categorical, m_in::Categorical, m_a::PointMass, ) = begin 
     B = Diagonal(probvec(m_out)) * mean(m_a) * Diagonal(probvec(m_in))
     return (out_in = Contingency(B ./ sum(B)), a = m_a)

--- a/src/rules/transition/out.jl
+++ b/src/rules/transition/out.jl
@@ -9,7 +9,17 @@ end
     return Categorical(a ./ sum(a))
 end
 
-@rule Transition(:out, Marginalisation) (m_in::Any, m_a::PointMass) = begin
+@rule Transition(:out, Marginalisation) (m_in::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin 
+    return @call_rule Transition(:out, Marginalisation) (m_in = m_in, m_a = q_a, meta = meta)
+end
+
+@rule Transition(:out, Marginalisation) (q_in::PointMass, q_a::PointMass) = begin
+    p = mean(q_a) * mean(q_in)
+    normalize!(p, 1)
+    return Categorical(p)
+end
+
+@rule Transition(:out, Marginalisation) (m_in::Categorical, m_a::PointMass) = begin
     p = mean(m_a) * probvec(m_in)
     normalize!(p, 1)
     return Categorical(p)


### PR DESCRIPTION
These rules implement analytical solutions for the Transition node when transition matrix is fixed and known (PointMass).