### PR TITLE
fix preoptimised factorisation constraint rules for nodes with 2 inputs

### DIFF
--- a/src/constraints/spec/factorisation_spec.jl
+++ b/src/constraints/spec/factorisation_spec.jl
@@ -201,7 +201,7 @@ resolve_factorisation(::UnspecifiedConstraints, any, model, fform, variables) = 
 resolve_factorisation(::UnspecifiedConstraints, ::Deterministic, model, fform, variables) = FullFactorisation()
 
 # Preoptimised dispatch rules for unspecified constraints and a stochastic node with 2 inputs
-resolve_factorisation(::UnspecifiedConstraints, ::Stochastic, model, fform, ::Tuple{V1, V2}) where {V1 <: RandomVariable, V2 <: RandomVariable}                         = ((1, 2))
+resolve_factorisation(::UnspecifiedConstraints, ::Stochastic, model, fform, ::Tuple{V1, V2}) where {V1 <: RandomVariable, V2 <: RandomVariable}                         = ((1, 2),)
 resolve_factorisation(::UnspecifiedConstraints, ::Stochastic, model, fform, ::Tuple{V1, V2}) where {V1 <: Union{<:ConstVariable, <:DataVariable}, V2 <: RandomVariable} = ((1,), (2,))
 resolve_factorisation(::UnspecifiedConstraints, ::Stochastic, model, fform, ::Tuple{V1, V2}) where {V1 <: RandomVariable, V2 <: Union{<:ConstVariable, <:DataVariable}} = ((1,), (2,))
 

--- a/test/constraints/spec/test_factorisation_spec.jl
+++ b/test/constraints/spec/test_factorisation_spec.jl
@@ -8,7 +8,7 @@ import ReactiveMP: FunctionalIndex
 import ReactiveMP: CombinedRange, SplittedRange, is_splitted
 import ReactiveMP: __as_unit_range, __factorisation_specification_resolve_index
 import ReactiveMP: resolve_factorisation
-import ReactiveMP: DefaultConstraints
+import ReactiveMP: DefaultConstraints, UnspecifiedConstraints
 import ReactiveMP: setanonymous!, activate!
 
 using GraphPPL # for `@constraints` macro
@@ -579,7 +579,8 @@ using GraphPPL # for `@constraints` macro
                 # empty
             end
 
-            for cs in (empty, DefaultConstraints)
+            # DefaultConstraints are equal to `UnspecifiedConstraints()` for now, but it might change in the future so we test both
+            for cs in (empty, UnspecifiedConstraints(), DefaultConstraints)
                 let model = FactorGraphModel()
                     d = datavar(model, :d, Float64)
                     c = constvar(model, :c, 1.0)
@@ -587,6 +588,8 @@ using GraphPPL # for `@constraints` macro
                     y = randomvar(model, :y)
                     z = randomvar(model, :z)
 
+                    @test ReactiveMP.resolve_factorisation(cs, model, fform, (x, y)) === ((1, 2),)
+                    @test ReactiveMP.resolve_factorisation(cs, model, fform, (y, x)) === ((1, 2),)
                     @test ReactiveMP.resolve_factorisation(cs, model, fform, (d, d)) === ((1,), (2,))
                     @test ReactiveMP.resolve_factorisation(cs, model, fform, (c, c)) === ((1,), (2,))
                     @test ReactiveMP.resolve_factorisation(cs, model, fform, (d, x)) === ((1,), (2,))


### PR DESCRIPTION
This PR fixes and adds extra tests for preoptimised dispatch rules for unspecified constraints and a stochastic node with 2 inputs.

Details for triggering the bug:
- Node must be stochastic
- Node must have 1 input and 1 output
- Both interfaces must connect to random variables
- There must be no constraints specified (even empty)