### PR TITLE
fix: reexport dot product from LinearAlgebra

### DIFF
--- a/src/nodes/dot_product.jl
+++ b/src/nodes/dot_product.jl
@@ -1,3 +1,5 @@
+export dot
+
 import LinearAlgebra: dot
 
 @node typeof(dot) Deterministic [ out, in1, in2 ]


### PR DESCRIPTION
This PR makes `dot` function visible without need to `using LinearAlgebra`