### PR TITLE
Add error for incompatible number of arguments in the model spec

### DIFF
--- a/src/node.jl
+++ b/src/node.jl
@@ -1008,8 +1008,10 @@ function make_node(fform, options::FactorNodeCreationOptions, args::Vararg{<:Abs
 end
 
 # This error message should be displayed if a node receives an incompatible number of arguments
-function make_node_incompatible_number_of_arguments_error(fuppertype, fbottomtype, interfaces_list, args) 
-    error("`$(fbottomtype)` expects $(length(interfaces_list)) arguments, but $(length(args)) were given. Double check the `$(indexed_name(args[1])) ~ $(fbottomtype)($(join(map(indexed_name, args[begin+1:end]), ", ")))` expression.")
+function make_node_incompatible_number_of_arguments_error(fuppertype, fbottomtype, interfaces_list, args)
+    error(
+        "`$(fbottomtype)` expects $(length(interfaces_list) - 1) arguments, but $(length(args) - 1) were given. Double check the `$(indexed_name(args[1])) ~ $(fbottomtype)($(join(map(indexed_name, args[begin+1:end]), ", ")))` expression."
+    )
 end
 # end
 
@@ -1187,7 +1189,11 @@ macro node(fformtype, sdtype, interfaces_list)
         end
 
         # Fallback method for unsupported number of arguments, e.g. if node expects 2 inputs, but only 1 was given
-        function ReactiveMP.make_node(::$fuppertype, options::FactorNodeCreationOptions, args::Vararg{<:AbstractVariable})
+        function ReactiveMP.make_node(
+            ::$fuppertype,
+            options::FactorNodeCreationOptions,
+            args::Vararg{<:AbstractVariable}
+        )
             ReactiveMP.make_node_incompatible_number_of_arguments_error($fuppertype, $fbottomtype, $interfaces, args)
         end
 

--- a/src/node.jl
+++ b/src/node.jl
@@ -1007,6 +1007,10 @@ function make_node(fform, options::FactorNodeCreationOptions, args::Vararg{<:Abs
     )
 end
 
+# This error message should be displayed if a node receives an incompatible number of arguments
+function make_node_incompatible_number_of_arguments_error(fuppertype, fbottomtype, interfaces_list, args) 
+    error("`$(fbottomtype)` expects $(length(interfaces_list)) arguments, but $(length(args)) were given. Double check the `$(indexed_name(args[1])) ~ $(fbottomtype)($(join(map(indexed_name, args[begin+1:end]), ", ")))` expression.")
+end
 # end
 
 ## macro helpers
@@ -1180,6 +1184,11 @@ macro node(fformtype, sdtype, interfaces_list)
             $(interface_uniqueness...)
             $(interface_connections...)
             return node
+        end
+
+        # Fallback method for unsupported number of arguments, e.g. if node expects 2 inputs, but only 1 was given
+        function ReactiveMP.make_node(::$fuppertype, options::FactorNodeCreationOptions, args::Vararg{<:AbstractVariable})
+            ReactiveMP.make_node_incompatible_number_of_arguments_error($fuppertype, $fbottomtype, $interfaces, args)
         end
 
         $(interface_name_getters...)


### PR DESCRIPTION
This PR adds new diagnostical error message in case if user made a mistake in a model specification and passed an incompatible number of arguments to some node.

```julia
struct Accept2Arguments end

@node Accept2Arguments Stochastic [ out, in1, in2 ]

@model function mymodel()
    a ~ NormalMeanVariance(0.0, 1.0)
    b ~ NormalMeanVariance(0.0, 1.0)
    c ~ NormalMeanVariance(0.0, 1.0)

    d = datavar(Float64)
    d ~ Accept2Arguments(a, b, c) # <- Before this PR the error message was uninformative
end
