### PR TITLE
fix: automatically renormalize Contingency matrix

### DIFF
--- a/src/distributions/categorical.jl
+++ b/src/distributions/categorical.jl
@@ -1,4 +1,4 @@
-export Bernoulli
+export Categorical
 
 import Distributions: Categorical, probs
 

--- a/src/distributions/contingency.jl
+++ b/src/distributions/contingency.jl
@@ -29,8 +29,8 @@ end
 # Renormalize by default
 Contingency(P::AbstractMatrix) = Contingency(P, Val(true))
 
-Contingency(P::M, renormalize::Val{true}) where { T, M <: AbstractMatrix{T} }  = Contingency{T, M}(P ./ sum(P))
-Contingency(P::M, renormalize::Val{false}) where { T, M <: AbstractMatrix{T} } = Contingency{T, M}(P)
+Contingency(P::M, renormalize::Val{true}) where {T, M <: AbstractMatrix{T}}  = Contingency{T, M}(P ./ sum(P))
+Contingency(P::M, renormalize::Val{false}) where {T, M <: AbstractMatrix{T}} = Contingency{T, M}(P)
 
 contingency_matrix(distribution::Contingency) = distribution.p
 

--- a/src/distributions/contingency.jl
+++ b/src/distributions/contingency.jl
@@ -24,11 +24,11 @@ A `Contingency` distribution over more than two variables requires higher-order 
 """
 struct Contingency{T, P <: AbstractMatrix{T}} <: ContinuousMatrixDistribution
     p::P
+
+    Contingency{T, P}(A::AbstractMatrix) where { T, P <: AbstractMatrix{T} } = new(A)
 end
 
-# Renormalize by default
-Contingency(P::AbstractMatrix) = Contingency(P, Val(true))
-
+Contingency(P::AbstractMatrix)                                               = Contingency(P, Val(true))
 Contingency(P::M, renormalize::Val{true}) where {T, M <: AbstractMatrix{T}}  = Contingency{T, M}(P ./ sum(P))
 Contingency(P::M, renormalize::Val{false}) where {T, M <: AbstractMatrix{T}} = Contingency{T, M}(P)
 

--- a/src/distributions/contingency.jl
+++ b/src/distributions/contingency.jl
@@ -25,7 +25,7 @@ A `Contingency` distribution over more than two variables requires higher-order 
 struct Contingency{T, P <: AbstractMatrix{T}} <: ContinuousMatrixDistribution
     p::P
 
-    Contingency{T, P}(A::AbstractMatrix) where { T, P <: AbstractMatrix{T} } = new(A)
+    Contingency{T, P}(A::AbstractMatrix) where {T, P <: AbstractMatrix{T}} = new(A)
 end
 
 Contingency(P::AbstractMatrix)                                               = Contingency(P, Val(true))

--- a/src/distributions/contingency.jl
+++ b/src/distributions/contingency.jl
@@ -2,9 +2,35 @@ export Contingency
 
 using LinearAlgebra
 
+"""
+    Contingency(P, renormalize = Val(true))
+
+The contingency distribution is a multivariate generalization of the categorical distribution. As a bivariate distribution, the 
+contingency distribution defines the joint probability over two unit vectors `v1` and `v2`. The parameter `P` encodes a contingency matrix that specifies the probability of co-occurrence.
+
+    v1 ∈ {0, 1}^d1 where Σ_j v1_j = 1
+    v2 ∈ {0, 1}^d2 where Σ_k v2_k = 1
+
+    P ∈ [0, 1]^{d1 × d2}, where Σ_jk P_jk = 1
+
+    f(v1, v2, P) = Contingency(out1, out2 | P) = Π_jk P_jk^{v1_j * v2_k}
+
+A `Contingency` distribution over more than two variables requires higher-order tensors as parameters; these are not implemented in ReactiveMP.
+
+# Arguments:
+- `P`, required, contingency matrix
+- `renormalize`, optional, supports either `Val(true)` or `Val(false)`, specifies whether matrix `P` must be automatically renormalized. Does not modify the original `P` and allocates a new one for the renormalized version. If set to `false` the contingency matrix `P` **must** be normalized by hand, otherwise the result of related calculations might be wrong
+
+"""
 struct Contingency{T, P <: AbstractMatrix{T}} <: ContinuousMatrixDistribution
     p::P
 end
+
+# Renormalize by default
+Contingency(P::AbstractMatrix) = Contingency(P, Val(true))
+
+Contingency(P::M, renormalize::Val{true}) where { T, M <: AbstractMatrix{T} }  = Contingency{T, M}(P ./ sum(P))
+Contingency(P::M, renormalize::Val{false}) where { T, M <: AbstractMatrix{T} } = Contingency{T, M}(P)
 
 contingency_matrix(distribution::Contingency) = distribution.p
 

--- a/test/distributions/test_contingency.jl
+++ b/test/distributions/test_contingency.jl
@@ -16,8 +16,12 @@ using Random
     end
 
     @testset "contingency_matrix" begin
-        @test ReactiveMP.contingency_matrix(Contingency(ones(3, 3))) == ones(3, 3)
-        @test ReactiveMP.contingency_matrix(Contingency(ones(4, 4))) == ones(4, 4)
+        @test ReactiveMP.contingency_matrix(Contingency(ones(3, 3))) == ones(3, 3) ./ 9
+        @test ReactiveMP.contingency_matrix(Contingency(ones(3, 3), Val(true))) == ones(3, 3) ./ 9
+        @test ReactiveMP.contingency_matrix(Contingency(ones(3, 3), Val(false))) == ones(3, 3) # Matrix is wrong, but just to test that `false` is working
+        @test ReactiveMP.contingency_matrix(Contingency(ones(4, 4))) == ones(4, 4) ./ 16
+        @test ReactiveMP.contingency_matrix(Contingency(ones(4, 4), Val(true))) == ones(4, 4) ./ 16
+        @test ReactiveMP.contingency_matrix(Contingency(ones(4, 4), Val(false))) == ones(4, 4)
     end
 
     @testset "vague" begin
@@ -35,9 +39,12 @@ using Random
     end
 
     @testset "entropy" begin
-        @test entropy(Contingency([0.1 0.9; 0.9 0.1])) ≈ 0.6501659467828964
-        @test entropy(Contingency([0.2 0.8; 0.8 0.2])) ≈ 1.0008048470763757
-        @test entropy(Contingency([0.45 0.75; 0.55 0.25])) ≈ 1.2504739583323967
+        @test entropy(Contingency([0.7 0.1; 0.1 0.1])) ≈ 0.9404479886553263
+        @test entropy(Contingency(10.0 * [0.7 0.1; 0.1 0.1])) ≈ 0.9404479886553263
+        @test entropy(Contingency([0.07 0.41; 0.31 0.21])) ≈ 1.242506182893139
+        @test entropy(Contingency(10.0 * [0.07 0.41; 0.31 0.21])) ≈ 1.242506182893139
+        @test entropy(Contingency([0.09 0.00; 0.00 0.91])) ≈ 0.30253782309749805
+        @test entropy(Contingency(10.0 * [0.09 0.00; 0.00 0.91])) ≈ 0.30253782309749805
     end
 end
 


### PR DESCRIPTION
This PR adds documentation for the `Contingency` distribution (cp from ForneyLab) and adds an optional `renormalize` argument. By default `Contingency` renormalizes its input, but it is possible to normalize input matrix by hand and pass `Val(false)` to disable automatic renormalization (this potentially saves some allocations :grin:)