### PR TITLE
fix: minor fix for pointmass form constraint

### DIFF
--- a/src/constraints/form/form_point_mass.jl
+++ b/src/constraints/form/form_point_mass.jl
@@ -75,9 +75,9 @@ default_prod_constraint(::PointMassFormConstraint) = ProdGeneric()
 
 make_form_constraint(::Type{<:PointMass}, args...; kwargs...) = PointMassFormConstraint(args...; kwargs...)
 
-call_optimizer(pmconstraint::PointMassFormConstraint, distribution)      = pmconstraint.optimizer(variate_form(distribution), value_support(distribution), pmconstraint, distribution)
-call_boundaries(pmconstraint::PointMassFormConstraint, distribution)     = pmconstraint.boundaries(variate_form(distribution), value_support(distribution), pmconstraint, distribution)
-call_starting_point(pmconstraint::PointMassFormConstraint, distribution) = pmconstraint.starting_point(variate_form(distribution), value_support(distribution), pmconstraint, distribution)
+call_optimizer(pmconstraint::PointMassFormConstraint, distribution::D) where {D}      = pmconstraint.optimizer(variate_form(D), value_support(D), pmconstraint, distribution)
+call_boundaries(pmconstraint::PointMassFormConstraint, distribution::D) where {D}     = pmconstraint.boundaries(variate_form(D), value_support(D), pmconstraint, distribution)
+call_starting_point(pmconstraint::PointMassFormConstraint, distribution::D) where {D} = pmconstraint.starting_point(variate_form(D), value_support(D), pmconstraint, distribution)
 
 constrain_form(pmconstraint::PointMassFormConstraint, distribution) = call_optimizer(pmconstraint, distribution)
 

--- a/src/distributions/function.jl
+++ b/src/distributions/function.jl
@@ -12,6 +12,7 @@ import Base: isapprox
 abstract type AbstractContinuousGenericLogPdf end
 
 value_support(::Type{<:AbstractContinuousGenericLogPdf}) = Continuous
+value_support(::AbstractContinuousGenericLogPdf)         = Continuous
 
 # We throw an error on purpose, since we do not want to use `AbstractContinuousGenericLogPdf` much without approximations
 # We want to encourage a user to use functional form constraints and approximate generic log-pdfs as much as possible instead
@@ -82,6 +83,7 @@ struct ContinuousUnivariateLogPdf{D <: DomainSets.Domain, F} <: AbstractContinuo
 end
 
 variate_form(::Type{<:ContinuousUnivariateLogPdf}) = Univariate
+variate_form(::ContinuousUnivariateLogPdf)         = Univariate
 
 getdomain(dist::ContinuousUnivariateLogPdf) = dist.domain
 getlogpdf(dist::ContinuousUnivariateLogPdf) = dist.logpdf
@@ -143,6 +145,7 @@ struct ContinuousMultivariateLogPdf{D <: DomainSets.Domain, F} <: AbstractContin
 end
 
 variate_form(::Type{<:ContinuousMultivariateLogPdf}) = Multivariate
+variate_form(::ContinuousMultivariateLogPdf)         = Multivariate
 
 getdomain(dist::ContinuousMultivariateLogPdf) = dist.domain
 getlogpdf(dist::ContinuousMultivariateLogPdf) = dist.logpdf
@@ -187,6 +190,7 @@ struct ContinuousGenericLogPdfVectorisedProduct{F} <: AbstractContinuousGenericL
 end
 
 variate_form(::Type{<:ContinuousGenericLogPdfVectorisedProduct{F}}) where {F} = variate_form(F)
+variate_form(::ContinuousGenericLogPdfVectorisedProduct{F}) where {F}         = variate_form(F)
 
 getdomain(dist::ContinuousGenericLogPdfVectorisedProduct) = getdomain(first(dist.vector))
 getlogpdf(dist::ContinuousGenericLogPdfVectorisedProduct) =


### PR DESCRIPTION
This PR fixes small issue with point mass form constraint and (possibly) undefined `variate_form` or `value_support` called on objects (for types it should be always defined).