### PR TITLE
Fix mv-precision inference with known mean

### DIFF
--- a/src/rules/mv_normal_mean_precision/precision.jl
+++ b/src/rules/mv_normal_mean_precision/precision.jl
@@ -5,10 +5,10 @@
     m_out, v_out   = mean_cov(q_out)
     m_mean, v_mean = mean_cov(q_μ)
 
-    df = ndims(q_μ) + 2
-    S  = cholinv(v_mean + v_out + (m_mean - m_out) * (m_mean - m_out)')
+    df   = ndims(q_μ) + 2
+    invS = v_mean + v_out + (m_mean - m_out) * (m_mean - m_out)'
 
-    return WishartMessage(df, S)
+    return WishartMessage(df, invS)
 end
 
 @rule MvNormalMeanPrecision(:Λ, Marginalisation) (q_out_μ::Any,) = begin
@@ -18,7 +18,7 @@ end
 
     mdiff = @views m_out_μ[1:d] - m_out_μ[d+1:end]
     vdiff = @views v_out_μ[1:d, 1:d] - v_out_μ[1:d, d+1:end] - v_out_μ[d+1:end, 1:d] + v_out_μ[d+1:end, d+1:end]
-    S     = cholinv(vdiff + mdiff * mdiff')
+    invS  = vdiff + mdiff * mdiff'
 
-    return WishartMessage(d + 2, S)
+    return WishartMessage(d + 2, invS)
 end

--- a/src/rules/normal_mixture/p.jl
+++ b/src/rules/normal_mixture/p.jl
@@ -19,6 +19,6 @@ export rule
         d                  = length(m_mean_k)
         return WishartMessage(
             one(eltype(z_bar)) + z_bar[k] + d,
-            cholinv(z_bar[k] * (v_out + v_mean_k + (m_out - m_mean_k) * (m_out - m_mean_k)'))
+            z_bar[k] * (v_out + v_mean_k + (m_out - m_mean_k) * (m_out - m_mean_k)')
         )
     end

--- a/src/rules/wishart/marginals.jl
+++ b/src/rules/wishart/marginals.jl
@@ -1,6 +1,6 @@
 export marginalrule
 
 @marginalrule Wishart(:out_ν_S) (m_out::WishartDistributionsFamily, m_ν::PointMass, m_S::PointMass) = begin
-    q_out = prod(ProdAnalytical(), WishartMessage(mean(m_ν), mean(m_S)), m_out)
+    q_out = prod(ProdAnalytical(), WishartMessage(mean(m_ν), cholinv(mean(m_S))), m_out)
     return (out = convert(Wishart, q_out), ν = m_ν, S = m_S)
 end

--- a/src/rules/wishart/out.jl
+++ b/src/rules/wishart/out.jl
@@ -1,10 +1,10 @@
 
 # Belief Propagation                #
 # --------------------------------- #
-@rule Wishart(:out, Marginalisation) (m_ν::PointMass, m_S::PointMass) = WishartMessage(mean(m_ν), mean(m_S))
+@rule Wishart(:out, Marginalisation) (m_ν::PointMass, m_S::PointMass) = WishartMessage(mean(m_ν), cholinv(mean(m_S)))
 
 # Variational                       # 
 # --------------------------------- #
-@rule Wishart(:out, Marginalisation) (q_ν::Any, m_S::PointMass) = WishartMessage(mean(q_ν), mean(m_S))
-@rule Wishart(:out, Marginalisation) (m_ν::PointMass, q_S::Any) = WishartMessage(mean(m_ν), mean(q_S))
-@rule Wishart(:out, Marginalisation) (q_ν::Any, q_S::Any)       = WishartMessage(mean(q_ν), mean(q_S))
+@rule Wishart(:out, Marginalisation) (q_ν::Any, m_S::PointMass) = WishartMessage(mean(q_ν), cholinv(mean(m_S)))
+@rule Wishart(:out, Marginalisation) (m_ν::PointMass, q_S::Any) = WishartMessage(mean(m_ν), cholinv(mean(q_S)))
+@rule Wishart(:out, Marginalisation) (q_ν::Any, q_S::Any)       = WishartMessage(mean(q_ν), cholinv(mean(q_S)))

--- a/test/distributions/test_sample_list.jl
+++ b/test/distributions/test_sample_list.jl
@@ -400,7 +400,7 @@ import ReactiveMP: WishartMessage
         (x = NormalMeanVariance(3.0, 7.0), y = NormalWeightedMeanPrecision(4.0, 6.0), mean_tol = [1e-1, 1e-1, 1e-1], cov_tol = [1e-1, 1e-1, 1e-1], entropy_tol = [1e-1, 1e-1, 1e-1]),
         (x = GammaShapeRate(3.0, 7.0), y = GammaShapeScale(4.0, 6.0), mean_tol = [1e-1, 1e-1, 1e-1], cov_tol = [1e-1, 1e-1, 1e-1], entropy_tol = [3e-1, 3e-1, 3e-1]),
         (x = MvNormalMeanCovariance(10rand(rng, 4), posdefm(rng, 4)), y = MvNormalMeanPrecision(10rand(rng, 4), posdefm(rng, 4)), mean_tol = [2e-1, 2e-1, 2e-1], cov_tol = [6e-1, 6e-1, 6e-1], entropy_tol = [4e-1, 4e-1, 4e-1]),
-        (x = WishartMessage(10.0, posdefm(rng, 3)), y = WishartMessage(5.0, posdefm(rng, 3)), mean_tol = [7e-1, 7e-1, 7e-1], cov_tol = [5e-1, 5e-1, 5e-1], entropy_tol = [2e-1, 2e-1, 2e-1])
+        (x = WishartMessage(10.0, cholinv(posdefm(rng, 3))), y = WishartMessage(5.0, cholinv(posdefm(rng, 3))), mean_tol = [7e-1, 7e-1, 7e-1], cov_tol = [5e-1, 5e-1, 5e-1], entropy_tol = [2e-1, 2e-1, 2e-1])
 ]
 
         for (i, N) in enumerate(sizes)

--- a/test/distributions/test_wishart.jl
+++ b/test/distributions/test_wishart.jl
@@ -38,16 +38,19 @@ import ReactiveMP: WishartMessage
     end
 
     @testset "prod" begin
-        v1 = [9.0 -3.4; -3.4 11.0]
-        v2 = [10.2 -3.3; -3.3 5.0]
-        v3 = [8.1 -2.7; -2.7 9.0]
+        inv_v1 = cholinv([9.0 -3.4; -3.4 11.0])
+        inv_v2 = cholinv([10.2 -3.3; -3.3 5.0])
+        inv_v3 = cholinv([8.1 -2.7; -2.7 9.0])
 
-        @test prod(ProdAnalytical(), WishartMessage(3, v1), WishartMessage(3, v2)) ≈
-              WishartMessage(3, [4.776325721474591 -1.6199382410125422; -1.6199382410125422 3.3487476649765537])
-        @test prod(ProdAnalytical(), WishartMessage(4, v1), WishartMessage(4, v3)) ≈
-              WishartMessage(5, [4.261143738311623 -1.5064864332819319; -1.5064864332819319 4.949867121624725])
-        @test prod(ProdAnalytical(), WishartMessage(5, v2), WishartMessage(4, v3)) ≈
-              WishartMessage(6, [4.51459128065395 -1.4750681198910067; -1.4750681198910067 3.129155313351499])
+        @test prod(ProdAnalytical(), WishartMessage(3, inv_v1), WishartMessage(3, inv_v2)) ≈
+              WishartMessage(
+            3,
+            cholinv([4.776325721474591 -1.6199382410125422; -1.6199382410125422 3.3487476649765537])
+        )
+        @test prod(ProdAnalytical(), WishartMessage(4, inv_v1), WishartMessage(4, inv_v3)) ≈
+              WishartMessage(5, cholinv([4.261143738311623 -1.5064864332819319; -1.5064864332819319 4.949867121624725]))
+        @test prod(ProdAnalytical(), WishartMessage(5, inv_v2), WishartMessage(4, inv_v3)) ≈
+              WishartMessage(6, cholinv([4.51459128065395 -1.4750681198910067; -1.4750681198910067 3.129155313351499]))
     end
 
     @testset "ndims" begin

--- a/test/models/test_mv_iid.jl
+++ b/test/models/test_mv_iid.jl
@@ -97,6 +97,7 @@ function inference_mv_wishart_known_mean(mean, data, n, d)
         model = Model(mv_iid_wishart_known_mean, mean, n, d),
         data = (y = data,),
         iterations = 10,
+        returnvars = KeepLast(),
         free_energy = Float64
     )
 end
@@ -106,6 +107,7 @@ function inference_mv_inverse_wishart_known_mean(mean, data, n, d)
         model = Model(mv_iid_inverse_wishart_known_mean, mean, n, d),
         data = (y = data,),
         iterations = 10,
+        returnvars = KeepLast(),
         free_energy = Float64
     )
 end

--- a/test/models/test_mv_iid.jl
+++ b/test/models/test_mv_iid.jl
@@ -22,7 +22,7 @@ end
 @constraints function constraints_mv_iid_wishart()
     q(m, P) = q(m)q(P)
 end
-
+## -------------------------------------------- ##
 @model function mv_iid_inverse_wishart(n, d)
     m ~ MvNormalMeanPrecision(zeros(d), 100 * diageye(d))
     C ~ InverseWishart(d + 1, diageye(d))
@@ -37,18 +37,38 @@ end
 @constraints function constraints_mv_iid_inverse_wishart()
     q(m, C) = q(m)q(C)
 end
+## -------------------------------------------- ##
+@model function mv_iid_wishart_known_mean(mean, n, d)
+    P ~ Wishart(d + 1, diageye(d))
 
+    m = constvar(mean)
+    y = datavar(Vector{Float64}, n)
+
+    for i in 1:n
+        y[i] ~ MvNormalMeanPrecision(m, P)
+    end
+end
+## -------------------------------------------- ##
+@model function mv_iid_inverse_wishart_known_mean(mean, n, d)
+    C ~ InverseWishart(d + 1, diageye(d))
+
+    m = constvar(mean)
+    y = datavar(Vector{Float64}, n)
+
+    for i in 1:n
+        y[i] ~ MvNormalMeanCovariance(m, C)
+    end
+end
 ## -------------------------------------------- ##
 ## Inference definition
 ## -------------------------------------------- ##
-
 function inference_mv_wishart(data, n, d)
     return inference(
         model = Model(mv_iid_wishart, n, d),
         data = (y = data,),
         constraints = constraints_mv_iid_wishart(),
         initmarginals = (
-            m = vague(MvNormalMeanPrecision, d),
+            m = vague(MvNormalMeanCovariance, d),
             P = vague(Wishart, d)
         ),
         returnvars = KeepLast(),
@@ -56,7 +76,7 @@ function inference_mv_wishart(data, n, d)
         free_energy = Float64
     )
 end
-
+## -------------------------------------------- ##
 function inference_mv_inverse_wishart(data, n, d)
     return inference(
         model = Model(mv_iid_inverse_wishart, n, d),
@@ -71,6 +91,25 @@ function inference_mv_inverse_wishart(data, n, d)
         free_energy = Float64
     )
 end
+## -------------------------------------------- ##
+function inference_mv_wishart_known_mean(mean, data, n, d)
+    return inference(
+        model = Model(mv_iid_wishart_known_mean, mean, n, d),
+        data = (y = data,),
+        iterations = 10,
+        free_energy = Float64
+    )
+end
+## -------------------------------------------- ##
+function inference_mv_inverse_wishart_known_mean(mean, data, n, d)
+    return inference(
+        model = Model(mv_iid_inverse_wishart_known_mean, mean, n, d),
+        data = (y = data,),
+        iterations = 10,
+        free_energy = Float64
+    )
+end
+## -------------------------------------------- ##
 
 @testset "Multivariate IID" begin
     @testset "Use case #1: Precision parametrisation" begin
@@ -90,12 +129,17 @@ end
         data = rand(rng, MvNormalMeanPrecision(m, P), n) |> eachcol |> collect .|> collect
         ## -------------------------------------------- ##
         ## Inference execution
-        result = inference_mv_wishart(data, n, d)
+        result    = inference_mv_wishart(data, n, d)
+        result_km = inference_mv_wishart_known_mean(m, data, n, d)
         ## -------------------------------------------- ##
         ## Test inference results
         @test isapprox(mean(result.posteriors[:m]), m, atol = 0.05)
         @test isapprox(mean(result.posteriors[:P]), P, atol = 0.07)
         @test all(<(0), filter(e -> abs(e) > 1e-10, diff(result.free_energy)))
+
+        @test isapprox(mean(result_km.posteriors[:P]), P, atol = 0.07)
+        # Check that FE does not depend on iteration in the known mean cast
+        @test all(==(first(result_km.free_energy)), result_km.free_energy)
         ## -------------------------------------------- ##
         ## Form debug output
         base_output = joinpath(pwd(), "_output", "models")
@@ -147,12 +191,17 @@ end
         data = rand(rng, MvNormalMeanCovariance(m, C), n) |> eachcol |> collect .|> collect
         ## -------------------------------------------- ##
         ## Inference execution
-        result = inference_mv_inverse_wishart(data, n, d)
+        result    = inference_mv_inverse_wishart(data, n, d)
+        result_km = inference_mv_inverse_wishart_known_mean(m, data, n, d)
         ## -------------------------------------------- ##
         ## Test inference results
         @test isapprox(mean(result.posteriors[:m]), m, atol = 0.05)
         @test isapprox(mean(result.posteriors[:C]), C, atol = 0.15)
         @test all(<(0), filter(e -> abs(e) > 1e-10, diff(result.free_energy)))
+
+        @test isapprox(mean(result_km.posteriors[:C]), C, atol = 0.15)
+        # Check that FE does not depend on iteration in the known mean cast
+        @test all(==(first(result_km.free_energy)), result_km.free_energy)
         ## -------------------------------------------- ##
         ## Form debug output
         base_output = joinpath(pwd(), "_output", "models")

--- a/test/rules/mv_normal_mean_precision/test_precision.jl
+++ b/test/rules/mv_normal_mean_precision/test_precision.jl
@@ -11,49 +11,52 @@ import ReactiveMP: WishartMessage, @test_rules
         @test_rules [with_float_conversions = true, float32_atol = 1e-5] MvNormalMeanPrecision(:Λ, Marginalisation) [
             (
                 input = (q_out = PointMass([1.0, 2.0]), q_μ = MvNormalMeanPrecision([3.0, 5.0], [3.0 2.0; 2.0 4.0])),
-                output = WishartMessage(4.0, [75/73 -46/73; -46/73 36/73])
+                output = WishartMessage(4.0, cholinv([75/73 -46/73; -46/73 36/73]))
             ),
             (
                 input = (q_out = MvNormalMeanPrecision([1.0; 2.0], [3.0 2.0; 2.0 4.0]), q_μ = PointMass([3.0; 5.0])),
-                output = WishartMessage(4.0, [75/73 -46/73; -46/73 36/73])
+                output = WishartMessage(4.0, cholinv([75/73 -46/73; -46/73 36/73]))
             ),
             (
                 input = (
                     q_out = MvNormalMeanPrecision([1.0; 2.0], [3.0 2.0; 2.0 4.0]),
                     q_μ = MvNormalMeanPrecision([3.0; 5.0], [3.0 2.0; 2.0 4.0])
                 ),
-                output = WishartMessage(4.0, [39/74 -11/37; -11/37 10/37])
+                output = WishartMessage(4.0, cholinv([39/74 -11/37; -11/37 10/37]))
             ),
             (
                 input = (
                     q_out = MvNormalMeanPrecision([1.0; 2.0; 3.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0]),
                     q_μ = MvNormalMeanPrecision([3.0; 5.0; -2.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0])
                 ),
-                output = WishartMessage(5.0, [15/11 -3/22 5/11; -3/22 19/22 5/11; 5/11 5/11 16/33])
+                output = WishartMessage(5.0, cholinv([15/11 -3/22 5/11; -3/22 19/22 5/11; 5/11 5/11 16/33]))
             )
         ]
         @test_rules [with_float_conversions = true, float32_atol = 1e-5] MvNormalMeanPrecision(:Λ, Marginalisation) [
             (
                 input = (q_out = PointMass([1.0, 2.0]), q_μ = MvNormalMeanCovariance([3.0, 5.0], [3.0 2.0; 2.0 4.0])),
-                output = WishartMessage(4.0, [13/27 -8/27; -8/27 7/27])
+                output = WishartMessage(4.0, cholinv([13/27 -8/27; -8/27 7/27]))
             ),
             (
                 input = (q_out = MvNormalMeanCovariance([1.0; 2.0], [3.0 2.0; 2.0 4.0]), q_μ = PointMass([3.0; 5.0])),
-                output = WishartMessage(4.0, [13/27 -8/27; -8/27 7/27])
+                output = WishartMessage(4.0, cholinv([13/27 -8/27; -8/27 7/27]))
             ),
             (
                 input = (
                     q_out = MvNormalMeanCovariance([1.0; 2.0], [3.0 2.0; 2.0 4.0]),
                     q_μ = MvNormalMeanCovariance([3.0; 5.0], [3.0 2.0; 2.0 4.0])
                 ),
-                output = WishartMessage(4.0, [17/70 -1/7; -1/7 1/7])
+                output = WishartMessage(4.0, cholinv([17/70 -1/7; -1/7 1/7]))
             ),
             (
                 input = (
                     q_out = MvNormalMeanCovariance([1.0; 2.0; 3.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0]),
                     q_μ = MvNormalMeanCovariance([3.0; 5.0; -2.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0])
                 ),
-                output = WishartMessage(5.0, [51/338 -6/169 5/169; -6/169 115/676 45/676; 5/169 45/676 47/676])
+                output = WishartMessage(
+                    5.0,
+                    cholinv([51/338 -6/169 5/169; -6/169 115/676 45/676; 5/169 45/676 47/676])
+                )
             )
         ]
         @test_rules [with_float_conversions = true, float32_atol = 1e-5] MvNormalMeanPrecision(:Λ, Marginalisation) [
@@ -62,28 +65,31 @@ import ReactiveMP: WishartMessage, @test_rules
                     q_out = PointMass([1.0, 2.0]),
                     q_μ = MvNormalWeightedMeanPrecision([3.0, 5.0], [3.0 2.0; 2.0 4.0])
                 ),
-                output = WishartMessage(4.0, [73/67 -26/67; -26/67 68/67])
+                output = WishartMessage(4.0, cholinv([73/67 -26/67; -26/67 68/67]))
             ),
             (
                 input = (
                     q_out = MvNormalWeightedMeanPrecision([1.0; 2.0], [3.0 2.0; 2.0 4.0]),
                     q_μ = PointMass([3.0; 5.0])
                 ),
-                output = WishartMessage(4.0, [165/163 -106/163; -106/163 76/163])
+                output = WishartMessage(4.0, cholinv([165/163 -106/163; -106/163 76/163]))
             ),
             (
                 input = (
                     q_out = MvNormalWeightedMeanPrecision([1.0; 2.0], [3.0 2.0; 2.0 4.0]),
                     q_μ = MvNormalWeightedMeanPrecision([3.0; 5.0], [3.0 2.0; 2.0 4.0])
                 ),
-                output = WishartMessage(4.0, [73/70 11/35; 11/35 34/35])
+                output = WishartMessage(4.0, cholinv([73/70 11/35; 11/35 34/35]))
             ),
             (
                 input = (
                     q_out = MvNormalWeightedMeanPrecision([1.0; 2.0; 3.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0]),
                     q_μ = MvNormalWeightedMeanPrecision([3.0; 5.0; -2.0], [3.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 4.0])
                 ),
-                output = WishartMessage(5.0, [459/338 -36/169 60/169; -36/169 115/169 90/169; 60/169 90/169 188/169])
+                output = WishartMessage(
+                    5.0,
+                    cholinv([459/338 -36/169 60/169; -36/169 115/169 90/169; 60/169 90/169 188/169])
+                )
             )
         ]
     end
