### PR TITLE
add Base.size method for pointmass

### DIFF
--- a/src/distributions/pointmass.jl
+++ b/src/distributions/pointmass.jl
@@ -1,7 +1,7 @@
 export PointMass, getpointmass
 
 import Distributions: mean, var, cov, std, insupport, pdf, logpdf, entropy
-import Base: ndims, precision, getindex, convert, isapprox, eltype
+import Base: ndims, precision, getindex, size, convert, isapprox, eltype
 import SpecialFunctions: loggamma, logbeta
 
 struct PointMass{P}
@@ -19,6 +19,7 @@ getpointmass(distribution::PointMass) = distribution.point
 ##
 
 Base.getindex(distribution::PointMass, index...) = Base.getindex(getpointmass(distribution), index...)
+Base.size(distribution::PointMass, index...) = Base.size(getpointmass(distribution), index...)
 
 Distributions.entropy(distribution::PointMass) = InfCountingReal(eltype(distribution), -1)
 

--- a/test/distributions/test_pointmass.jl
+++ b/test/distributions/test_pointmass.jl
@@ -118,6 +118,8 @@ import ReactiveMP: xtlog, mirrorlog
             @test dist[2] === matrix[2]
             @test dist[3] === matrix[3]
             @test dist[3, 3] === matrix[3, 3]
+            @test size(dist, 1) === size(matrix, 1)
+            @test size(dist, 2) === size(matrix, 2)
             @test_throws BoundsError dist[N^3]
             @test_throws BoundsError dist[N+1, N+1]
 


### PR DESCRIPTION
This PR adds `Base.size` method for the `PointMass` distribution