### PR TITLE
Fix factorisation constraints for anonymous random variables from deterministic functions 

### DIFF
--- a/src/constraints/spec/factorisation_spec.jl
+++ b/src/constraints/spec/factorisation_spec.jl
@@ -221,7 +221,19 @@ This function resolves factorisation constraints in a form of a tuple for a give
 
 See also: [`ConstraintsSpecification`](@ref)
 """
+function resolve_factorisation end
+
 function resolve_factorisation(constraints, model, fform, _variables)
+    return resolve_factorisation(sdtype(fform), constraints, model, fform, _variables)
+end
+
+# Deterministic nodes always have `FullFactorisation` constraint (by default)
+function resolve_factorisation(::Deterministic, constraints, model, fform, _variables)
+    return FullFactorisation()
+end
+
+# Stochastic nodes may have different factorisation constraints
+function resolve_factorisation(::Stochastic, constraints, model, fform, _variables)
     # Input `_variables` may include 'tupled' variables in it (e.g. in NormalMixture node)
     # Before doing any computations we flatten the input and perform all computations in flatten space
     # The output of the `resolve_factorisation` is flattened too

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -151,12 +151,13 @@ This function is a part of private API and should not be used explicitly.
 """
 function resolve_variable_proxy end
 
-resolve_variable_proxy(var::AbstractVariable) =
+function resolve_variable_proxy(var::AbstractVariable)
     if !isanonymous(var)
-        resolve_variable_proxy(var, VariableReferenceProxyChecked(), nothing)
+        return resolve_variable_proxy(var, VariableReferenceProxyChecked(), nothing)
     else
-        resolve_variable_proxy(var, VariableReferenceProxyUnchecked(), proxy_variables(var))
+        return resolve_variable_proxy(var, VariableReferenceProxyUnchecked(), proxy_variables(var))
     end
+end
 
 resolve_variable_proxy(
     var::AbstractVariable,

--- a/test/constraints/spec/test_factorisation_spec.jl
+++ b/test/constraints/spec/test_factorisation_spec.jl
@@ -644,6 +644,30 @@ using GraphPPL # for `@constraints` macro
             @test ReactiveMP.resolve_factorisation(cs2, model, fform, ((x, y), z)) === ((1,), (2, 3))
         end
 
+        @testset "Use case #17" begin 
+            # Deterministic node must ignore multiple proxy vars 
+            model = FactorGraphModel()
+
+            x = randomvar(model, :x)
+            y = randomvar(model, :y)
+
+            # `z` is anonymous var composed of `x` and `y`
+            z = randomvar(model, ReactiveMP.randomvar_options_set_proxy_variables((x, y)), :z)
+            ReactiveMP.setanonymous!(z, true)
+            
+            d = randomvar(model, :d)
+
+            cs = @constraints begin 
+                q(d, x) = q(d)q(x)
+            end
+
+            # Remove this `@test_throws` when this feature is implemented, currently we throw an error
+            # But it would be nice to support this case too
+            @test_throws ErrorException ReactiveMP.resolve_factorisation(cs, model, TestFactorisationStochastic, (d, z)) 
+            # Deterministic node should ignore `resolve_factorisation` and multiple proxy vars
+            @test ReactiveMP.resolve_factorisation(cs, model, TestFactorisationDeterministic, (d, z)) == FullFactorisation()
+        end
+
         ## Warning testing below
 
         # Variable does not exist
@@ -803,7 +827,7 @@ using GraphPPL # for `@constraints` macro
                 q(x, y) = q(x)q(y)
             end
 
-            @test_throws ErrorException ReactiveMP.resolve_factorisation(cs, model, :Normal, (x, y))
+            @test_throws ErrorException ReactiveMP.resolve_factorisation(cs, model, fform, (x, y))
         end
     end
 end

--- a/test/constraints/spec/test_factorisation_spec.jl
+++ b/test/constraints/spec/test_factorisation_spec.jl
@@ -644,7 +644,7 @@ using GraphPPL # for `@constraints` macro
             @test ReactiveMP.resolve_factorisation(cs2, model, fform, ((x, y), z)) === ((1,), (2, 3))
         end
 
-        @testset "Use case #17" begin 
+        @testset "Use case #17" begin
             # Deterministic node must ignore multiple proxy vars 
             model = FactorGraphModel()
 
@@ -654,18 +654,19 @@ using GraphPPL # for `@constraints` macro
             # `z` is anonymous var composed of `x` and `y`
             z = randomvar(model, ReactiveMP.randomvar_options_set_proxy_variables((x, y)), :z)
             ReactiveMP.setanonymous!(z, true)
-            
+
             d = randomvar(model, :d)
 
-            cs = @constraints begin 
+            cs = @constraints begin
                 q(d, x) = q(d)q(x)
             end
 
             # Remove this `@test_throws` when this feature is implemented, currently we throw an error
             # But it would be nice to support this case too
-            @test_throws ErrorException ReactiveMP.resolve_factorisation(cs, model, TestFactorisationStochastic, (d, z)) 
+            @test_throws ErrorException ReactiveMP.resolve_factorisation(cs, model, TestFactorisationStochastic, (d, z))
             # Deterministic node should ignore `resolve_factorisation` and multiple proxy vars
-            @test ReactiveMP.resolve_factorisation(cs, model, TestFactorisationDeterministic, (d, z)) == FullFactorisation()
+            @test ReactiveMP.resolve_factorisation(cs, model, TestFactorisationDeterministic, (d, z)) ==
+                  FullFactorisation()
         end
 
         ## Warning testing below


### PR DESCRIPTION
This PR fixes a case when factorisation constraints resolution engine failed in case if model had anonymous random variables created from deterministic node. This PR also must improve performance a bit as previously factorisation constraints ran for deterministic nodes but the result was ignored. I didn't benchmark it though. In the fixed version we short-circuit on deterministic nodes and skip the computation of local factorisations.