### PR TITLE
Update vague for InverseWishart

### DIFF
--- a/src/distributions/wishart_inverse.jl
+++ b/src/distributions/wishart_inverse.jl
@@ -63,7 +63,7 @@ function Distributions.mean(::typeof(inv), dist::InverseWishartDistributionsFami
     return mean(Wishart(ν, cholinv(S)))
 end
 
-vague(::Type{<:InverseWishart}, dims::Integer) = InverseWishart(dims, tiny .* diageye(dims))
+vague(::Type{<:InverseWishart}, dims::Integer) = InverseWishart(dims + 2, tiny .* diageye(dims))
 
 Base.ndims(dist::InverseWishart) = size(dist, 1)
 

--- a/test/distributions/test_wishart_inverse.jl
+++ b/test/distributions/test_wishart_inverse.jl
@@ -50,16 +50,21 @@ import ReactiveMP: InverseWishartMessage
 
         @test typeof(d1) <: InverseWishart
         ν1, S1 = params(d1)
-        @test ν1 == dims
+        @test ν1 == dims + 2
         @test S1 == tiny .* diageye(dims)
+
+        @test mean(d1) == S1
+
 
         dims = 4
         d2 = vague(InverseWishart, dims)
 
         @test typeof(d2) <: InverseWishart
         ν2, S2 = params(d2)
-        @test ν2 == dims
+        @test ν2 == dims + 2
         @test S2 == tiny .* diageye(dims)
+
+        @test mean(d2) == S2
     end
 
     @testset "entropy" begin

--- a/test/distributions/test_wishart_inverse.jl
+++ b/test/distributions/test_wishart_inverse.jl
@@ -55,7 +55,6 @@ import ReactiveMP: InverseWishartMessage
 
         @test mean(d1) == S1
 
-
         dims = 4
         d2 = vague(InverseWishart, dims)
 


### PR DESCRIPTION
This PR fixes #195 by redefining the `vague` function for the `InverseWishart` type.

The mean is defined only when `df > dim + 1`, where `df` is degrees of freedom, and `dim` is the dimensionality of the scale matrix. Hence, we do:

```julia
vague(::Type{<:InverseWishart}, dims::Integer) = InverseWishart(dims + 2, tiny .* diageye(dims))
```
