### PR TITLE
fix: add mode method for point mass

### DIFF
--- a/src/distributions/pointmass.jl
+++ b/src/distributions/pointmass.jl
@@ -29,6 +29,7 @@ Distributions.pdf(distribution::PointMass{T}, x::Real)       where { T <: Real }
 Distributions.logpdf(distribution::PointMass{T}, x::Real)    where { T <: Real } = Distributions.insupport(distribution, x) ? zero(T) : convert(T, -Inf)
 
 Distributions.mean(distribution::PointMass{T}) where { T <: Real } = getpointmass(distribution)
+Distributions.mode(distribution::PointMass{T}) where { T <: Real } = mean(distribution)
 Distributions.var(distribution::PointMass{T})  where { T <: Real } = zero(T)
 Distributions.std(distribution::PointMass{T})  where { T <: Real } = zero(T)
 Distributions.cov(distribution::PointMass{T})  where { T <: Real } = zero(T)
@@ -51,6 +52,7 @@ Distributions.pdf(distribution::PointMass{V}, x::AbstractVector)       where { T
 Distributions.logpdf(distribution::PointMass{V}, x::AbstractVector)    where { T <: Real, V <: AbstractVector{T} } = Distributions.insupport(distribution, x) ? zero(T) : convert(T, -Inf)
 
 Distributions.mean(distribution::PointMass{V}) where { T <: Real, V <: AbstractVector{T} } = getpointmass(distribution)
+Distributions.mode(distribution::PointMass{V}) where { T <: Real, V <: AbstractVector{T} } = mean(distribution)
 Distributions.var(distribution::PointMass{V})  where { T <: Real, V <: AbstractVector{T} } = zeros(T, (ndims(distribution), ))
 Distributions.std(distribution::PointMass{V})  where { T <: Real, V <: AbstractVector{T} } = zeros(T, (ndims(distribution), ))
 Distributions.cov(distribution::PointMass{V})  where { T <: Real, V <: AbstractVector{T} } = zeros(T, (ndims(distribution), ndims(distribution)))
@@ -78,6 +80,7 @@ Distributions.pdf(distribution::PointMass{M}, x::AbstractMatrix)       where { T
 Distributions.logpdf(distribution::PointMass{M}, x::AbstractMatrix)    where { T <: Real, M <: AbstractMatrix{T} } = Distributions.insupport(distribution, x) ? zero(T) : convert(T, -Inf)
 
 Distributions.mean(distribution::PointMass{M}) where { T <: Real, M <: AbstractMatrix{T} } = getpointmass(distribution)
+Distributions.mode(distribution::PointMass{M}) where { T <: Real, M <: AbstractMatrix{T} } = mean(distribution)
 Distributions.var(distribution::PointMass{M})  where { T <: Real, M <: AbstractMatrix{T} } = zeros(T, ndims(distribution))
 Distributions.std(distribution::PointMass{M})  where { T <: Real, M <: AbstractMatrix{T} } = zeros(T, ndims(distribution))
 Distributions.cov(distribution::PointMass{M})  where { T <: Real, M <: AbstractMatrix{T} } = error("Distributions.cov(::PointMass{ <: AbstractMatrix }) is not defined")

--- a/test/distributions/test_pointmass.jl
+++ b/test/distributions/test_pointmass.jl
@@ -45,6 +45,7 @@ import ReactiveMP: xtlog, mirrorlog
             @test (@inferred entropy(dist)) == InfCountingReal(eltype(dist), -1)
 
             @test @test_inferred(T, mean(dist))         == scalar
+            @test @test_inferred(T, mode(dist))         == scalar
             @test @test_inferred(T, var(dist))          == zero(T)
             @test @test_inferred(T, std(dist))          == zero(T)
             @test @test_inferred(T, cov(dist))          == zero(T)
@@ -93,6 +94,7 @@ import ReactiveMP: xtlog, mirrorlog
             @test (@inferred entropy(dist)) == InfCountingReal(eltype(dist), -1)
 
             @test @test_inferred(AbstractVector{T}, mean(dist))         == vector
+            @test @test_inferred(AbstractVector{T}, mode(dist))         == vector
             @test @test_inferred(AbstractVector{T}, var(dist))          == zeros(T, N)
             @test @test_inferred(AbstractVector{T}, std(dist))          == zeros(T, N)
             @test @test_inferred(AbstractMatrix{T}, cov(dist))          == zeros(T, N, N)
@@ -142,6 +144,7 @@ import ReactiveMP: xtlog, mirrorlog
             @test (@inferred entropy(dist)) == InfCountingReal(eltype(dist), -1)
 
             @test @test_inferred(AbstractMatrix{T}, mean(dist))       == matrix
+            @test @test_inferred(AbstractMatrix{T}, mode(dist))       == matrix
             @test @test_inferred(AbstractMatrix{T}, var(dist))        == zeros(N, N)
             @test @test_inferred(AbstractMatrix{T}, std(dist))        == zeros(N, N)
             @test @test_inferred(Tuple{Int, Int}, ndims(dist)) == (N, N)


### PR DESCRIPTION
This PR implements `mode` for `PointMass`.