@@ -92,15 +98,15 @@ import ReactiveMP: WishartMessage, @test_rules
         @test_rules [with_float_conversions = true] MvNormalMeanPrecision(:Λ, Marginalisation) [
             (
                 input = (q_out_μ = MvNormalMeanCovariance(ones(4), diageye(4)),),
-                output = WishartMessage(4.0, [0.5 0.0; 0.0 0.5])
+                output = WishartMessage(4.0, cholinv([0.5 0.0; 0.0 0.5]))
             ),
             (
                 input = (q_out_μ = MvNormalMeanPrecision(ones(4), diageye(4)),),
-                output = WishartMessage(4.0, [0.5 0.0; 0.0 0.5])
+                output = WishartMessage(4.0, cholinv([0.5 0.0; 0.0 0.5]))
             ),
             (
                 input = (q_out_μ = MvNormalWeightedMeanPrecision(ones(4), diageye(4)),),
-                output = WishartMessage(4.0, [0.5 0.0; 0.0 0.5])
+                output = WishartMessage(4.0, cholinv([0.5 0.0; 0.0 0.5]))
             )
         ]
 
@@ -110,17 +116,17 @@ import ReactiveMP: WishartMessage, @test_rules
         @test_rules [with_float_conversions = true, float32_atol = 1e-5] MvNormalMeanPrecision(:Λ, Marginalisation) [
             (
                 input = (q_out_μ = MvNormalMeanCovariance(a, A),),
-                output = WishartMessage(4.0, [13/150 -2/75; -2/75 7/150])
+                output = WishartMessage(4.0, cholinv([13/150 -2/75; -2/75 7/150]))
             ),
             (
                 input = (q_out_μ = MvNormalMeanPrecision(a, A),),
-                output = WishartMessage(4.0, [3751/1966 -3653/3932; -3653/3932 30259/58980])
+                output = WishartMessage(4.0, cholinv([3751/1966 -3653/3932; -3653/3932 30259/58980]))
             ),
             (
                 input = (q_out_μ = MvNormalWeightedMeanPrecision(a, A),),
                 output = WishartMessage(
                     4.0,
-                    [139109613/68523766 -96827813/137047532; -96827813/137047532 62742851/68523766]
+                    cholinv([139109613/68523766 -96827813/137047532; -96827813/137047532 62742851/68523766])
                 )
             )
         ]

