### PR TITLE
Add mode calculation for GammaShapeRate distribution

### DIFF
--- a/src/distributions/gamma.jl
+++ b/src/distributions/gamma.jl
@@ -9,8 +9,6 @@ const GammaDistributionsFamily{T} = Union{GammaShapeScale{T}, GammaShapeRate{T}}
 
 Distributions.cov(dist::GammaDistributionsFamily) = var(dist)
 
-Distributions.mode(d::GammaShapeRate) = shape(d) >= 1 ? mode(GammaShapeScale(shape(d), 1/rate(d))) : throw(error("Gamma has no mode when shape < 1"))
-
 function mean(::typeof(log), dist::GammaShapeScale)
     k, θ = params(dist)
     return digamma(k) + log(θ)

--- a/src/distributions/gamma.jl
+++ b/src/distributions/gamma.jl
@@ -9,6 +9,8 @@ const GammaDistributionsFamily{T} = Union{GammaShapeScale{T}, GammaShapeRate{T}}
 
 Distributions.cov(dist::GammaDistributionsFamily) = var(dist)
 
+Distributions.mode(d::GammaShapeRate) = shape(d) >= 1 ? mode(GammaShapeScale(shape(d), 1/rate(d))) : throw(error("Gamma has no mode when shape < 1"))
+
 function mean(::typeof(log), dist::GammaShapeScale)
     k, θ = params(dist)
     return digamma(k) + log(θ)

--- a/src/distributions/gamma_shape_rate.jl
+++ b/src/distributions/gamma_shape_rate.jl
@@ -25,6 +25,9 @@ Distributions.mean(dist::GammaShapeRate)   = shape(dist) / rate(dist)
 Distributions.var(dist::GammaShapeRate)    = shape(dist) / abs2(rate(dist))
 Distributions.params(dist::GammaShapeRate) = (shape(dist), rate(dist))
 
+Distributions.mode(d::GammaShapeRate) = shape(d) >=1 ? mode(Gamma(shape(d), scale(d))) : 
+    throw(error("Gamma has no mode when shape < 1"))
+
 function Distributions.entropy(dist::GammaShapeRate)
     a, b = params(dist)
     return a - log(b) + loggamma(a) + (1 - a) * digamma(a)

--- a/src/distributions/gamma_shape_rate.jl
+++ b/src/distributions/gamma_shape_rate.jl
@@ -25,7 +25,8 @@ Distributions.mean(dist::GammaShapeRate)   = shape(dist) / rate(dist)
 Distributions.var(dist::GammaShapeRate)    = shape(dist) / abs2(rate(dist))
 Distributions.params(dist::GammaShapeRate) = (shape(dist), rate(dist))
 
-Distributions.mode(d::GammaShapeRate) = shape(d) >=1 ? mode(Gamma(shape(d), scale(d))) : 
+Distributions.mode(d::GammaShapeRate) =
+    shape(d) >= 1 ? mode(Gamma(shape(d), scale(d))) :
     throw(error("Gamma has no mode when shape < 1"))
 
 function Distributions.entropy(dist::GammaShapeRate)


### PR DESCRIPTION
The mode of a GammaShapeRate distribution is now calculated by extracting the shape and rate parameters, inverting the rate to a scale parameter, defining a GammaShapeScale distribution and calling Distributions.jl's mode calculation.

Notes:
-  GammaShapeScale inherits mode calculation because it is a redefinition of Distributions.Gamma.
- In case of shape < 1, mode calculation throws identical error to Distributions.Gamma mode calculation.