### PR TITLE
Fix interaction between `autovar` and variables in a form of a tuple 

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -466,8 +466,7 @@ function ReactiveMP.make_node(
     autovar::AutoVar,
     args::Vararg
 )
-
-    foreach(args) do arg 
+    foreach(args) do arg
         @assert (typeof(arg) <: AbstractVariable || eltype(arg) <: AbstractVariable) "`make_node` cannot create a node with the given arguments autovar = $(autovar), args = [ $(args...) ]"
     end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -464,8 +464,13 @@ function ReactiveMP.make_node(
     options::FactorNodeCreationOptions,
     fform,
     autovar::AutoVar,
-    args::Vararg{<:ReactiveMP.AbstractVariable}
+    args::Vararg
 )
+
+    foreach(args) do arg 
+        @assert (typeof(arg) <: AbstractVariable || eltype(arg) <: AbstractVariable) "`make_node` cannot create a node with the given arguments autovar = $(autovar), args = [ $(args...) ]"
+    end
+
     proxy     = isdeterministic(sdtype(fform)) ? args : nothing
     rvoptions = ReactiveMP.randomvar_options_set_proxy_variables(ReactiveMP.EmptyRandomVariableCreationOptions, proxy)
     var       = ReactiveMP.make_autovar(model, rvoptions, ReactiveMP.name(autovar), true) # add! is inside

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -7,6 +7,32 @@ using Random
 
 # TODO: move this tests to RxInfer.jl
 @testset "@model macro tests" begin
+
+    @testset "Tuple based variables usage #1" begin 
+
+        @model [ default_factorisation = MeanField() ] function mixture_model()
+            
+            mean1 ~ Normal(mean = 10, variance = 10000)
+            mean2 ~ Normal(mean = -10, variance = 10000)
+            prec1 ~ Gamma(shape = 1, rate = 1)
+            prec2 ~ Gamma(shape = 1, rate = 1)
+            
+            selector ~ Bernoulli(0.3)
+            mixture  ~ NormalMixture(selector, (mean1, mean2), (prec1, prec2))
+            
+            y = datavar(Float64)
+            y ~ Normal(mean = mixture, variance = 1.0)
+            
+        end
+
+        model, _ = mixture_model()
+
+        @test model[:selector] isa RandomVariable
+        @test model[:mixture] isa RandomVariable
+        @test length(getnodes(model)) === 7
+
+    end
+
     @testset "Broadcasting #1" begin
         @model function bsyntax1(n, broadcasting)
             m ~ NormalMeanPrecision(0.0, 1.0)

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -7,22 +7,18 @@ using Random
 
 # TODO: move this tests to RxInfer.jl
 @testset "@model macro tests" begin
-
-    @testset "Tuple based variables usage #1" begin 
-
-        @model [ default_factorisation = MeanField() ] function mixture_model()
-            
+    @testset "Tuple based variables usage #1" begin
+        @model [default_factorisation = MeanField()] function mixture_model()
             mean1 ~ Normal(mean = 10, variance = 10000)
             mean2 ~ Normal(mean = -10, variance = 10000)
             prec1 ~ Gamma(shape = 1, rate = 1)
             prec2 ~ Gamma(shape = 1, rate = 1)
-            
+
             selector ~ Bernoulli(0.3)
             mixture  ~ NormalMixture(selector, (mean1, mean2), (prec1, prec2))
-            
+
             y = datavar(Float64)
             y ~ Normal(mean = mixture, variance = 1.0)
-            
         end
 
         model, _ = mixture_model()
@@ -30,7 +26,6 @@ using Random
         @test model[:selector] isa RandomVariable
         @test model[:mixture] isa RandomVariable
         @test length(getnodes(model)) === 7
-
     end
 
     @testset "Broadcasting #1" begin


### PR DESCRIPTION
This PR fixes a bug when inference engine incorrectly attempted to create a node with an `AutoVar` object. Usually `AutoVar` object must be converted to either a new `RandomVariable` or reference an already existing variable. That didn't happen for the `tuple`-based variables, because of the incorrect type dispatch specification in the `make_node` function.