--- a/test/rules/wishart/test_marginals.jl
+++ b/test/rules/wishart/test_marginals.jl
@@ -12,7 +12,7 @@ import ReactiveMP: WishartMessage, @test_marginalrules
         @test_marginalrules [with_float_conversions = true, float32_atol = 1e-5] Wishart(:out_ν_S) [
             (
                 input = (
-                    m_out = WishartMessage(3.0, [3.0 -1.0; -1.0 4.0]),
+                    m_out = WishartMessage(3.0, cholinv([3.0 -1.0; -1.0 4.0])),
                     m_ν = PointMass(2.0),
                     m_S = PointMass([1.0 0.0; 0.0 1.0])
                 ),
@@ -24,7 +24,7 @@ import ReactiveMP: WishartMessage, @test_marginalrules
             ),
             (
                 input = (
-                    m_out = WishartMessage(7.0, [9.0 -2.0; -2.0 1.0]),
+                    m_out = WishartMessage(7.0, cholinv([9.0 -2.0; -2.0 1.0])),
                     m_ν = PointMass(4.0),
                     m_S = PointMass([4.0 -2.0; -2.0 4.0])
                 ),
@@ -36,7 +36,7 @@ import ReactiveMP: WishartMessage, @test_marginalrules
             ),
             (
                 input = (
-                    m_out = WishartMessage(4.0, [9.0 -2.0 1.0; -2.0 5.0 -2.0; 1.0 -2.0 11.0]),
+                    m_out = WishartMessage(4.0, cholinv([9.0 -2.0 1.0; -2.0 5.0 -2.0; 1.0 -2.0 11.0])),
                     m_ν = PointMass(3.0),
                     m_S = PointMass([11.0 -2.0 1.0; -2.0 5.0 -2.0; 1.0 -2.0 9.0])
                 ),

--- a/test/rules/wishart/test_out.jl
+++ b/test/rules/wishart/test_out.jl
@@ -12,15 +12,15 @@ import ReactiveMP: WishartMessage, @test_rules
         @test_rules [with_float_conversions = true] Wishart(:out, Marginalisation) [
             (
                 input = (m_ν = PointMass(2.0), m_S = PointMass([1.0 0.0; 0.0 1.0])),
-                output = WishartMessage(2.0, [1.0 0.0; 0.0 1.0])
+                output = WishartMessage(2.0, cholinv([1.0 0.0; 0.0 1.0]))
             ),
             (
                 input = (m_ν = PointMass(3.0), m_S = PointMass([10.0 -1.0; -1.0 3.0])),
-                output = WishartMessage(3.0, [10.0 -1.0; -1.0 3.0])
+                output = WishartMessage(3.0, cholinv([10.0 -1.0; -1.0 3.0]))
             ),
             (
                 input = (m_ν = PointMass(4.0), m_S = PointMass([1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])),
-                output = WishartMessage(4.0, [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])
+                output = WishartMessage(4.0, cholinv([1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0]))
             )
         ]
     end
@@ -29,15 +29,15 @@ import ReactiveMP: WishartMessage, @test_rules
         @test_rules [with_float_conversions = true] Wishart(:out, Marginalisation) [
             (
                 input = (m_ν = PointMass(2.0), q_S = PointMass([1.0 0.0; 0.0 1.0])),
-                output = WishartMessage(2.0, [1.0 0.0; 0.0 1.0])
+                output = WishartMessage(2.0, cholinv([1.0 0.0; 0.0 1.0]))
             ),
             (
                 input = (m_ν = PointMass(3.0), q_S = PointMass([10.0 -1.0; -1.0 3.0])),
-                output = WishartMessage(3.0, [10.0 -1.0; -1.0 3.0])
+                output = WishartMessage(3.0, cholinv([10.0 -1.0; -1.0 3.0]))
             ),
             (
                 input = (m_ν = PointMass(4.0), q_S = PointMass([1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])),
-                output = WishartMessage(4.0, [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])
+                output = WishartMessage(4.0, cholinv([1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0]))
             )
         ]
     end
@@ -46,15 +46,15 @@ import ReactiveMP: WishartMessage, @test_rules
         @test_rules [with_float_conversions = true] Wishart(:out, Marginalisation) [
             (
                 input = (q_ν = PointMass(2.0), m_S = PointMass([1.0 0.0; 0.0 1.0])),
-                output = WishartMessage(2.0, [1.0 0.0; 0.0 1.0])
+                output = WishartMessage(2.0, cholinv([1.0 0.0; 0.0 1.0]))
             ),
             (
                 input = (q_ν = PointMass(3.0), m_S = PointMass([10.0 -1.0; -1.0 3.0])),
-                output = WishartMessage(3.0, [10.0 -1.0; -1.0 3.0])
+                output = WishartMessage(3.0, cholinv([10.0 -1.0; -1.0 3.0]))
             ),
             (
                 input = (q_ν = PointMass(4.0), m_S = PointMass([1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])),
-                output = WishartMessage(4.0, [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])
+                output = WishartMessage(4.0, cholinv([1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0]))
             )
         ]
     end
@@ -63,15 +63,15 @@ import ReactiveMP: WishartMessage, @test_rules
         @test_rules [with_float_conversions = true] Wishart(:out, Marginalisation) [
             (
                 input = (q_ν = PointMass(2.0), q_S = PointMass([1.0 0.0; 0.0 1.0])),
-                output = WishartMessage(2.0, [1.0 0.0; 0.0 1.0])
+                output = WishartMessage(2.0, cholinv([1.0 0.0; 0.0 1.0]))
             ),
             (
                 input = (q_ν = PointMass(3.0), q_S = PointMass([10.0 -1.0; -1.0 3.0])),
-                output = WishartMessage(3.0, [10.0 -1.0; -1.0 3.0])
+                output = WishartMessage(3.0, cholinv([10.0 -1.0; -1.0 3.0]))
             ),
             (
                 input = (q_ν = PointMass(4.0), q_S = PointMass([1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])),
-                output = WishartMessage(4.0, [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])
+                output = WishartMessage(4.0, cholinv([1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0]))
             )
         ]
     end


### PR DESCRIPTION
This PR fixes #193 by changing `WishartMessage` to store an inverse of its scale-matrix. This avoids unnecessary matrix invertions and correctly handles inference of precision matrix when mean is known. This fix potentially makes inference a bit faster too (way less inversions), but I haven't done any benchmarks. From the user perspective nothing changed really. The only one downside of this PR is that it is no longer possible to create an improper `Wishart` prior (because ReactiveMP.jl internally converts `Wishart` prior to `WishartMessage` which does one invertion).