### PR TITLE
fix: add symmetric marginal rule for scalar multiplication

### DIFF
--- a/src/rules/multiplication/marginals.jl
+++ b/src/rules/multiplication/marginals.jl
@@ -2,14 +2,22 @@
 @marginalrule typeof(*)(:A_in) (
     m_out::NormalDistributionsFamily,
     m_A::PointMass,
-    m_in::F,
+    m_in::NormalDistributionsFamily,
     meta::Any
-) where {F <: NormalDistributionsFamily} = begin
-    # A = mean(m_A)
-    # xi_out, W_out = weightedmean_precision(m_out)
-    # W = A' * W_out * A
-    # b_in = convert(promote_variate_type(F, NormalWeightedMeanPrecision), A' * xi_out, W)  
+) = begin
     b_in = @call_rule typeof(*)(:in, Marginalisation) (m_out = m_out, m_A = m_A, meta = meta)
     q_in = prod(ProdAnalytical(), b_in, m_in)
     return (A = m_A, in = q_in)
+end
+
+# Specific version for scalar with switched arguments.
+# Note that for multivariate case in general multiplication is not a commutative operation, 
+# but for scalars we make an exception
+@marginalrule typeof(*)(:A_in) (
+    m_out::UnivariateNormalDistributionsFamily,
+    m_A::UnivariateNormalDistributionsFamily,
+    m_in::PointMass{<:Real},
+    meta::Any
+) = begin
+    return @call_marginalrule typeof(*)(:A_in) (m_out = m_out, m_A = m_in, m_in = m_A, meta = meta)
 end


### PR DESCRIPTION
Fixes #135 