### PR TITLE
feat: new functional dependencies pipeline `RequireInboundMarginal`

### DIFF
--- a/src/node.jl
+++ b/src/node.jl
@@ -543,14 +543,28 @@ See also: [`ReactiveMP.RequireInboundFunctionalDependencies`](@ref), [`ReactiveM
 """
 struct DefaultFunctionalDependencies <: AbstractNodeFunctionalDependenciesPipeline end
 
-function message_dependencies(::DefaultFunctionalDependencies, nodeinterfaces, nodelocalmarginals, varcluster, cindex, iindex)
+function message_dependencies(
+    ::DefaultFunctionalDependencies,
+    nodeinterfaces,
+    nodelocalmarginals,
+    varcluster,
+    cindex,
+    iindex
+)
     # First we remove current edge index from the list of dependencies
     vdependencies = TupleTools.deleteat(varcluster, varclusterindex(varcluster, iindex))
     # Second we map interface indices to the actual interfaces
     return map(inds -> map(i -> @inbounds(nodeinterfaces[i]), inds), vdependencies)
 end
 
-function marginal_dependencies(::DefaultFunctionalDependencies, nodeinterfaces, nodelocalmarginals, varcluster, cindex, iindex)
+function marginal_dependencies(
+    ::DefaultFunctionalDependencies,
+    nodeinterfaces,
+    nodelocalmarginals,
+    varcluster,
+    cindex,
+    iindex
+)
     return TupleTools.deleteat(nodelocalmarginals, cindex)
 end
 
@@ -631,12 +645,33 @@ function message_dependencies(
         end
         return map(inds -> map(i -> @inbounds(nodeinterfaces[i]), inds), varcluster)
     else
-        return message_dependencies(DefaultFunctionalDependencies(), nodeinterfaces, nodelocalmarginals, varcluster, cindex, iindex)
+        return message_dependencies(
+            DefaultFunctionalDependencies(),
+            nodeinterfaces,
+            nodelocalmarginals,
+            varcluster,
+            cindex,
+            iindex
+        )
     end
 end
 
-function marginal_dependencies(::RequireInboundFunctionalDependencies, nodeinterfaces, nodelocalmarginals, varcluster, cindex, iindex)
-    return marginal_dependencies(DefaultFunctionalDependencies(), nodeinterfaces, nodelocalmarginals, varcluster, cindex, iindex)
+function marginal_dependencies(
+    ::RequireInboundFunctionalDependencies,
+    nodeinterfaces,
+    nodelocalmarginals,
+    varcluster,
+    cindex,
+    iindex
+)
+    return marginal_dependencies(
+        DefaultFunctionalDependencies(),
+        nodeinterfaces,
+        nodelocalmarginals,
+        varcluster,
+        cindex,
+        iindex
+    )
 end
 
 ### With inbound marginals
@@ -654,7 +689,14 @@ function message_dependencies(
     cindex,
     iindex
 )
-    return message_dependencies(DefaultFunctionalDependencies(), nodeinterfaces, nodelocalmarginals, varcluster, cindex, iindex)
+    return message_dependencies(
+        DefaultFunctionalDependencies(),
+        nodeinterfaces,
+        nodelocalmarginals,
+        varcluster,
+        cindex,
+        iindex
+    )
 end
 
 function marginal_dependencies(
@@ -667,7 +709,7 @@ function marginal_dependencies(
 )
     # First we find dependency index in `indices`, we use it later to find `start_with` distribution
     depindex = findfirst((i) -> i === iindex, dependencies.indices)
-    
+
     if depindex !== nothing
         # We create an auxiliary local marginal with non-standard index here and inject it to other standard dependencies
         extra_localmarginal = FactorNodeLocalMarginal(-1, name(nodeinterfaces[iindex]))
@@ -678,9 +720,26 @@ function marginal_dependencies(
             setmarginal!(vmarginal, start_with)
         end
         setstream!(extra_localmarginal, vmarginal)
-        return (extra_localmarginal, marginal_dependencies(DefaultFunctionalDependencies(), nodeinterfaces, nodelocalmarginals, varcluster, cindex, iindex)...)
+        return (
+            extra_localmarginal,
+            marginal_dependencies(
+                DefaultFunctionalDependencies(),
+                nodeinterfaces,
+                nodelocalmarginals,
+                varcluster,
+                cindex,
+                iindex
+            )...
+        )
     else
-        return marginal_dependencies(DefaultFunctionalDependencies(), nodeinterfaces, nodelocalmarginals, varcluster, cindex, iindex)
+        return marginal_dependencies(
+            DefaultFunctionalDependencies(),
+            nodeinterfaces,
+            nodelocalmarginals,
+            varcluster,
+            cindex,
+            iindex
+        )
     end
 end
 

--- a/src/node.jl
+++ b/src/node.jl
@@ -672,7 +672,9 @@ function marginal_dependencies(
     depindex = findfirst((i) -> i === iindex, dependencies.indices)
     
     if depindex !== nothing
-        error("Not implemented")
+        extramarginal = FactorNodeLocalMarginal(-1, name(nodeinterfaces[iindex]))
+        setmarginal!(extramarginal, getmarginal(connectedvar(nodeinterfaces[iindex]), IncludeAll()))
+        return (extramarginal, marginal_dependencies(DefaultFunctionalDependencies(), nodelocalmarginals, varcluster, cindex, iindex)...)
     else
         return marginal_dependencies(DefaultFunctionalDependencies(), nodelocalmarginals, varcluster, cindex, iindex)
     end

--- a/src/node.jl
+++ b/src/node.jl
@@ -636,12 +636,12 @@ function message_dependencies(
         end
         return map(inds -> map(mapindex, inds), varcluster)
     else
-        return message_dependencies(DefaultFunctionalDependencies(), nodeinterfaces, varcluster, iindex)
+        return message_dependencies(DefaultFunctionalDependencies(), nodeinterfaces, varcluster, cindex, iindex)
     end
 end
 
 function marginal_dependencies(::RequireInboundFunctionalDependencies, nodelocalmarginals, varcluster, cindex, iindex)
-    return marginal_dependencies(DefaultFunctionalDependencies(), nodelocalmarginals, varcluster, cindex)
+    return marginal_dependencies(DefaultFunctionalDependencies(), nodelocalmarginals, varcluster, cindex, iindex)
 end
 
 ### With inbound marginals
@@ -658,17 +658,24 @@ function message_dependencies(
     cindex,
     iindex
 )
-    return message_dependencies(DefaultFunctionalDependencies(), nodeinterfaces, varcluster, iindex)
+    return message_dependencies(DefaultFunctionalDependencies(), nodeinterfaces, varcluster, cindex, iindex)
 end
 
 function marginal_dependencies(
-    ::RequireInboundMarginalFunctionalDependencies,
+    dependencies::RequireInboundMarginalFunctionalDependencies,
     nodelocalmarginals,
     varcluster,
     cindex,
     iindex
 )
-    error("Not implemented")
+    # First we find dependency index in `indices`, we use it later to find `start_with` distribution
+    depindex = findfirst((i) -> i === iindex, dependencies.indices)
+    
+    if depindex !== nothing
+        error("Not implemented")
+    else
+        return marginal_dependencies(DefaultFunctionalDependencies(), nodelocalmarginals, varcluster, cindex, iindex)
+    end
 end
 
 ### Everything


### PR DESCRIPTION
This PR adds `RequireInboundMarginalFunctionalDependencies`, which specifies that in order to compute a message on some edge rule requires marginal on the same edge. The interface is pretty much the same as for `RequireInboundFunctionalDependencies`.

Do not merge, tests are not implemented (yet). 