### PR TITLE
CVI stability fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -61,7 +61,6 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -69,6 +68,8 @@ PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestSetExtensions = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
 
 [targets]
-test = ["Test", "Pkg", "Logging", "InteractiveUtils", "TestSetExtensions", "Coverage", "Dates", "Distributed", "Documenter", "BenchmarkCI", "BenchmarkTools", "PkgBenchmark", "Aqua", "StableRNGs", "Flux", "Zygote"]
+test = ["Test", "Pkg", "Logging", "InteractiveUtils", "TestSetExtensions", "Coverage", "Dates", "Distributed", "Documenter", "BenchmarkCI", "BenchmarkTools", "PkgBenchmark", "Aqua", "StableRNGs", "Flux", "Zygote", "DiffResults"]

--- a/Project.toml
+++ b/Project.toml
@@ -47,8 +47,8 @@ SpecialFunctions = "1.4, 2"
 StaticArrays = "1.2"
 StatsBase = "0.33"
 StatsFuns = "0.9, 1"
-TupleTools = "1.2.0"
 TinyHugeNumbers = "1.0.0"
+TupleTools = "1.2.0"
 Unrolled = "0.1.3"
 julia = "1.6.0"
 
@@ -61,6 +61,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -70,4 +71,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestSetExtensions = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
 
 [targets]
-test = ["Test", "Pkg", "Logging", "InteractiveUtils", "TestSetExtensions", "Coverage", "Dates", "Distributed", "Documenter", "BenchmarkCI", "BenchmarkTools", "PkgBenchmark", "Aqua", "StableRNGs", "Flux"]
+test = ["Test", "Pkg", "Logging", "InteractiveUtils", "TestSetExtensions", "Coverage", "Dates", "Distributed", "Documenter", "BenchmarkCI", "BenchmarkTools", "PkgBenchmark", "Aqua", "StableRNGs", "Flux", "Zygote"]

--- a/src/ReactiveMP.jl
+++ b/src/ReactiveMP.jl
@@ -178,12 +178,12 @@ function __init__()
 
         struct ZygoteGrad end
 
-        function compute_grad(::ZygoteGrad, A::F, vec_params) where {F}
-            Zygote.gradient(A, vec_params)[1]
+        function compute_grad(::ZygoteGrad, f::F, vec_params) where {F}
+            Zygote.gradient(f, vec_params)[1]
         end
 
-        function compute_hessian(::ZygoteGrad, A::G, ::F, vec_params) where {G, F}
-            Zygote.hessian(A, vec_params)
+        function compute_hessian(::ZygoteGrad, f::F, vec_params) where {F}
+            Zygote.hessian(f, vec_params)
         end
 
         get_df_m(::ZygoteGrad, ::Type{<:UnivariateNormalNaturalParameters}, ::Type{<:UnivariateGaussianDistributionsFamily}, logp_nc::Function) =

--- a/src/ReactiveMP.jl
+++ b/src/ReactiveMP.jl
@@ -196,7 +196,7 @@ function __init__()
         function compute_df_mv(::CVI{R, O, ForwardDiffGrad}, logp::F, vec::Vector) where {R, O, F}
             result = DiffResults.HessianResult(vec)
             result = ForwardDiff.hessian!(result, logp, vec)
-            return (DiffResults.gradient(result), DiffResults.hessian(result))
+            return DiffResults.gradient(result), DiffResults.hessian(result) ./ 2
         end
 
     end

--- a/src/ReactiveMP.jl
+++ b/src/ReactiveMP.jl
@@ -172,6 +172,20 @@ function __init__()
             return Flux.Optimise.update!(opt, vec(λ), vec(∇))
         end
     end
+
+    @require Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f" begin
+        export ZygoteGrad
+
+        struct ZygoteGrad end
+
+        function compute_grad(::ZygoteGrad, A::F, vec_params) where {F}
+            Zygote.gradient(A, vec_params)[1]
+        end
+
+        function compute_hessian(::ZygoteGrad, A::G, ::F, vec_params) where {G, F}
+            Zygote.hessian(A, vec_params)
+        end
+    end
 end
 
 end

--- a/src/ReactiveMP.jl
+++ b/src/ReactiveMP.jl
@@ -185,6 +185,12 @@ function __init__()
         function compute_hessian(::ZygoteGrad, A::G, ::F, vec_params) where {G, F}
             Zygote.hessian(A, vec_params)
         end
+
+        get_df_m(::ZygoteGrad, ::Type{<:UnivariateNormalNaturalParameters}, ::Type{<:UnivariateGaussianDistributionsFamily}, logp_nc::Function) =
+            (z) -> Zygote.gradient(logp_nc, z)[1]
+
+        get_df_v(::ZygoteGrad, ::Type{<:UnivariateNormalNaturalParameters}, ::Type{<:UnivariateGaussianDistributionsFamily}, logp_nc::Function, df_m::Function) =
+            (z) -> Zygote.hessian(logp_nc, z)
     end
 end
 

--- a/src/ReactiveMP.jl
+++ b/src/ReactiveMP.jl
@@ -178,19 +178,17 @@ function __init__()
 
         struct ZygoteGrad end
 
-        function compute_grad(::ZygoteGrad, f::F, vec_params) where {F}
+        function compute_gradient(::ZygoteGrad, f::F, vec_params::Vector) where {F}
             Zygote.gradient(f, vec_params)[1]
         end
 
-        function compute_hessian(::ZygoteGrad, f::F, vec_params) where {F}
+        function compute_hessian(::ZygoteGrad, f::F, vec_params::Vector) where {F}
             Zygote.hessian(f, vec_params)
         end
 
-        get_df_m(::ZygoteGrad, ::Type{<:UnivariateNormalNaturalParameters}, ::Type{<:UnivariateGaussianDistributionsFamily}, logp_nc::Function) =
-            (z) -> Zygote.gradient(logp_nc, z)[1]
-
-        get_df_v(::ZygoteGrad, ::Type{<:UnivariateNormalNaturalParameters}, ::Type{<:UnivariateGaussianDistributionsFamily}, logp_nc::Function, df_m::Function) =
-            (z) -> Zygote.hessian(logp_nc, z)
+        function compute_derivative(::ZygoteGrad, f::F, value::Real) where {F}
+            Zygote.gradient(f, value)[1]
+        end
     end
 end
 

--- a/src/ReactiveMP.jl
+++ b/src/ReactiveMP.jl
@@ -178,21 +178,13 @@ function __init__()
 
         struct ZygoteGrad end
 
-        function compute_gradient(::ZygoteGrad, f::F, vec_params::Vector) where {F}
-            Zygote.gradient(f, vec_params)[1]
-        end
-
-        function compute_hessian(::ZygoteGrad, f::F, vec_params::Vector) where {F}
-            Zygote.hessian(f, vec_params)
-        end
-
-        function compute_derivative(::ZygoteGrad, f::F, value::Real) where {F}
-            Zygote.gradient(f, value)[1]
-        end
+        compute_gradient(::ZygoteGrad, f::F, vec::AbstractVector) where {F} = Zygote.gradient(f, vec)[1]
+        compute_hessian(::ZygoteGrad, f::F, vec::AbstractVector) where {F}  = Zygote.hessian(f, vec)
+        compute_derivative(::ZygoteGrad, f::F, value::Real) where {F}       = Zygote.gradient(f, value)[1]
     end
 
     @require DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5" begin
-        function compute_df_mv(::CVI{R, O, ForwardDiffGrad}, logp::F, vec::Vector) where {R, O, F}
+        function compute_df_mv(::CVI{R, O, ForwardDiffGrad}, logp::F, vec::AbstractVector) where {R, O, F}
             result = DiffResults.HessianResult(vec)
             result = ForwardDiff.hessian!(result, logp, vec)
             return DiffResults.gradient(result), DiffResults.hessian(result) ./ 2

--- a/src/ReactiveMP.jl
+++ b/src/ReactiveMP.jl
@@ -192,13 +192,11 @@ function __init__()
     end
 
     @require DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5" begin
-        
         function compute_df_mv(::CVI{R, O, ForwardDiffGrad}, logp::F, vec::Vector) where {R, O, F}
             result = DiffResults.HessianResult(vec)
             result = ForwardDiff.hessian!(result, logp, vec)
             return DiffResults.gradient(result), DiffResults.hessian(result) ./ 2
         end
-
     end
 end
 

--- a/src/ReactiveMP.jl
+++ b/src/ReactiveMP.jl
@@ -190,6 +190,16 @@ function __init__()
             Zygote.gradient(f, value)[1]
         end
     end
+
+    @require DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5" begin
+        
+        function compute_df_mv(::CVI{R, O, ForwardDiffGrad}, logp::F, vec::Vector) where {R, O, F}
+            result = DiffResults.HessianResult(vec)
+            result = ForwardDiff.hessian!(result, logp, vec)
+            return (DiffResults.gradient(result), DiffResults.hessian(result))
+        end
+
+    end
 end
 
 end

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -36,14 +36,14 @@ Arguments
     Run `using Zygote` in your Julia session to enable the `ZygoteGrad` option support for the CVI `grad` parameter.
 
 """
-struct ProdCVI{R, O, G} <: AbstractApproximationMethod
+struct ProdCVI{R, O, G, B} <: AbstractApproximationMethod
     rng::R
     n_samples::Int
     num_iterations::Int
     opt::O
     grad::G
     warn::Bool
-    enforce_proper_messages::Val
+    enforce_proper_messages::Val{B}
 end
 
 get_grad(approximation::ProdCVI) = approximation.grad

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -107,7 +107,7 @@ function render_cvi(approximation::CVIApproximation, logp_nc::F, initial) where 
         z_s = rand(rng, q_friendly)
 
         logq = (vec_params) -> logpdf(as_naturalparams(T, vec_params), z_s)
-        ∇logq = compute_grad(approximation.grad, logq, vec(λ))
+        ∇logq = compute_grad(get_grad(approximation), logq, vec(λ))
 
         fisher_matrix = Fisher(vec(λ))
         ∇f = cholinv(fisher_matrix) * (logp_nc(z_s) .* ∇logq)

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -73,12 +73,12 @@ const CVI = CVIApproximation
 
 struct ForwardDiffGrad end
 
-function compute_grad(::ForwardDiffGrad, A::F, vec_params) where {F}
-    ForwardDiff.gradient(A, vec_params)
+function compute_grad(::ForwardDiffGrad, f::F, vec_params) where {F}
+    ForwardDiff.gradient(f, vec_params)
 end
 
-function compute_hessian(::ForwardDiffGrad, A::G, ::F, vec_params) where {G, F}
-    ForwardDiff.hessian(A, vec_params)
+function compute_hessian(::ForwardDiffGrad, f::F, vec_params) where {F}
+    ForwardDiff.hessian(f, vec_params)
 end
 
 function enforce_proper_message(enforce::Bool, λ::NaturalParameters, η::NaturalParameters)
@@ -97,8 +97,7 @@ function render_cvi(approximation::CVIApproximation, logp_nc::F, initial) where 
     hasupdated = false
 
     A = (vec_params) -> lognormalizer(as_naturalparams(T, vec_params))
-    gradA = (vec_params) -> compute_grad(get_grad(approximation), A, vec_params)
-    Fisher = (vec_params) -> compute_hessian(get_grad(approximation), A, gradA, vec_params)
+    Fisher = (vec_params) -> compute_hessian(get_grad(approximation), A, vec_params)
 
     for _ in 1:its
         q = convert(Distribution, λ)

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -25,9 +25,9 @@ Arguments
  - `n_samples`: number of samples to use for statistics approximation
  - `num_iterations`: number of iteration for the natural parameters gradient optimization
  - `opt`: optimizer, which will be used to perform the natural parameters gradient optimization step
- - `grad`: structure to select, how gradient and hessian for the natural will be computed
+ - `grad`: optional, structure to select how the gradient and the hessian will be computed
  - `warn`: optional, defaults to false, enables or disables warnings related to the optimization steps
- - `proper_message`: optional, defaults to true, enables or disables inforce for the approximation be proper distribution
+ - `proper_message`: optional, defaults to true, enables or disables inforce for the approximation be a proper distribution
 
 !!! note 
     Run `using Flux` in your Julia session to enable the `Flux` optimizers support for the CVI approximation method.

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -60,7 +60,6 @@ function ProdCVI(n_samples::Int, n_iterations::Int, opt, grad = ForwardDiffGrad(
     return ProdCVI(Random.GLOBAL_RNG, n_samples, n_iterations, opt, grad, n_gradpoints, enforce_proper_messages, warn)
 end
 
-
 """Alias for the `ProdCVI` method. See help for [`ProdCVI`](@ref)"""
 const CVI = ProdCVI
 

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -111,16 +111,16 @@ end
 function prod(approximation::CVI, logp::F, dist) where {F <: Function}
     rng = something(approximation.rng, Random.GLOBAL_RNG)
 
-    #  natural parameters of incoming distribution message
+    # Natural parameters of incoming distribution message
     η = naturalparams(dist)
 
     # Natural parameter type of incoming distribution
     T = typeof(η)
 
-    # initial parameters of projected distribution
+    # Initial parameters of projected distribution
     λ = naturalparams(dist)
 
-    # initialize update flag
+    # Initialize update flag
     hasupdated = false
 
     for _ in 1:(approximation.num_iterations)

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -107,7 +107,8 @@ function render_cvi(approximation::CVIApproximation, logp_nc::F, initial) where 
         logq = (vec_params) -> logpdf(as_naturalparams(T, vec_params), z_s)
         ∇logq = compute_grad(approximation.grad, logq, vec(λ))
 
-        ∇f = Fisher(vec(λ)) \ (logp_nc(z_s) .* ∇logq)
+        fisher_matrix = Fisher(vec(λ))
+        ∇f = cholinv(fisher_matrix) * (logp_nc(z_s) .* ∇logq)
         ∇ = λ - η - as_naturalparams(T, ∇f)
         updated = as_naturalparams(T, cvi_update!(opt, λ, ∇))
 

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -95,7 +95,7 @@ function render_cvi(approximation::CVIApproximation, logp_nc::F, initial) where 
         ∇logq = compute_grad(approximation.grad, logq, vec(λ))
 
         ∇f = Fisher(vec(λ)) \ (logp_nc(z_s) .* ∇logq)
-        ∇ = λ - as_naturalparams(T, ∇f)
+        ∇ = λ - η - as_naturalparams(T, ∇f)
         updated = as_naturalparams(T, cvi_update!(opt, λ, ∇))
 
         if isproper(updated)

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -32,6 +32,9 @@ Arguments
  - `enforce_proper_messages`: optional, defaults to true, ensures that a message, computed towards the inbound edges, is a proper distribution
 
 !!! note 
+    Run `n_gradpoints` is not used at all in the Gaussian case
+
+!!! note 
     Run `using Flux` in your Julia session to enable the `Flux` optimizers support for the CVI approximation method.
 
 !!! note 
@@ -147,7 +150,7 @@ function prod(approximation::CVI, left, dist)
         
         q = convert(Distribution, λ)
         _, q_friendly = logpdf_sample_friendly(q)
-        z_s = rand(rng, q_friendly, approximation.n_gradpoints)
+        z_s = cvilinearize(rand(rng, q_friendly, approximation.n_gradpoints))
 
         # compute gradient of log-likelihood
         logq = (x) -> mean(map((z) -> logp(z)*logpdf(as_naturalparams(T, x), z), z_s))

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -1,4 +1,4 @@
-export CVIApproximation, CVI
+export CVIApproximation, CVI, ForwardDiffGrad
 
 using Random
 
@@ -31,6 +31,9 @@ Arguments
 
 !!! note 
     Run `using Flux` in your Julia session to enable the `Flux` optimizers support for the CVI approximation method.
+
+!!! note 
+    Run `using Zygote` in your Julia session to enable the `ZygoteGrad` option support for the CVI grad.
 
 """
 struct CVIApproximation{R, O, G} <: AbstractApproximationMethod

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -24,7 +24,7 @@ This method performs an approximation of the product of the `dist` and `logp` wi
 Arguments
  - `rng`: random number generator
  - `n_samples`: number of samples to use for statistics approximation
- - `num_iterations`: number of iteration for the natural parameters gradient optimization
+ - `n_iterations`: number of iteration for the natural parameters gradient optimization
  - `opt`: optimizer, which will be used to perform the natural parameters gradient optimization step
  - `grad`: optional, defaults to `ForwardDiffGrad()`, structure to select how the gradient and the hessian will be computed
  - `warn`: optional, defaults to false, enables or disables warnings related to the optimization steps
@@ -43,7 +43,7 @@ Arguments
 struct ProdCVI{R, O, G, B} <: AbstractApproximationMethod
     rng::R
     n_samples::Int
-    num_iterations::Int
+    n_iterations::Int
     opt::O
     grad::G
     warn::Bool
@@ -52,24 +52,24 @@ end
 
 get_grad(approximation::ProdCVI) = approximation.grad
 
-function ProdCVI(rng::AbstractRNG, n_samples::Int, num_iterations::Int, opt::O, grad::G, warn::Bool, enforce_proper_messages::Bool) where {O, G}
-    return ProdCVI(rng, n_samples, num_iterations, opt, grad, warn, Val{enforce_proper_messages}())
+function ProdCVI(rng::AbstractRNG, n_samples::Int, n_iterations::Int, opt::O, grad::G, warn::Bool, enforce_proper_messages::Bool) where {O, G}
+    return ProdCVI(rng, n_samples, n_iterations, opt, grad, warn, Val{enforce_proper_messages}())
 end
 
-function ProdCVI(rng::AbstractRNG, n_samples::Int, num_iterations::Int, opt::O) where {O}
-    return ProdCVI(rng, n_samples, num_iterations, opt, ForwardDiffGrad(), false, true)
+function ProdCVI(rng::AbstractRNG, n_samples::Int, n_iterations::Int, opt::O) where {O}
+    return ProdCVI(rng, n_samples, n_iterations, opt, ForwardDiffGrad(), false, true)
 end
 
-function ProdCVI(rng::AbstractRNG, n_samples::Int, num_iterations::Int, opt::O, grad::G) where {O, G}
-    return ProdCVI(rng, n_samples, num_iterations, opt, grad, false, true)
+function ProdCVI(rng::AbstractRNG, n_samples::Int, n_iterations::Int, opt::O, grad::G) where {O, G}
+    return ProdCVI(rng, n_samples, n_iterations, opt, grad, false, true)
 end
 
-function ProdCVI(n_samples::Int, num_iterations::Int, opt::O, warn::Bool = false) where {O}
-    return ProdCVI(Random.GLOBAL_RNG, n_samples, num_iterations, opt, ForwardDiffGrad(), warn, true)
+function ProdCVI(n_samples::Int, n_iterations::Int, opt::O, warn::Bool = false) where {O}
+    return ProdCVI(Random.GLOBAL_RNG, n_samples, n_iterations, opt, ForwardDiffGrad(), warn, true)
 end
 
-function ProdCVI(n_samples::Int, num_iterations::Int, opt::O, grad::G, warn::Bool = false) where {O, G}
-    return ProdCVI(Random.GLOBAL_RNG, n_samples, num_iterations, opt, grad, warn, true)
+function ProdCVI(n_samples::Int, n_iterations::Int, opt::O, grad::G, warn::Bool = false) where {O, G}
+    return ProdCVI(Random.GLOBAL_RNG, n_samples, n_iterations, opt, grad, warn, true)
 end
 
 """Alias for the `ProdCVI` method. See help for [`ProdCVI`](@ref)"""
@@ -135,7 +135,7 @@ function prod(approximation::CVI, left, dist)
     # Initialize update flag
     hasupdated = false
 
-    for _ in 1:(approximation.num_iterations)
+    for _ in 1:(approximation.n_iterations)
 
         # create distribution to sample from and sample from it
         q = convert(Distribution, λ)

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -47,6 +47,10 @@ function CVIApproximation(rng::AbstractRNG, n_samples::Int, num_iterations::Int,
     return CVIApproximation(rng, n_samples, num_iterations, opt, ForwardDiffGrad(), false, true)
 end
 
+function CVIApproximation(rng::AbstractRNG, n_samples::Int, num_iterations::Int, opt::O, grad::G) where {O, G}
+    return CVIApproximation(rng, n_samples, num_iterations, opt, grad, false, true)
+end
+
 function CVIApproximation(n_samples::Int, num_iterations::Int, opt::O, warn::Bool = false) where {O}
     return CVIApproximation(Random.GLOBAL_RNG, n_samples, num_iterations, opt, ForwardDiffGrad(), warn, true)
 end

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -113,7 +113,7 @@ function render_cvi(approximation::CVIApproximation, logp_nc::F, initial) where 
         ∇ = λ - η - as_naturalparams(T, ∇f)
         updated = as_naturalparams(T, cvi_update!(opt, λ, ∇))
 
-        if isproper(updated) && enforce_proper_message(approximation.proper_message, updated, η)
+        if isproper(updated) && enforce_proper_message(approximation.enforce_proper_messages, updated, η)
             λ = updated
             hasupdated = true
         end

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -89,10 +89,6 @@ function compute_hessian(::ForwardDiffGrad, f::F, vec_params) where {F}
     ForwardDiff.hessian(f, vec_params)
 end
 
-function compute_jacobian(::ForwardDiffGrad, f::F, vec_params) where {F}
-    ForwardDiff.jacobian(f, vec_params)
-end
-
 function enforce_proper_message(enforce::Bool, λ::NaturalParameters, η::NaturalParameters)
     return !enforce || (enforce && isproper(λ - η))
 end

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -71,11 +71,7 @@ function ProdCVI(n_samples::Int, num_iterations::Int, opt::O, grad::G, warn::Boo
     return ProdCVI(Random.GLOBAL_RNG, n_samples, num_iterations, opt, grad, warn, Val{true}())
 end
 
-"""
-Alias for the `ProdCVI` method.
-
-See also: [`ProdCVI`](@ref)
-"""
+"""Alias for the `ProdCVI` method. See help for [`ProdCVI`](@ref)"""
 const CVI = ProdCVI
 
 #---------------------------
@@ -114,6 +110,7 @@ end
 # without type constraints it will create stack-overflow error
 # prod(approximation::CVI, dist, logp::F) where {F} = prod(approximation, logp, dist)
 
+# The function assumes only `logpdf` for `left` and that we can sample from `dist`
 function prod(approximation::CVI, left, dist)
     rng = something(approximation.rng, Random.GLOBAL_RNG)
 

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -147,13 +147,13 @@ function prod(approximation::CVI, left, dist)
     for _ in 1:(approximation.n_iterations)
 
         # create distribution to sample from and sample from it
-        
+
         q = convert(Distribution, λ)
         _, q_friendly = logpdf_sample_friendly(q)
         z_s = cvilinearize(rand(rng, q_friendly, approximation.n_gradpoints))
 
         # compute gradient of log-likelihood
-        logq = (x) -> mean(map((z) -> logp(z)*logpdf(as_naturalparams(T, x), z), z_s))
+        logq = (x) -> mean(map((z) -> logp(z) * logpdf(as_naturalparams(T, x), z), z_s))
         ∇logq = compute_gradient(get_grad(approximation), logq, vec(λ))
 
         # compute Fisher matrix and Cholesky decomposition

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -25,7 +25,9 @@ Arguments
  - `n_samples`: number of samples to use for statistics approximation
  - `num_iterations`: number of iteration for the natural parameters gradient optimization
  - `opt`: optimizer, which will be used to perform the natural parameters gradient optimization step
+ - `grad`: structure to select, how gradient and hessian for the natural will be computed
  - `warn`: optional, defaults to false, enables or disables warnings related to the optimization steps
+ - `proper_message`: optional, defaults to true, enables or disables inforce for the approximation be proper distribution
 
 !!! note 
     Run `using Flux` in your Julia session to enable the `Flux` optimizers support for the CVI approximation method.
@@ -36,17 +38,17 @@ struct CVIApproximation{R, O, G} <: AbstractApproximationMethod
     n_samples::Int
     num_iterations::Int
     opt::O
-    warn::Bool
     grad::G
+    warn::Bool
     proper_message::Bool
 end
 
 function CVIApproximation(rng::AbstractRNG, n_samples::Int, num_iterations::Int, opt::O) where {O}
-    return CVIApproximation(rng, n_samples, num_iterations, opt, false, ForwardDiffGrad(), true)
+    return CVIApproximation(rng, n_samples, num_iterations, opt, ForwardDiffGrad(), false, true)
 end
 
 function CVIApproximation(n_samples::Int, num_iterations::Int, opt::O, warn::Bool = false) where {O}
-    return CVIApproximation(Random.GLOBAL_RNG, n_samples, num_iterations, opt, warn, ForwardDiffGrad(), true)
+    return CVIApproximation(Random.GLOBAL_RNG, n_samples, num_iterations, opt, ForwardDiffGrad(), warn, true)
 end
 
 """

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -48,17 +48,18 @@ struct ProdCVI{R, O, G, B} <: AbstractApproximationMethod
     n_gradpoints::Int
     enforce_proper_messages::Val{B}
     warn::Bool
+
+    function ProdCVI(
+        rng::R, n_samples::Int, n_iterations::Int, opt::O, grad::G = ForwardDiffGrad(), n_gradpoints::Int = 1, enforce_proper_messages::Val{B} = Val(true), warn::Bool = false
+    ) where {R, O, G, B}
+        return new{R, O, G, B}(rng, n_samples, n_iterations, opt, grad, n_gradpoints, enforce_proper_messages, warn)
+    end
 end
 
 function ProdCVI(n_samples::Int, n_iterations::Int, opt, grad = ForwardDiffGrad(), n_gradpoints::Int = 1, enforce_proper_messages::Val = Val(true), warn::Bool = false)
     return ProdCVI(Random.GLOBAL_RNG, n_samples, n_iterations, opt, grad, n_gradpoints, enforce_proper_messages, warn)
 end
 
-function ProdCVI(
-    rng::R, n_samples::Int, n_iterations::Int, opt::O, grad::G = ForwardDiffGrad(), n_gradpoints::Int = 1, enforce_proper_messages::Val{B} = Val(true), warn::Bool = false
-) where {R, O, G, B}
-    return ProdCVI{R, O, G, B}(rng, n_samples, n_iterations, opt, grad, n_gradpoints, enforce_proper_messages, warn)
-end
 
 """Alias for the `ProdCVI` method. See help for [`ProdCVI`](@ref)"""
 const CVI = ProdCVI

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -105,6 +105,7 @@ function compute_fisher_matrix(approximation::CVI, ::Type{T}, params::Vector) wh
     return F
 end
 
+# without type constraints it will create stakeoverflow error
 # prod(approximation::CVI, dist, logp::F) where {F} = prod(approximation, logp, dist)
 
 function prod(approximation::CVI, logp::F, dist) where {F <: Function}
@@ -133,7 +134,7 @@ function prod(approximation::CVI, logp::F, dist) where {F <: Function}
         logq = (x) -> logpdf(as_naturalparams(T, x), z_s)
         ∇logq = logp(z_s) .* compute_gradient(get_grad(approximation), logq, vec(λ))
 
-        #  compute Fisher matrix and Cholesky decomposition
+        # compute Fisher matrix and Cholesky decomposition
         Fisher = compute_fisher_matrix(approximation, T, vec(λ))
         F_chol = fastcholesky!(Fisher)
 

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -25,6 +25,7 @@ Arguments
  - `rng`: random number generator
  - `n_samples`: number of samples to use for statistics approximation
  - `n_iterations`: number of iteration for the natural parameters gradient optimization
+ - `n_gradpoints`: optional, defaults to 1, number of points to estimate gradient of the likelihood (dist*logp)
  - `opt`: optimizer, which will be used to perform the natural parameters gradient optimization step
  - `grad`: optional, defaults to `ForwardDiffGrad()`, structure to select how the gradient and the hessian will be computed
  - `warn`: optional, defaults to false, enables or disables warnings related to the optimization steps

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -1,4 +1,4 @@
-export CVI, ForwardDiffGrad
+export CVI, ProdCVI, ForwardDiffGrad
 
 using Random
 
@@ -111,11 +111,13 @@ function compute_fisher_matrix(approximation::CVI, ::Type{T}, vec::AbstractVecto
     return F
 end
 
-# without type constraints it will create stakeoverflow error
+# without type constraints it will create stack-overflow error
 # prod(approximation::CVI, dist, logp::F) where {F} = prod(approximation, logp, dist)
 
-function prod(approximation::CVI, logp::F, dist) where {F <: Function}
+function prod(approximation::CVI, left, dist)
     rng = something(approximation.rng, Random.GLOBAL_RNG)
+
+    logp = (x) -> logpdf(left, x)
 
     # Natural parameters of incoming distribution message
     η = naturalparams(dist)
@@ -164,5 +166,5 @@ function prod(approximation::CVI, logp::F, dist) where {F <: Function}
         @warn "CVI approximation has not updated the initial state. The method did not converge. Set `warn = false` to supress this warning."
     end
 
-    return λ
+    return convert(Distribution, λ)
 end

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -79,7 +79,7 @@ function compute_hessian(::ForwardDiffGrad, A::G, ::F, vec_params) where {G, F}
     ForwardDiff.hessian(A, vec_params)
 end
 
-function inforce_proper_message(inforce::Bool, λ::NaturalParameters, η::NaturalParameters)
+function enforce_proper_message(inforce::Bool, λ::NaturalParameters, η::NaturalParameters)
     return !inforce || (inforce && isproper(λ - η))
 end
 
@@ -112,7 +112,7 @@ function render_cvi(approximation::CVIApproximation, logp_nc::F, initial) where 
         ∇ = λ - η - as_naturalparams(T, ∇f)
         updated = as_naturalparams(T, cvi_update!(opt, λ, ∇))
 
-        if isproper(updated) && inforce_proper_message(approximation.proper_message, updated, η)
+        if isproper(updated) && enforce_proper_message(approximation.proper_message, updated, η)
             λ = updated
             hasupdated = true
         end

--- a/src/approximations/cvi.jl
+++ b/src/approximations/cvi.jl
@@ -27,7 +27,7 @@ Arguments
  - `opt`: optimizer, which will be used to perform the natural parameters gradient optimization step
  - `grad`: optional, default to `ForwardDiffGrad`, structure to select how the gradient and the hessian will be computed
  - `warn`: optional, defaults to false, enables or disables warnings related to the optimization steps
- - `proper_message`: optional, defaults to true, ensures that a message, computed towards the inbound edges, is a proper distribution
+ - `enforce_proper_messages`: optional, defaults to true, ensures that a message, computed towards the inbound edges, is a proper distribution
 
 !!! note 
     Run `using Flux` in your Julia session to enable the `Flux` optimizers support for the CVI approximation method.
@@ -43,7 +43,7 @@ struct CVIApproximation{R, O, G} <: AbstractApproximationMethod
     opt::O
     grad::G
     warn::Bool
-    proper_message::Bool
+    enforce_proper_messages::Bool
 end
 
 get_grad(approximation::CVIApproximation) = approximation.grad

--- a/src/distributions/function.jl
+++ b/src/distributions/function.jl
@@ -20,6 +20,7 @@ DomainSets.dimension(::UnspecifiedDomain) = UnspecifiedDimension()
 
 Base.in(::Any, ::UnspecifiedDomain) = true
 
+Base.:(!=)(::UnspecifiedDimension, ::Int)  = true
 Base.:(!==)(::UnspecifiedDimension, ::Int) = true
 Base.:(==)(::UnspecifiedDimension, ::Int)  = true
 

--- a/src/distributions/function.jl
+++ b/src/distributions/function.jl
@@ -89,7 +89,7 @@ end
 variate_form(::Type{<:ContinuousUnivariateLogPdf}) = Univariate
 variate_form(::ContinuousUnivariateLogPdf)         = Univariate
 
-promote_variate_type(::Type{ Univariate }, ::Type{ AbstractContinuousGenericLogPdf }) = ContinuousUnivariateLogPdf
+promote_variate_type(::Type{Univariate}, ::Type{AbstractContinuousGenericLogPdf}) = ContinuousUnivariateLogPdf
 
 getdomain(dist::ContinuousUnivariateLogPdf) = dist.domain
 getlogpdf(dist::ContinuousUnivariateLogPdf) = dist.logpdf
@@ -147,7 +147,7 @@ end
 variate_form(::Type{<:ContinuousMultivariateLogPdf}) = Multivariate
 variate_form(::ContinuousMultivariateLogPdf)         = Multivariate
 
-promote_variate_type(::Type{ Multivariate }, ::Type{ AbstractContinuousGenericLogPdf }) = ContinuousMultivariateLogPdf
+promote_variate_type(::Type{Multivariate}, ::Type{AbstractContinuousGenericLogPdf}) = ContinuousMultivariateLogPdf
 
 getdomain(dist::ContinuousMultivariateLogPdf) = dist.domain
 getlogpdf(dist::ContinuousMultivariateLogPdf) = dist.logpdf

--- a/src/distributions/function.jl
+++ b/src/distributions/function.jl
@@ -188,6 +188,16 @@ prod(::ProdAnalytical, left::F, right::F) where {F <: AbstractContinuousGenericL
 
 prod(::ProdAnalytical, left::GenericLogPdfVectorisedProduct{F}, right::F) where {F <: AbstractContinuousGenericLogPdf} = push!(left, right)
 
+## Symmetric CVI prod method
+
+function prod(approximation::CVI, left, dist::AbstractContinuousGenericLogPdf)
+    return prod(approximation, dist, left) # We swap arguments in case if `AbstractContinuousGenericLogPdf` on the right hand side
+end
+
+function prod(approximation::CVI, left::AbstractContinuousGenericLogPdf, dist::AbstractContinuousGenericLogPdf)
+    error("The `CVI` approximation expects at least on of the arguments to be a distribution")
+end
+
 ## Utility methods for tests 
 
 # These methods are inaccurate and relies on various approximation methods, which may fail in different scenarios

--- a/src/distributions/function.jl
+++ b/src/distributions/function.jl
@@ -6,7 +6,14 @@ import DomainSets
 import DomainIntegrals
 import HCubature
 
-import Base: isapprox
+import DomainSets: Domain
+
+import Base: isapprox, in
+
+# Unknown domain that is used as a placeholder when exact domain knowledge is unavailable
+struct UnspecifiedDomain <: Domain{Any} end
+
+Base.in(::UnspecifiedDomain, ::Any) = true
 
 abstract type AbstractContinuousGenericLogPdf end
 
@@ -82,6 +89,8 @@ end
 variate_form(::Type{<:ContinuousUnivariateLogPdf}) = Univariate
 variate_form(::ContinuousUnivariateLogPdf)         = Univariate
 
+promote_variate_type(::Type{ Univariate }, ::Type{ AbstractContinuousGenericLogPdf }) = ContinuousUnivariateLogPdf
+
 getdomain(dist::ContinuousUnivariateLogPdf) = dist.domain
 getlogpdf(dist::ContinuousUnivariateLogPdf) = dist.logpdf
 
@@ -137,6 +146,8 @@ end
 
 variate_form(::Type{<:ContinuousMultivariateLogPdf}) = Multivariate
 variate_form(::ContinuousMultivariateLogPdf)         = Multivariate
+
+promote_variate_type(::Type{ Multivariate }, ::Type{ AbstractContinuousGenericLogPdf }) = ContinuousMultivariateLogPdf
 
 getdomain(dist::ContinuousMultivariateLogPdf) = dist.domain
 getlogpdf(dist::ContinuousMultivariateLogPdf) = dist.logpdf

--- a/src/distributions/function.jl
+++ b/src/distributions/function.jl
@@ -6,14 +6,22 @@ import DomainSets
 import DomainIntegrals
 import HCubature
 
-import DomainSets: Domain
+import DomainSets: Domain, dimension
 
 import Base: isapprox, in
 
 # Unknown domain that is used as a placeholder when exact domain knowledge is unavailable
 struct UnspecifiedDomain <: Domain{Any} end
 
-Base.in(::UnspecifiedDomain, ::Any) = true
+# Unknown dimension is equal and not equal to any number
+struct UnspecifiedDimension end
+
+DomainSets.dimension(::UnspecifiedDomain) = UnspecifiedDimension()
+
+Base.in(::Any, ::UnspecifiedDomain) = true
+
+Base.:(!==)(::UnspecifiedDimension, ::Int) = true
+Base.:(==)(::UnspecifiedDimension, ::Int)  = true
 
 abstract type AbstractContinuousGenericLogPdf end
 
@@ -81,7 +89,7 @@ struct ContinuousUnivariateLogPdf{D <: DomainSets.Domain, F} <: AbstractContinuo
     logpdf::F
 
     ContinuousUnivariateLogPdf(domain::D, logpdf::F) where {D, F} = begin
-        @assert DomainSets.dimension(domain) === 1 "Cannot create ContinuousUnivariateLogPdf. Dimension of domain = $(domain) is not equal to 1."
+        @assert DomainSets.dimension(domain) == 1 "Cannot create ContinuousUnivariateLogPdf. Dimension of domain = $(domain) is not equal to 1."
         return new{D, F}(domain, logpdf)
     end
 end

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -484,8 +484,9 @@ function lognormalizer(η::UnivariateNormalNaturalParameters)
 end
 
 function lognormalizer(η::MultivariateNormalNaturalParameters)
-    L = fastcholesky(-η.minus_half_precision_matrix)
-    return η.weighted_mean' * (L \ η.weighted_mean) / 4 - (length(η.weighted_mean) * log(2) + logdet(L)) / 2
+    # L = fastcholesky(-η.minus_half_precision_matrix)
+    # return η.weighted_mean' * (L \ η.weighted_mean) / 4 - (length(η.weighted_mean) * log(2) + logdet(L)) / 2
+    return -η.weighted_mean' * (η.minus_half_precision_matrix \ η.weighted_mean) / 4 - logdet(-2 * η.minus_half_precision_matrix) / 2
 end
 
 # Semih: logpdf wrt natural params. ForwardDiff is not stable with reshape function which

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -27,6 +27,7 @@ import StatsFuns: invsqrt2π
 
 using LoopVectorization
 using LinearAlgebra
+using SpecialFunctions
 
 # Joint over multiple Gaussians
 
@@ -490,12 +491,12 @@ end
 # precludes the usage of logPdf functions previously defined. Below function is
 # meant to be used with Zygote.
 function Distributions.logpdf(η::UnivariateNormalNaturalParameters, x)
-    return log(invsqrt2π) + x * η.weighted_mean + x^2 * η.minus_half_precision - lognormalizer(η)
+    return -log2π / 2 + x * η.weighted_mean + x^2 * η.minus_half_precision - lognormalizer(η)
 end
 
 function Distributions.logpdf(η::MultivariateNormalNaturalParameters, x)
     ϕx = vcat(x, vec(x * transpose(x)))
-    return log((2 * pi)^(-0.5 * length(η.weighted_mean))) + transpose(ϕx) * vec(η) + lognormalizer(η)
+    return -length(η.weighted_mean)*log2π / 2 + transpose(ϕx) * vec(η) + lognormalizer(η)
 end
 
 isproper(params::UnivariateNormalNaturalParameters) = params.minus_half_precision < 0

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -568,7 +568,7 @@ function render_cvi(approximation::CVIApproximation, logp_nc::F, initial::Gaussi
         ∇f = as_naturalparams(T, df_μ1, df_μ2)
         ∇ = λ - η - ∇f
         λ_new = as_naturalparams(T, cvi_update!(opt, λ, ∇))
-        if isproper(λ_new) && enforce_proper_message(approximation.proper_message, λ, η)
+        if isproper(λ_new) && enforce_proper_message(approximation.proper_message, λ_new, η)
             λ = λ_new
             hasupdated = true
         end

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -538,13 +538,17 @@ end
 
 # Thes functions extends the `CVI` approximation method in case if input is from the `NormalDistributionsFamily`
 
-get_df_m(::ForwardDiffGrad, ::Type{<:UnivariateNormalNaturalParameters}, ::Type{<:UnivariateGaussianDistributionsFamily}, logp_nc::Function) = (z) -> ForwardDiff.derivative(logp_nc, z)
+get_df_m(::ForwardDiffGrad, ::Type{<:UnivariateNormalNaturalParameters}, ::Type{<:UnivariateGaussianDistributionsFamily}, logp_nc::Function) =
+    (z) -> ForwardDiff.derivative(logp_nc, z)
 
-get_df_m(::ForwardDiffGrad, ::Type{<:MultivariateNormalNaturalParameters}, ::Type{<:MultivariateGaussianDistributionsFamily}, logp_nc::Function) = (z) -> ForwardDiff.gradient(logp_nc, z)
+get_df_m(::ForwardDiffGrad, ::Type{<:MultivariateNormalNaturalParameters}, ::Type{<:MultivariateGaussianDistributionsFamily}, logp_nc::Function) =
+    (z) -> ForwardDiff.gradient(logp_nc, z)
 
-get_df_v(::ForwardDiffGrad, ::Type{<:UnivariateNormalNaturalParameters}, ::Type{<:UnivariateGaussianDistributionsFamily}, df_m::Function) = (z) -> ForwardDiff.derivative(df_m, z)
+get_df_v(::ForwardDiffGrad, ::Type{<:UnivariateNormalNaturalParameters}, ::Type{<:UnivariateGaussianDistributionsFamily}, logp_nc::Function, df_m::Function) =
+    (z) -> ForwardDiff.derivative(df_m, z)
 
-get_df_v(::ForwardDiffGrad, ::Type{<:MultivariateNormalNaturalParameters}, ::Type{<:MultivariateGaussianDistributionsFamily}, df_m::Function) = (z) -> ForwardDiff.jacobian(df_m, z)
+get_df_v(::ForwardDiffGrad, ::Type{<:MultivariateNormalNaturalParameters}, ::Type{<:MultivariateGaussianDistributionsFamily}, logp_nc::Function, df_m::Function) =
+    (z) -> ForwardDiff.jacobian(df_m, z)
 
 function render_cvi(approximation::CVIApproximation, logp_nc::F, initial::GaussianDistributionsFamily) where {F}
     η = naturalparams(initial)
@@ -556,7 +560,7 @@ function render_cvi(approximation::CVIApproximation, logp_nc::F, initial::Gaussi
     its = approximation.num_iterations
 
     df_m = (z) -> get_df_m(approximation.grad, typeof(λ), typeof(initial), logp_nc)(z)
-    df_v = (z) -> get_df_v(approximation.grad, typeof(λ), typeof(initial), df_m)(z) / 2
+    df_v = (z) -> get_df_v(approximation.grad, typeof(λ), typeof(initial), logp_nc, df_m)(z) / 2
 
     hasupdated = false
 

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -484,7 +484,8 @@ function lognormalizer(η::UnivariateNormalNaturalParameters)
 end
 
 function lognormalizer(η::MultivariateNormalNaturalParameters)
-    return η.weighted_mean' * (η.minus_half_precision_matrix \ η.weighted_mean) / 4 + logdet(-2 * η.minus_half_precision_matrix) / 2
+    L = fastcholesky(-η.minus_half_precision_matrix)
+    return η.weighted_mean' * (L \ η.weighted_mean) / 4 - (length(η.weighted_mean) * log(2) + logdet(L)) / 2
 end
 
 # Semih: logpdf wrt natural params. ForwardDiff is not stable with reshape function which
@@ -496,7 +497,7 @@ end
 
 function Distributions.logpdf(η::MultivariateNormalNaturalParameters, x)
     ϕx = vcat(x, vec(x * transpose(x)))
-    return -length(η.weighted_mean) * log2π / 2 + transpose(ϕx) * vec(η) + lognormalizer(η)
+    return -length(η.weighted_mean) * log2π / 2 + transpose(ϕx) * vec(η) - lognormalizer(η)
 end
 
 isproper(params::UnivariateNormalNaturalParameters) = params.minus_half_precision < 0

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -551,8 +551,11 @@ function compute_df_mv(approximation::CVI, logp::F, z_s::AbstractVector) where {
     return df_m, df_v ./ 2
 end
 
-function prod(approximation::CVI, logp::F, dist::GaussianDistributionsFamily) where {F <: Function}
+function prod(approximation::CVI, left, dist::GaussianDistributionsFamily) 
     rng = something(approximation.rng, Random.GLOBAL_RNG)
+
+    logp = (x) -> logpdf(left, x)
+
     # Natural parameters of incoming distribution message
     η = naturalparams(dist)
     T = typeof(η)
@@ -593,5 +596,5 @@ function prod(approximation::CVI, logp::F, dist::GaussianDistributionsFamily) wh
         @warn "CVI approximation has not updated the initial state. The method did not converge. Set `warn = false` to supress this warning."
     end
 
-    return λ
+    return convert(Distribution, λ)
 end

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -484,8 +484,6 @@ function lognormalizer(η::UnivariateNormalNaturalParameters)
 end
 
 function lognormalizer(η::MultivariateNormalNaturalParameters)
-    # L = fastcholesky(-η.minus_half_precision_matrix)
-    # return η.weighted_mean' * (L \ η.weighted_mean) / 4 - (length(η.weighted_mean) * log(2) + logdet(L)) / 2
     return -η.weighted_mean' * (η.minus_half_precision_matrix \ η.weighted_mean) / 4 - logdet(-2 * η.minus_half_precision_matrix) / 2
 end
 
@@ -542,14 +540,14 @@ end
 # Thes functions extends the `CVI` approximation method in case if input is from the `NormalDistributionsFamily`
 
 function compute_df_mv(approximation::CVI, logp::F, z_s::Real) where {F}
-    df_m = compute_derivative(get_grad(approximation), logp, z_s)
-    df_v = compute_second_derivative(get_grad(approximation), logp, z_s)
+    df_m = compute_derivative(approximation.grad, logp, z_s)
+    df_v = compute_second_derivative(approximation.grad, logp, z_s)
     return df_m, df_v / 2
 end
 
 function compute_df_mv(approximation::CVI, logp::F, z_s::AbstractVector) where {F}
-    df_m = compute_gradient(get_grad(approximation), logp, z_s)
-    df_v = compute_hessian(get_grad(approximation), logp, z_s)
+    df_m = compute_gradient(approximation.grad, logp, z_s)
+    df_v = compute_hessian(approximation.grad, logp, z_s)
     return df_m, df_v ./ 2
 end
 

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -538,13 +538,13 @@ end
 
 # Thes functions extends the `CVI` approximation method in case if input is from the `NormalDistributionsFamily`
 
-get_df_m(::Type{<:UnivariateNormalNaturalParameters}, ::Type{<:UnivariateGaussianDistributionsFamily}, logp_nc::Function) = (z) -> ForwardDiff.derivative(logp_nc, z)
+get_df_m(::ForwardDiffGrad, ::Type{<:UnivariateNormalNaturalParameters}, ::Type{<:UnivariateGaussianDistributionsFamily}, logp_nc::Function) = (z) -> ForwardDiff.derivative(logp_nc, z)
 
-get_df_m(::Type{<:MultivariateNormalNaturalParameters}, ::Type{<:MultivariateGaussianDistributionsFamily}, logp_nc::Function) = (z) -> ForwardDiff.gradient(logp_nc, z)
+get_df_m(::ForwardDiffGrad, ::Type{<:MultivariateNormalNaturalParameters}, ::Type{<:MultivariateGaussianDistributionsFamily}, logp_nc::Function) = (z) -> ForwardDiff.gradient(logp_nc, z)
 
-get_df_v(::Type{<:UnivariateNormalNaturalParameters}, ::Type{<:UnivariateGaussianDistributionsFamily}, df_m::Function) = (z) -> ForwardDiff.derivative(df_m, z)
+get_df_v(::ForwardDiffGrad, ::Type{<:UnivariateNormalNaturalParameters}, ::Type{<:UnivariateGaussianDistributionsFamily}, df_m::Function) = (z) -> ForwardDiff.derivative(df_m, z)
 
-get_df_v(::Type{<:MultivariateNormalNaturalParameters}, ::Type{<:MultivariateGaussianDistributionsFamily}, df_m::Function) = (z) -> ForwardDiff.jacobian(df_m, z)
+get_df_v(::ForwardDiffGrad, ::Type{<:MultivariateNormalNaturalParameters}, ::Type{<:MultivariateGaussianDistributionsFamily}, df_m::Function) = (z) -> ForwardDiff.jacobian(df_m, z)
 
 function render_cvi(approximation::CVIApproximation, logp_nc::F, initial::GaussianDistributionsFamily) where {F}
     η = naturalparams(initial)
@@ -555,8 +555,8 @@ function render_cvi(approximation::CVIApproximation, logp_nc::F, initial::Gaussi
     opt = approximation.opt
     its = approximation.num_iterations
 
-    df_m = (z) -> get_df_m(typeof(λ), typeof(initial), logp_nc)(z)
-    df_v = (z) -> get_df_v(typeof(λ), typeof(initial), df_m)(z) / 2
+    df_m = (z) -> get_df_m(approximation.grad, typeof(λ), typeof(initial), logp_nc)(z)
+    df_v = (z) -> get_df_v(approximation.grad, typeof(λ), typeof(initial), df_m)(z) / 2
 
     hasupdated = false
 

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -539,18 +539,13 @@ end
 
 # Thes functions extends the `CVI` approximation method in case if input is from the `NormalDistributionsFamily`
 
-function compute_second_derivative(grad::G, logp::F, z_s::Real) where {G, F}
-    first_derivative = (x) -> compute_derivative(grad, logp, x)
-    return compute_derivative(grad, first_derivative, z_s)
-end
-
 function compute_df_mv(approximation::CVI, logp::F, z_s::Real) where {F}
     df_m = compute_derivative(get_grad(approximation), logp, z_s)
     df_v = compute_second_derivative(get_grad(approximation), logp, z_s)
     return df_m, df_v / 2
 end
 
-function compute_df_mv(approximation::CVI, logp::F, z_s::Vector) where {F}
+function compute_df_mv(approximation::CVI, logp::F, z_s::AbstractVector) where {F}
     df_m = compute_gradient(get_grad(approximation), logp, z_s)
     df_v = compute_hessian(get_grad(approximation), logp, z_s)
     return df_m, df_v ./ 2

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -559,8 +559,8 @@ function render_cvi(approximation::CVIApproximation, logp_nc::F, initial::Gaussi
     opt = approximation.opt
     its = approximation.num_iterations
 
-    df_m = (z) -> get_df_m(approximation.grad, typeof(λ), typeof(initial), logp_nc)(z)
-    df_v = (z) -> get_df_v(approximation.grad, typeof(λ), typeof(initial), logp_nc, df_m)(z) / 2
+    df_m = (z) -> get_df_m(get_grad(approximation), typeof(λ), typeof(initial), logp_nc)(z)
+    df_v = (z) -> get_df_v(get_grad(approximation), typeof(λ), typeof(initial), logp_nc, df_m)(z) / 2
 
     hasupdated = false
 

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -599,9 +599,3 @@ function prod(approximation::CVI, logp::F, dist::GaussianDistributionsFamily) wh
 
     return λ
 end
-
-struct TestValField
-    valfield::Val
-end
-
-test_val_field(::Val{true}) = true

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -479,7 +479,7 @@ function Base.:-(left::MultivariateNormalNaturalParameters, right::MultivariateN
 end
 
 function lognormalizer(η::UnivariateNormalNaturalParameters)
-    return η.weighted_mean^2 / (4 * η.minus_half_precision) + log(-2 * η.minus_half_precision) / 2
+    return - η.weighted_mean^2 / (4 * η.minus_half_precision) - log(-2 * η.minus_half_precision) / 2
 end
 
 function lognormalizer(η::MultivariateNormalNaturalParameters)
@@ -490,7 +490,7 @@ end
 # precludes the usage of logPdf functions previously defined. Below function is
 # meant to be used with Zygote.
 function Distributions.logpdf(η::UnivariateNormalNaturalParameters, x)
-    return log(invsqrt2π) + x * η.weighted_mean + x^2 * η.minus_half_precision + lognormalizer(η)
+    return log(invsqrt2π) + x * η.weighted_mean + x^2 * η.minus_half_precision - lognormalizer(η)
 end
 
 function Distributions.logpdf(η::MultivariateNormalNaturalParameters, x)

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -599,3 +599,9 @@ function prod(approximation::CVI, logp::F, dist::GaussianDistributionsFamily) wh
 
     return λ
 end
+
+struct TestValField
+    valfield::Val
+end
+
+test_val_field(::Val{true}) = true

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -572,7 +572,7 @@ function render_cvi(approximation::CVIApproximation, logp_nc::F, initial::Gaussi
         ∇f = as_naturalparams(T, df_μ1, df_μ2)
         ∇ = λ - η - ∇f
         λ_new = as_naturalparams(T, cvi_update!(opt, λ, ∇))
-        if isproper(λ_new) && enforce_proper_message(approximation.proper_message, λ_new, η)
+        if isproper(λ_new) && enforce_proper_message(approximation.enforce_proper_messages, λ_new, η)
             λ = λ_new
             hasupdated = true
         end

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -479,7 +479,7 @@ function Base.:-(left::MultivariateNormalNaturalParameters, right::MultivariateN
 end
 
 function lognormalizer(η::UnivariateNormalNaturalParameters)
-    return - η.weighted_mean^2 / (4 * η.minus_half_precision) - log(-2 * η.minus_half_precision) / 2
+    return -η.weighted_mean^2 / (4 * η.minus_half_precision) - log(-2 * η.minus_half_precision) / 2
 end
 
 function lognormalizer(η::MultivariateNormalNaturalParameters)

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -568,7 +568,7 @@ function render_cvi(approximation::CVIApproximation, logp_nc::F, initial::Gaussi
         ∇f = as_naturalparams(T, df_μ1, df_μ2)
         ∇ = λ - η - ∇f
         λ_new = as_naturalparams(T, cvi_update!(opt, λ, ∇))
-        if isproper(λ_new)
+        if isproper(λ_new) && enforce_proper_message(approximation.proper_message, λ, η)
             λ = λ_new
             hasupdated = true
         end

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -568,7 +568,7 @@ function prod(approximation::CVI, left, dist::GaussianDistributionsFamily)
     # Initialize update flag
     hasupdated = false
 
-    for _ in 1:(approximation.num_iterations)
+    for _ in 1:(approximation.n_iterations)
         # create distribution to sample from and sample from it
         q = convert(Distribution, λ)
         z_s = rand(rng, q)

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -551,7 +551,7 @@ function compute_df_mv(approximation::CVI, logp::F, z_s::AbstractVector) where {
     return df_m, df_v ./ 2
 end
 
-function prod(approximation::CVI, left, dist::GaussianDistributionsFamily) 
+function prod(approximation::CVI, left, dist::GaussianDistributionsFamily)
     rng = something(approximation.rng, Random.GLOBAL_RNG)
 
     logp = (x) -> logpdf(left, x)

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -496,7 +496,7 @@ end
 
 function Distributions.logpdf(η::MultivariateNormalNaturalParameters, x)
     ϕx = vcat(x, vec(x * transpose(x)))
-    return -length(η.weighted_mean)*log2π / 2 + transpose(ϕx) * vec(η) + lognormalizer(η)
+    return -length(η.weighted_mean) * log2π / 2 + transpose(ϕx) * vec(η) + lognormalizer(η)
 end
 
 isproper(params::UnivariateNormalNaturalParameters) = params.minus_half_precision < 0

--- a/src/nodes/delta/delta.jl
+++ b/src/nodes/delta/delta.jl
@@ -140,9 +140,9 @@ deltafn_rule_layout(::DeltaFnNode, ::AbstractApproximationMethod, inverse::Nothi
 deltafn_rule_layout(::DeltaFnNode, ::AbstractApproximationMethod, inverse::Function)                      = DeltaFnDefaultKnownInverseRuleLayout()
 deltafn_rule_layout(::DeltaFnNode, ::AbstractApproximationMethod, inverse::NTuple{N, Function}) where {N} = DeltaFnDefaultKnownInverseRuleLayout()
 
-deltafn_rule_layout(::DeltaFnNode, ::CVIApproximation, inverse::Nothing) = CVIApproximationDeltaFnRuleLayout()
+deltafn_rule_layout(::DeltaFnNode, ::CVI, inverse::Nothing) = CVIApproximationDeltaFnRuleLayout()
 
-function deltafn_rule_layout(::DeltaFnNode, ::CVIApproximation, inverse::Any)
+function deltafn_rule_layout(::DeltaFnNode, ::CVI, inverse::Any)
     @warn "CVI Approximation does not accept the inverse function. Ignoring the provided inverse."
     return CVIApproximationDeltaFnRuleLayout()
 end

--- a/src/rules/delta/cvi/in.jl
+++ b/src/rules/delta/cvi/in.jl
@@ -1,6 +1,6 @@
 using Random
 import Distributions: Distribution
 
-@rule DeltaFn((:in, k), Marginalisation) (q_ins::FactorizedJoint, m_in::Any, meta::DeltaMeta{M}) where {M <: CVIApproximation} = begin
+@rule DeltaFn((:in, k), Marginalisation) (q_ins::FactorizedJoint, m_in::Any, meta::DeltaMeta{M}) where {M <: CVI} = begin
     return convert(Distribution, naturalparams(q_ins[k]) - naturalparams(m_in))
 end

--- a/src/rules/delta/cvi/marginals.jl
+++ b/src/rules/delta/cvi/marginals.jl
@@ -3,7 +3,12 @@ import Distributions: Distribution
 
 @marginalrule DeltaFn(:ins) (m_out::Any, m_ins::ManyOf{1, Any}, meta::DeltaMeta{M}) where {M <: CVI} = begin
     g = getnodefn(Val(:out))
-    q = convert(Distribution, prod(getmethod(meta), (z) -> logpdf(m_out, g(z)), first(m_ins)))
+
+    # Create an `AbstractContinuousGenericLogPdf` with an unspecified domain and the transformed `logpdf` function
+    F = promote_variate_type(variate_form(first(m_ins)), AbstractContinuousGenericLogPdf)
+    f = convert(F, UnspecifiedDomain(), (z) -> logpdf(m_out, g(z)))
+    q = prod(getmethod(meta), f, first(m_ins))
+    
     return FactorizedJoint((q,))
 end
 
@@ -12,7 +17,7 @@ end
     rng = something(method.rng, Random.GLOBAL_RNG)
     pre_samples = zip(map(m_in_k -> cvilinearize(rand(rng, m_in_k, method.n_samples)), m_ins)...)
 
-    logp_nc_drop_index = let g = getnodefn(Val(:out))
+    logp_nc_drop_index = let g = getnodefn(Val(:out)), pre_samples = pre_samples
         (z, i, pre_samples) -> begin
             samples = map(ttuple -> TupleTools.insertat(ttuple, i, (z,)), pre_samples)
             t_samples = map(s -> g(s...), samples)
@@ -21,7 +26,17 @@ end
         end
     end
 
-    optimize_natural_parameters = (i, pre_samples) -> prod(method, (z) -> logp_nc_drop_index(z, i, pre_samples), m_ins[i])
+    
+    optimize_natural_parameters = let method = method, m_ins = m_ins, logp_nc_drop_index = logp_nc_drop_index
+        (i, pre_samples) -> begin 
+            # Create an `AbstractContinuousGenericLogPdf` with an unspecified domain and the transformed `logpdf` function
+            df = let i = i, pre_samples = pre_samples, logp_nc_drop_index = logp_nc_drop_index
+                (z) -> logp_nc_drop_index(z, i, pre_samples)
+            end
+            logp = convert(promote_variate_type(variate_form(first(m_ins)), AbstractContinuousGenericLogPdf), UnspecifiedDomain(), df)
+            return prod(method, logp, m_ins[i])
+        end
+    end
 
-    return FactorizedJoint(ntuple(i -> convert(Distribution, optimize_natural_parameters(i, pre_samples)), length(m_ins)))
+    return FactorizedJoint(ntuple(i -> optimize_natural_parameters(i, pre_samples), length(m_ins)))
 end

--- a/src/rules/delta/cvi/marginals.jl
+++ b/src/rules/delta/cvi/marginals.jl
@@ -8,7 +8,7 @@ import Distributions: Distribution
     F = promote_variate_type(variate_form(first(m_ins)), AbstractContinuousGenericLogPdf)
     f = convert(F, UnspecifiedDomain(), (z) -> logpdf(m_out, g(z)))
     q = prod(getmethod(meta), f, first(m_ins))
-    
+
     return FactorizedJoint((q,))
 end
 
@@ -26,9 +26,8 @@ end
         end
     end
 
-    
     optimize_natural_parameters = let method = method, m_ins = m_ins, logp_nc_drop_index = logp_nc_drop_index
-        (i, pre_samples) -> begin 
+        (i, pre_samples) -> begin
             # Create an `AbstractContinuousGenericLogPdf` with an unspecified domain and the transformed `logpdf` function
             df = let i = i, pre_samples = pre_samples, logp_nc_drop_index = logp_nc_drop_index
                 (z) -> logp_nc_drop_index(z, i, pre_samples)

--- a/src/rules/delta/cvi/out.jl
+++ b/src/rules/delta/cvi/out.jl
@@ -1,5 +1,5 @@
 
-@rule DeltaFn(:out, Marginalisation) (q_ins::FactorizedJoint{P}, meta::DeltaMeta{M}) where {P <: NTuple{1}, M <: CVIApproximation} = begin
+@rule DeltaFn(:out, Marginalisation) (q_ins::FactorizedJoint{P}, meta::DeltaMeta{M}) where {P <: NTuple{1}, M <: CVI} = begin
     method            = getmethod(meta)
     q_sample_friendly = ReactiveMP.logpdf_sample_friendly(q_ins[1])[2]
     rng               = something(method.rng, Random.GLOBAL_RNG)
@@ -8,7 +8,7 @@
     return ProdFinal(SampleList(q_out))
 end
 
-@rule DeltaFn(:out, Marginalisation) (q_ins::FactorizedJoint, meta::DeltaMeta{M}) where {M <: CVIApproximation} = begin
+@rule DeltaFn(:out, Marginalisation) (q_ins::FactorizedJoint, meta::DeltaMeta{M}) where {M <: CVI} = begin
     method = getmethod(meta)
     q_ins_sample_friendly = map(marginal -> ReactiveMP.logpdf_sample_friendly(marginal)[2], getmultipliers(q_ins))
     rng = something(method.rng, Random.GLOBAL_RNG)

--- a/test/approximations/test_cvi.jl
+++ b/test/approximations/test_cvi.jl
@@ -193,7 +193,7 @@ end
             seed = 123
             rng = StableRNG(seed)
             optimizer = Descent(0.001)
-            meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), 1, Val(false), false)
+            meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), 10, Val(false), false)
             for i in 1:3
                 m_out, m_in = MvGaussianMeanCovariance(fill(i, 2)), MvGaussianMeanCovariance(zeros(2))
                 g_cvi1 = Base.@invoke prod(meta::CVI, (ContinuousMultivariateLogPdf(2, (x) -> logpdf(m_out, x)))::AbstractContinuousGenericLogPdf, m_in::Any)

--- a/test/approximations/test_cvi.jl
+++ b/test/approximations/test_cvi.jl
@@ -121,6 +121,30 @@ end
         end
     end
 
+    @testset "cvi `prod` tests (n_gradpoints = 60)" begin
+        rng = StableRNG(42)
+
+        tests = (
+            (method = CVI(StableRNG(42), 1, 600, 60, Descent(0.01), ForwardDiffGrad(), false, true), tol = 2e-1),
+            (method = CVI(StableRNG(42), 1, 600, 60, Descent(0.01), ZygoteGrad(), false, true), tol = 2e-1)
+        )
+
+        # Check several prods against their analytical solutions
+        for test in tests, i in 1:5
+
+            # Univariate `Gamma`
+            g1 = GammaShapeRate(rand(rng) + 1, rand(rng) + 1)
+            g2 = GammaShapeRate(rand(rng) + 1, rand(rng) + 1)
+
+            g_analytical = prod(ProdAnalytical(), g1, g2)
+            g_cvi1 = prod(test[:method], g1, g2)
+            g_cvi2 = prod(test[:method], ContinuousUnivariateLogPdf((x) -> logpdf(g1, x)), g2)
+
+            @test g_cvi1 ≈ g_analytical atol = test[:tol]
+            @test g_cvi2 ≈ g_analytical atol = test[:tol]
+        end
+    end
+
     @testset "Normal x Normal (Log-likelihood preconditioner prod)" begin
         seed = 123
         rng = StableRNG(seed)

--- a/test/approximations/test_cvi.jl
+++ b/test/approximations/test_cvi.jl
@@ -169,7 +169,7 @@ end
             seed = 123
             rng = StableRNG(seed)
             optimizer = Descent(0.001)
-            meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), false, false, false)
+            meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), false, false)
             for i in 1:3
                 m_out, m_in = MvGaussianMeanCovariance(fill(i, 2)), MvGaussianMeanCovariance(zeros(2))
                 g_cvi1 = Base.@invoke prod(meta::CVI, (ContinuousMultivariateLogPdf(2, (x) -> logpdf(m_out, x)))::AbstractContinuousGenericLogPdf, m_in::Any)
@@ -179,5 +179,4 @@ end
         end
     end
 end
-
 end

--- a/test/approximations/test_cvi.jl
+++ b/test/approximations/test_cvi.jl
@@ -169,12 +169,12 @@ end
             seed = 123
             rng = StableRNG(seed)
             optimizer = Descent(0.001)
-            meta = CVI(rng, 1, 5000, optimizer, ZygoteGrad(), true, true)
-
+            meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), false, false, false)
             for i in 1:3
                 m_out, m_in = MvGaussianMeanCovariance(fill(i, 2)), MvGaussianMeanCovariance(zeros(2))
-                λ = Base.@invoke prod(meta::CVI, (ContinuousMultivariateLogPdf(2, (x) -> logpdf(m_out, x)))::AbstractContinuousGenericLogPdf, m_in::Any)
-                @test isapprox(convert(Distribution, λ), MvNormalWeightedMeanPrecision(fill(i, 2), diageye(2) * 2), atol = 0.5)
+                g_cvi1 = Base.@invoke prod(meta::CVI, (ContinuousMultivariateLogPdf(2, (x) -> logpdf(m_out, x)))::AbstractContinuousGenericLogPdf, m_in::Any)
+                g_analytical = MvNormalWeightedMeanPrecision(fill(i, 2), diageye(2) * 2)
+                @test all(isapprox.(mean(g_analytical), mean(g_cvi1), atol = 0.3))
             end
         end
     end

--- a/test/approximations/test_cvi.jl
+++ b/test/approximations/test_cvi.jl
@@ -79,8 +79,8 @@ end
         rng = StableRNG(42)
 
         tests = (
-            (method = CVI(StableRNG(42), 1, 1000, Descent(0.01), ForwardDiffGrad(), false, true), tol = 5e-1),
-            (method = CVI(StableRNG(42), 1, 1000, Descent(0.01), ZygoteGrad(), false, true), tol = 5e-1)
+            (method = CVI(StableRNG(42), 1, 1000, Descent(0.01), ForwardDiffGrad(), 1, Val(true), false), tol = 5e-1),
+            (method = CVI(StableRNG(42), 1, 1000, Descent(0.01), ZygoteGrad(), 1, Val(true), false), tol = 5e-1)
         )
 
         # Check several prods against their analytical solutions
@@ -107,7 +107,7 @@ end
             @test all(isapprox.(mean_var(g_analytical), mean_var(g_cvi2), atol = test[:tol]))
 
             # Multivariate `Normal`
-            if !(ReactiveMP.get_grad(test[:method]) isa ZygoteGrad) # `Zygote` does not support mutations
+            if !(test[:method].grad isa ZygoteGrad) # `Zygote` does not support mutations
                 for d in (2, 3)
                     mn1 = MvNormalMeanCovariance(10 * randn(rng, d), 10 * rand(rng, d))
                     mn2 = MvNormalMeanCovariance(10 * randn(rng, d), 10 * rand(rng, d))
@@ -125,8 +125,8 @@ end
         rng = StableRNG(42)
 
         tests = (
-            (method = CVI(StableRNG(42), 1, 600, 60, Descent(0.01), ForwardDiffGrad(), false, true), tol = 2e-1),
-            (method = CVI(StableRNG(42), 1, 600, 60, Descent(0.01), ZygoteGrad(), false, true), tol = 2e-1)
+            (method = CVI(StableRNG(42), 1, 600, Descent(0.01), ForwardDiffGrad(), 60, Val(true), false), tol = 2e-1),
+            (method = CVI(StableRNG(42), 1, 600, Descent(0.01), ZygoteGrad(), 60, Val(true), false), tol = 2e-1)
         )
 
         # Check several prods against their analytical solutions
@@ -149,7 +149,7 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.01)
-        meta = CVI(rng, 1, 1000, optimizer, ForwardDiffGrad(), false, false)
+        meta = CVI(rng, 1, 1000, optimizer, ForwardDiffGrad(), 1, Val(false), false)
 
         for i in 1:10
             m_out, m_in = NormalMeanVariance(i, 1), NormalMeanVariance(0, 1)
@@ -163,7 +163,7 @@ end
             seed = 123
             rng = StableRNG(seed)
             optimizer = Descent(0.001)
-            meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), false, false)
+            meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), 1, Val(false), false)
 
             for i in 1:3
                 m_out, m_in = NormalMeanVariance(i, 1), NormalMeanVariance(0, 1)
@@ -178,7 +178,7 @@ end
             seed = 123
             rng = StableRNG(seed)
             optimizer = Descent(0.001)
-            meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), false, false)
+            meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), 1, Val(false), false)
 
             for i in 1:3
                 m_out, m_in = MvNormalMeanCovariance([i], [1]), MvNormalMeanCovariance([0], [1])
@@ -193,7 +193,7 @@ end
             seed = 123
             rng = StableRNG(seed)
             optimizer = Descent(0.001)
-            meta = CVI(rng, 1, 5000, 10, optimizer, ForwardDiffGrad(), false, false)
+            meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), 1, Val(false), false)
             for i in 1:3
                 m_out, m_in = MvGaussianMeanCovariance(fill(i, 2)), MvGaussianMeanCovariance(zeros(2))
                 g_cvi1 = Base.@invoke prod(meta::CVI, (ContinuousMultivariateLogPdf(2, (x) -> logpdf(m_out, x)))::AbstractContinuousGenericLogPdf, m_in::Any)

--- a/test/approximations/test_cvi.jl
+++ b/test/approximations/test_cvi.jl
@@ -193,12 +193,12 @@ end
             seed = 123
             rng = StableRNG(seed)
             optimizer = Descent(0.001)
-            meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), false, false)
+            meta = CVI(rng, 1, 5000, 10, optimizer, ForwardDiffGrad(), false, false)
             for i in 1:3
                 m_out, m_in = MvGaussianMeanCovariance(fill(i, 2)), MvGaussianMeanCovariance(zeros(2))
                 g_cvi1 = Base.@invoke prod(meta::CVI, (ContinuousMultivariateLogPdf(2, (x) -> logpdf(m_out, x)))::AbstractContinuousGenericLogPdf, m_in::Any)
                 g_analytical = MvNormalWeightedMeanPrecision(fill(i, 2), diageye(2) * 2)
-                @test all(isapprox.(mean(g_analytical), mean(g_cvi1), atol = 0.3))
+                @test all(isapprox.(mean(g_analytical), mean(g_cvi1), atol = 0.2))
             end
         end
     end

--- a/test/approximations/test_cvi.jl
+++ b/test/approximations/test_cvi.jl
@@ -165,11 +165,11 @@ end
             end
         end
 
-        @testset "MvNormal x MvNormal 2d (Fisher preconditioner prod)" begin
+        @testset "MvNormal x MvNormal 2D (Fisher preconditioner prod)" begin
             seed = 123
             rng = StableRNG(seed)
             optimizer = Descent(0.001)
-            meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), false, true)
+            meta = CVI(rng, 1, 5000, optimizer, ZygoteGrad(), true, true)
 
             for i in 1:3
                 m_out, m_in = MvGaussianMeanCovariance(fill(i, 2)), MvGaussianMeanCovariance(zeros(2))

--- a/test/approximations/test_cvi.jl
+++ b/test/approximations/test_cvi.jl
@@ -7,8 +7,9 @@ using StableRNGs
 using Distributions
 using Zygote
 using Flux
+using DiffResults
 
-import ReactiveMP: naturalparams, NaturalParameters
+import ReactiveMP: naturalparams, NaturalParameters, AbstractContinuousGenericLogPdf
 
 struct EmptyOptimizer end
 
@@ -30,8 +31,8 @@ end
         for (m_in, m_out) in ((NormalMeanVariance(0, 1), NormalMeanVariance(0, 1)), (GammaShapeRate(2, 2), GammaShapeRate(2, 2)), (Bernoulli(0.5), Bernoulli(0.5)))
             opt = EmptyOptimizer()
             meta = CVI(1, 100, opt)
-            λ = prod(meta, (z) -> logpdf(m_out, z), m_in)
-            @test all(mean_var(convert(Distribution, λ)) .== mean_var(m_in))
+            λ = prod(meta, ContinuousUnivariateLogPdf((z) -> logpdf(m_out, z)), m_in)
+            @test all(mean_var(λ) .== mean_var(m_in))
         end
     end
 
@@ -39,8 +40,8 @@ end
         for (m_in, m_out) in ((NormalMeanVariance(0, 1), NormalMeanVariance(0, 1)), (GammaShapeRate(2, 2), GammaShapeRate(2, 2)), (Bernoulli(0.5), Bernoulli(0.5)))
             opt = CountingOptimizer(0)
             meta = CVI(1, 100, opt)
-            λ = prod(meta, (z) -> logpdf(m_out, z), m_in)
-            @test all(mean_var(convert(Distribution, λ)) .== mean_var(m_in))
+            λ = prod(meta, ContinuousUnivariateLogPdf((z) -> logpdf(m_out, z)), m_in)
+            @test all(mean_var(λ) .== mean_var(m_in))
             @test opt.num_its === 100
         end
     end
@@ -48,33 +49,77 @@ end
     @testset "counting lambda optimizer" begin
         for (m_in, m_out) in ((NormalMeanVariance(0, 1), NormalMeanVariance(0, 1)), (GammaShapeRate(2, 2), GammaShapeRate(2, 2)), (Bernoulli(0.5), Bernoulli(0.5)))
             η = naturalparams(m_in)
-            logp_nc = (z) -> logpdf(m_out, z)
             num_its = 0
             opt = (λ, ∇) -> begin
                 num_its += 1
                 return vec(λ)
             end
             meta = CVI(1, 100, opt)
-            λ = prod(meta, (z) -> logpdf(m_out, z), m_in)
-            @test all(mean_var(convert(Distribution, λ)) .== mean_var(m_in))
+            λ = prod(meta, ContinuousUnivariateLogPdf((z) -> logpdf(m_out, z)), m_in)
+            @test all(mean_var(λ) .== mean_var(m_in))
             @test num_its === 100
         end
     end
 
     @testset "counting lambda optimizer (Zygote Grad)" begin
         for (m_in, m_out) in ((NormalMeanVariance(0, 1), NormalMeanVariance(0, 1)), (GammaShapeRate(2, 2), GammaShapeRate(2, 2)), (Bernoulli(0.5), Bernoulli(0.5)))
-            η = naturalparams(m_in)
-            logp_nc = (z) -> logpdf(m_out, z)
             num_its = 0
             opt = (λ, ∇) -> begin
                 num_its += 1
                 return vec(λ)
             end
             meta = CVI(1, 100, opt, ZygoteGrad())
-            λ = prod(meta, (z) -> logpdf(m_out, z), m_in)
-            @test all(mean_var(convert(Distribution, λ)) .== mean_var(m_in))
+            λ = prod(meta, ContinuousUnivariateLogPdf((z) -> logpdf(m_out, z)), m_in)
+            @test all(mean_var(λ) .== mean_var(m_in))
             @test num_its === 100
         end
+    end
+
+    @testset "cvi `prod` tests" begin
+
+        rng = StableRNG(42)
+
+        tests = (
+            (method = CVI(StableRNG(42), 1, 1000, Descent(0.01), ForwardDiffGrad(), false, true), tol = 5e-1),
+            (method = CVI(StableRNG(42), 1, 1000, Descent(0.01), ZygoteGrad(), false, true), tol = 5e-1)
+        )
+
+        # Check several prods against their analytical solutions
+        for test in tests, i in 1:5
+
+            # Univariate `Normal`
+            n1 = NormalMeanVariance(10 * randn(rng), 10 * rand(rng))
+            n2 = NormalMeanVariance(10 * randn(rng), 10 * rand(rng))
+
+            n_analytical = prod(ProdAnalytical(), n1, n2)
+            n_cvi = prod(test[:method], ContinuousUnivariateLogPdf((x) -> logpdf(n1, x)), n2)
+
+            @test n_analytical ≈ n_cvi atol=test[:tol]
+
+            # Univariate `Gamma`
+            g1 = GammaShapeRate(rand(rng) + 1, rand(rng) + 1)
+            g2 = GammaShapeRate(rand(rng) + 1, rand(rng) + 1)
+
+            g_analytical = prod(ProdAnalytical(), g1, g2)
+            g_cvi = prod(test[:method], ContinuousUnivariateLogPdf((x) -> logpdf(g1, x)), g2)
+
+            @test all(isapprox.(mean_var(g_analytical), mean_var(g_cvi), atol = test[:tol]))
+
+            # Multivariate `Normal`
+            if !(ReactiveMP.get_grad(test[:method]) isa ZygoteGrad) # `Zygote` does not support mutations
+                for d in (2, 3)
+                    mn1 = MvNormalMeanCovariance(10 * randn(rng, d), 10 * rand(rng, d))
+                    mn2 = MvNormalMeanCovariance(10 * randn(rng, d), 10 * rand(rng, d))
+
+                    mn_analytical = prod(ProdAnalytical(), mn1, mn2)
+                    mn_cvi = prod(test[:method], ContinuousMultivariateLogPdf(d, (x) -> logpdf(mn1, x)), mn2)
+
+                    @test mn_analytical ≈ mn_cvi atol=test[:tol]
+                end
+            end
+
+        end
+
     end
 
     @testset "Normal x Normal (Log-likelihood preconditioner prod)" begin
@@ -85,12 +130,12 @@ end
 
         for i in 1:10
             m_out, m_in = NormalMeanVariance(i, 1), NormalMeanVariance(0, 1)
-            λ = prod(meta, (z) -> logpdf(m_out, z), m_in)
+            λ = prod(meta, ContinuousUnivariateLogPdf((z) -> logpdf(m_out, z)), m_in)
             @test isapprox(convert(Distribution, λ), NormalWeightedMeanPrecision(i, 2), atol = 0.1)
         end
     end
 
-    @static if VERSION ≥ v"1.7"
+    @static if VERSION ≥ v"1.7" # Base.@invoke is available only in Julia >= 1.7
         @testset "Normal x Normal (Fisher preconditioner prod)" begin
             seed = 123
             rng = StableRNG(seed)
@@ -99,7 +144,7 @@ end
 
             for i in 1:3
                 m_out, m_in = NormalMeanVariance(i, 1), NormalMeanVariance(0, 1)
-                λ = Base.@invoke prod(meta::CVI, ((z) -> logpdf(m_out, z))::Function, m_in::Any)
+                λ = Base.@invoke prod(meta::CVI, (ContinuousUnivariateLogPdf((z) -> logpdf(m_out, z)))::AbstractContinuousGenericLogPdf, m_in::Any)
                 @test isapprox(convert(Distribution, λ), NormalWeightedMeanPrecision(i, 2), atol = 0.5)
             end
         end
@@ -107,3 +152,4 @@ end
 end
 
 end
+

--- a/test/approximations/test_cvi.jl
+++ b/test/approximations/test_cvi.jl
@@ -91,18 +91,20 @@ end
             n2 = NormalMeanVariance(10 * randn(rng), 10 * rand(rng))
 
             n_analytical = prod(ProdAnalytical(), n1, n2)
-            n_cvi = prod(test[:method], ContinuousUnivariateLogPdf((x) -> logpdf(n1, x)), n2)
 
-            @test n_analytical ≈ n_cvi atol = test[:tol]
+            @test prod(test[:method], ContinuousUnivariateLogPdf((x) -> logpdf(n1, x)), n2) ≈ n_analytical atol = test[:tol]
+            @test prod(test[:method], n1, n2) ≈ n_analytical atol = test[:tol]
 
             # Univariate `Gamma`
             g1 = GammaShapeRate(rand(rng) + 1, rand(rng) + 1)
             g2 = GammaShapeRate(rand(rng) + 1, rand(rng) + 1)
 
             g_analytical = prod(ProdAnalytical(), g1, g2)
-            g_cvi = prod(test[:method], ContinuousUnivariateLogPdf((x) -> logpdf(g1, x)), g2)
+            g_cvi1 = prod(test[:method], g1, g2)
+            g_cvi2 = prod(test[:method], ContinuousUnivariateLogPdf((x) -> logpdf(g1, x)), g2)
 
-            @test all(isapprox.(mean_var(g_analytical), mean_var(g_cvi), atol = test[:tol]))
+            @test all(isapprox.(mean_var(g_analytical), mean_var(g_cvi1), atol = test[:tol]))
+            @test all(isapprox.(mean_var(g_analytical), mean_var(g_cvi2), atol = test[:tol]))
 
             # Multivariate `Normal`
             if !(ReactiveMP.get_grad(test[:method]) isa ZygoteGrad) # `Zygote` does not support mutations
@@ -111,9 +113,9 @@ end
                     mn2 = MvNormalMeanCovariance(10 * randn(rng, d), 10 * rand(rng, d))
 
                     mn_analytical = prod(ProdAnalytical(), mn1, mn2)
-                    mn_cvi = prod(test[:method], ContinuousMultivariateLogPdf(d, (x) -> logpdf(mn1, x)), mn2)
 
-                    @test mn_analytical ≈ mn_cvi atol = test[:tol]
+                    @test prod(test[:method], mn1, mn2) ≈ mn_analytical atol = test[:tol]
+                    @test prod(test[:method], ContinuousMultivariateLogPdf(d, (x) -> logpdf(mn1, x)), mn2) ≈ mn_analytical atol = test[:tol]
                 end
             end
         end

--- a/test/approximations/test_cvi.jl
+++ b/test/approximations/test_cvi.jl
@@ -76,7 +76,6 @@ end
     end
 
     @testset "cvi `prod` tests" begin
-
         rng = StableRNG(42)
 
         tests = (
@@ -94,7 +93,7 @@ end
             n_analytical = prod(ProdAnalytical(), n1, n2)
             n_cvi = prod(test[:method], ContinuousUnivariateLogPdf((x) -> logpdf(n1, x)), n2)
 
-            @test n_analytical ≈ n_cvi atol=test[:tol]
+            @test n_analytical ≈ n_cvi atol = test[:tol]
 
             # Univariate `Gamma`
             g1 = GammaShapeRate(rand(rng) + 1, rand(rng) + 1)
@@ -114,12 +113,10 @@ end
                     mn_analytical = prod(ProdAnalytical(), mn1, mn2)
                     mn_cvi = prod(test[:method], ContinuousMultivariateLogPdf(d, (x) -> logpdf(mn1, x)), mn2)
 
-                    @test mn_analytical ≈ mn_cvi atol=test[:tol]
+                    @test mn_analytical ≈ mn_cvi atol = test[:tol]
                 end
             end
-
         end
-
     end
 
     @testset "Normal x Normal (Log-likelihood preconditioner prod)" begin
@@ -152,4 +149,3 @@ end
 end
 
 end
-

--- a/test/approximations/test_fisher_matrix.jl
+++ b/test/approximations/test_fisher_matrix.jl
@@ -1,0 +1,38 @@
+module ReactiveMPRenderCVITest
+
+using Test
+using ReactiveMP
+using Random
+using StableRNGs
+using Distributions
+using SpecialFunctions
+
+import ReactiveMP: naturalparams, NaturalParameters, AbstractContinuousGenericLogPdf
+
+struct EmptyOptimizer end
+
+function ReactiveMP.cvi_update!(::EmptyOptimizer, λ, ∇)
+    return vec(λ)
+end
+
+function informationmatrix(dist::GammaShapeRate)
+    return [polygamma(1, shape(dist)) -1/rate(dist); -1/rate(dist) shape(dist)/rate(dist)^2]
+end
+
+@testset "cvi:informationmatrix" begin
+    @testset "GammaShapeRate" begin
+        seed = 123
+        rng = StableRNG(seed)
+        meta = CVI(rng, 1, 5000, EmptyOptimizer(), ForwardDiffGrad(), false, false, false)
+        for i in 1:100
+            for j in 1:100
+                gammashaperate = GammaShapeRate(i, j)
+                params = vec(naturalparams(gammashaperate))
+                estimated_fisher_matrix = ReactiveMP.compute_fisher_matrix(meta, ReactiveMP.GammaNaturalParameters, params)
+                @test [1 0; 0 -1]' * estimated_fisher_matrix * [1 0; 0 -1] ≈ informationmatrix(gammashaperate)
+            end
+        end
+    end
+end
+
+end

--- a/test/distributions/test_normal.jl
+++ b/test/distributions/test_normal.jl
@@ -288,7 +288,7 @@ import ReactiveMP: convert_eltype
         end
 
         @testset "lognormalizer" begin
-            @test lognormalizer(UnivariateNormalNaturalParameters(1, -2)) ≈ (log(2) - 1 / 8)
+            @test lognormalizer(UnivariateNormalNaturalParameters(1, -2)) ≈ -(log(2) - 1 / 8)
         end
 
         @testset "logpdf" begin

--- a/test/distributions/test_normal.jl
+++ b/test/distributions/test_normal.jl
@@ -332,7 +332,7 @@ import ReactiveMP: convert_eltype
 
         @testset "lognormalizer" begin
             mt = zeros(Float64, 1, 1) .- 2.0
-            @test lognormalizer(MultivariateNormalNaturalParameters([1], mt)) ≈ (log(2) - 1 / 8)
+            @test lognormalizer(MultivariateNormalNaturalParameters([1], mt)) ≈ -(log(2) - 1 / 8)
         end
 
         @testset "isproper" begin

--- a/test/nodes/delta/cvi/test_cvi.jl
+++ b/test/nodes/delta/cvi/test_cvi.jl
@@ -6,6 +6,7 @@ using Random
 using StableRNGs
 using Distributions
 using Zygote
+using Flux
 
 import ReactiveMP: naturalparams, NaturalParameters
 
@@ -73,6 +74,32 @@ end
             λ = prod(meta, (z) -> logpdf(m_out, z), m_in)
             @test all(mean_var(convert(Distribution, λ)) .== mean_var(m_in))
             @test num_its === 100
+        end
+    end
+
+    @testset "Normal x Normal (Specific prod)" begin
+        seed = 123
+        rng = StableRNG(seed)
+        optimizer = Descent(0.01)
+        meta = CVI(rng, 1, 1000, optimizer, ForwardDiffGrad(), false, false)
+
+        for i in 1:10
+            m_out, m_in = NormalMeanVariance(i, 1), NormalMeanVariance(0, 1)
+            λ = prod(meta, (z) -> logpdf(m_out, z), m_in)
+            @test isapprox(convert(Distribution, λ), NormalWeightedMeanPrecision(i, 2), atol = 0.1)
+        end
+    end
+
+    @testset "Normal x Normal (Generic prod)" begin
+        seed = 123
+        rng = StableRNG(seed)
+        optimizer = Descent(0.001)
+        meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), false, false)
+
+        for i in 1:3
+            m_out, m_in = NormalMeanVariance(i, 1), NormalMeanVariance(0, 1)
+            λ = Base.@invoke prod(meta::CVI, ((z) -> logpdf(m_out, z))::Function, m_in::Any)
+            @test isapprox(convert(Distribution, λ), NormalWeightedMeanPrecision(i, 2), atol = 0.5)
         end
     end
 end

--- a/test/nodes/delta/cvi/test_cvi.jl
+++ b/test/nodes/delta/cvi/test_cvi.jl
@@ -77,7 +77,7 @@ end
         end
     end
 
-    @testset "Normal x Normal (Specific prod)" begin
+    @testset "Normal x Normal (Log-likelihood preconditioner prod)" begin
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.01)
@@ -90,7 +90,7 @@ end
         end
     end
 
-    @testset "Normal x Normal (Generic prod)" begin
+    @testset "Normal x Normal (Fisher preconditioner prod)" begin
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.001)

--- a/test/nodes/delta/cvi/test_cvi.jl
+++ b/test/nodes/delta/cvi/test_cvi.jl
@@ -90,16 +90,18 @@ end
         end
     end
 
-    @testset "Normal x Normal (Fisher preconditioner prod)" begin
-        seed = 123
-        rng = StableRNG(seed)
-        optimizer = Descent(0.001)
-        meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), false, false)
+    @static if VERSION ≥ v"1.7"
+        @testset "Normal x Normal (Fisher preconditioner prod)" begin
+            seed = 123
+            rng = StableRNG(seed)
+            optimizer = Descent(0.001)
+            meta = CVI(rng, 1, 5000, optimizer, ForwardDiffGrad(), false, false)
 
-        for i in 1:3
-            m_out, m_in = NormalMeanVariance(i, 1), NormalMeanVariance(0, 1)
-            λ = Base.@invoke prod(meta::CVI, ((z) -> logpdf(m_out, z))::Function, m_in::Any)
-            @test isapprox(convert(Distribution, λ), NormalWeightedMeanPrecision(i, 2), atol = 0.5)
+            for i in 1:3
+                m_out, m_in = NormalMeanVariance(i, 1), NormalMeanVariance(0, 1)
+                λ = Base.@invoke prod(meta::CVI, ((z) -> logpdf(m_out, z))::Function, m_in::Any)
+                @test isapprox(convert(Distribution, λ), NormalWeightedMeanPrecision(i, 2), atol = 0.5)
+            end
         end
     end
 end

--- a/test/rules/delta/cvi/test_in.jl
+++ b/test/rules/delta/cvi/test_in.jl
@@ -13,9 +13,34 @@ g(x) = x
 struct EmptyOptimizer end
 
 @testset "rules:Delta:cvi:in" begin
-    @test_rules [with_float_conversions = false] DeltaFn{g}((:in, k = 1), Marginalisation) [(
-        input = (q_ins = FactorizedJoint((NormalMeanVariance(),)), m_in = NormalMeanVariance(1, 2), meta = DeltaMeta(method = CVIApproximation(1, 1, EmptyOptimizer()))),
-        output = NormalWeightedMeanPrecision(-0.5, 0.5)
-    )]
+    @test_rules [with_float_conversions = false] DeltaFn{g}((:in, k = 1), Marginalisation) [
+        (
+            input = (q_ins = FactorizedJoint((NormalMeanVariance(),)), m_in = NormalMeanVariance(1, 2), meta = DeltaMeta(method = CVIApproximation(1, 1, EmptyOptimizer()))),
+            output = NormalWeightedMeanPrecision(-0.5, 0.5)
+        ),
+        (
+            input = (q_ins = FactorizedJoint((GammaShapeRate(2, 2),)), m_in = GammaShapeRate(1, 1), meta = DeltaMeta(method = CVIApproximation(1, 1, EmptyOptimizer()))),
+            output = GammaShapeRate(2.0, 1.0)
+        )
+    ]
+
+    @test_rules [with_float_conversions = false] DeltaFn{g}((:in, k = 2), Marginalisation) [
+        (
+            input = (
+                q_ins = FactorizedJoint((GammaShapeRate(2, 2), NormalMeanVariance())),
+                m_in = NormalMeanVariance(1, 2),
+                meta = DeltaMeta(method = CVIApproximation(1, 1, EmptyOptimizer()))
+            ),
+            output = NormalWeightedMeanPrecision(-0.5, 0.5)
+        ),
+        (
+            input = (
+                q_ins = FactorizedJoint((NormalMeanVariance(), GammaShapeRate(2, 2))),
+                m_in = GammaShapeRate(1, 1),
+                meta = DeltaMeta(method = CVIApproximation(1, 1, EmptyOptimizer()))
+            ),
+            output = GammaShapeRate(2.0, 1.0)
+        )
+    ]
 end # testset
 end # module

--- a/test/rules/delta/cvi/test_in.jl
+++ b/test/rules/delta/cvi/test_in.jl
@@ -15,11 +15,11 @@ struct EmptyOptimizer end
 @testset "rules:Delta:cvi:in" begin
     @test_rules [with_float_conversions = false] DeltaFn{g}((:in, k = 1), Marginalisation) [
         (
-            input = (q_ins = FactorizedJoint((NormalMeanVariance(),)), m_in = NormalMeanVariance(1, 2), meta = DeltaMeta(method = CVIApproximation(1, 1, EmptyOptimizer()))),
+            input = (q_ins = FactorizedJoint((NormalMeanVariance(),)), m_in = NormalMeanVariance(1, 2), meta = DeltaMeta(method = CVI(1, 1, EmptyOptimizer()))),
             output = NormalWeightedMeanPrecision(-0.5, 0.5)
         ),
         (
-            input = (q_ins = FactorizedJoint((GammaShapeRate(2, 2),)), m_in = GammaShapeRate(1, 1), meta = DeltaMeta(method = CVIApproximation(1, 1, EmptyOptimizer()))),
+            input = (q_ins = FactorizedJoint((GammaShapeRate(2, 2),)), m_in = GammaShapeRate(1, 1), meta = DeltaMeta(method = CVI(1, 1, EmptyOptimizer()))),
             output = GammaShapeRate(2.0, 1.0)
         )
     ]
@@ -27,18 +27,12 @@ struct EmptyOptimizer end
     @test_rules [with_float_conversions = false] DeltaFn{g}((:in, k = 2), Marginalisation) [
         (
             input = (
-                q_ins = FactorizedJoint((GammaShapeRate(2, 2), NormalMeanVariance())),
-                m_in = NormalMeanVariance(1, 2),
-                meta = DeltaMeta(method = CVIApproximation(1, 1, EmptyOptimizer()))
+                q_ins = FactorizedJoint((GammaShapeRate(2, 2), NormalMeanVariance())), m_in = NormalMeanVariance(1, 2), meta = DeltaMeta(method = CVI(1, 1, EmptyOptimizer()))
             ),
             output = NormalWeightedMeanPrecision(-0.5, 0.5)
         ),
         (
-            input = (
-                q_ins = FactorizedJoint((NormalMeanVariance(), GammaShapeRate(2, 2))),
-                m_in = GammaShapeRate(1, 1),
-                meta = DeltaMeta(method = CVIApproximation(1, 1, EmptyOptimizer()))
-            ),
+            input = (q_ins = FactorizedJoint((NormalMeanVariance(), GammaShapeRate(2, 2))), m_in = GammaShapeRate(1, 1), meta = DeltaMeta(method = CVI(1, 1, EmptyOptimizer()))),
             output = GammaShapeRate(2.0, 1.0)
         )
     ]

--- a/test/rules/delta/cvi/test_marginals.jl
+++ b/test/rules/delta/cvi/test_marginals.jl
@@ -11,16 +11,6 @@ using StableRNGs
 import ReactiveMP: @test_marginalrules
 import ReactiveMP: FactorizedJoint, getmultipliers
 
-struct ZygoteGrad end
-
-function ReactiveMP.compute_grad(::ZygoteGrad, A::F, vec_params) where {F}
-    Zygote.gradient(A, vec_params)[1]
-end
-
-function ReactiveMP.compute_hessian(::ZygoteGrad, A::G, ::F, vec_params) where {G, F}
-    Zygote.hessian(A, vec_params)
-end
-
 add_1 = (x::Real) -> x + 1
 
 function two_into_one(x::Real, y::Real)

--- a/test/rules/delta/cvi/test_marginals.jl
+++ b/test/rules/delta/cvi/test_marginals.jl
@@ -105,7 +105,7 @@ end
 
         @test_marginalrules [with_float_conversions = false, atol = 0.2] DeltaFn{identity}(:ins) [
             (input = (m_out = GammaShapeRate(1, 1), m_ins = ManyOf(GammaShapeRate(1, 1)), meta = test_meta), output = FactorizedJoint((GammaShapeRate(1, 2),))),
-            (input = (m_out = GammaShapeRate(1, 1), m_ins = ManyOf(GammaShapeRate(1, 2)), meta = test_meta), output = FactorizedJoint((GammaShapeRate(1, 3),))),
+            (input = (m_out = GammaShapeRate(1, 1), m_ins = ManyOf(GammaShapeRate(1, 2)), meta = test_meta), output = FactorizedJoint((GammaShapeRate(1, 3),)))
         ]
 
         seed = 123

--- a/test/rules/delta/cvi/test_marginals.jl
+++ b/test/rules/delta/cvi/test_marginals.jl
@@ -26,7 +26,7 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.01)
-        test_meta = DeltaMeta(method = CVI(rng, 1, 500, optimizer, ForwardDiffGrad(), false, false))
+        test_meta = DeltaMeta(method = CVI(rng, 1, 500, optimizer, ForwardDiffGrad(), 1, Val(false), false))
         @test_marginalrules [with_float_conversions = false, atol = 0.1] DeltaFn{identity}(:ins) [
             (
                 input = (m_out = NormalMeanVariance(1, 1), m_ins = ManyOf(NormalMeanVariance()), meta = test_meta),
@@ -46,7 +46,7 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.01)
-        test_meta = DeltaMeta(method = CVI(rng, 1, 500, optimizer, ForwardDiffGrad(), false, true))
+        test_meta = DeltaMeta(method = CVI(rng, 1, 500, optimizer, ForwardDiffGrad(), 1, Val(true), false))
         @test_marginalrules [with_float_conversions = false, atol = 0.1] DeltaFn{identity}(:ins) [
             (
                 input = (m_out = NormalMeanVariance(1, 1), m_ins = ManyOf(NormalMeanVariance()), meta = test_meta),
@@ -70,7 +70,7 @@ end
                 input = (
                     m_out = NormalMeanVariance(1, 1),
                     m_ins = ManyOf(NormalMeanVariance()),
-                    meta = DeltaMeta(method = CVI(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), false, false))
+                    meta = DeltaMeta(method = CVI(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), 1, Val(false), false))
                 ),
                 output = FactorizedJoint((NormalWeightedMeanPrecision(1.0, 2.0),))
             ),
@@ -78,7 +78,7 @@ end
                 input = (
                     m_out = NormalMeanVariance(2, 1),
                     m_ins = ManyOf(NormalMeanVariance()),
-                    meta = DeltaMeta(method = CVI(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), false, false))
+                    meta = DeltaMeta(method = CVI(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), 1, Val(false), false))
                 ),
                 output = FactorizedJoint((NormalWeightedMeanPrecision(2.0, 2.0),))
             ),
@@ -86,7 +86,7 @@ end
                 input = (
                     m_out = NormalMeanVariance(10, 1),
                     m_ins = ManyOf(NormalMeanVariance()),
-                    meta = DeltaMeta(method = CVI(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), false, false))
+                    meta = DeltaMeta(method = CVI(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), 1, Val(false), false))
                 ),
                 output = FactorizedJoint((NormalWeightedMeanPrecision(10.0, 2.0),))
             )
@@ -96,7 +96,7 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.01)
-        test_meta = DeltaMeta(method = CVI(rng, 1, 1000, optimizer, ForwardDiffGrad(), false, false))
+        test_meta = DeltaMeta(method = CVI(rng, 1, 1000, optimizer, ForwardDiffGrad(), 1, Val(false), false))
         @test_marginalrules [with_float_conversions = false, atol = 0.1] DeltaFn{identity}(:ins) [
             (
                 input = (m_out = MvGaussianMeanCovariance(ones(2)), m_ins = ManyOf(MvGaussianMeanCovariance(zeros(2))), meta = test_meta),
@@ -116,7 +116,7 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.01)
-        test_meta = DeltaMeta(method = CVI(rng, 1, 500, optimizer, ForwardDiffGrad(), false, false))
+        test_meta = DeltaMeta(method = CVI(rng, 1, 500, optimizer, ForwardDiffGrad(), 1, Val(false), false))
         @test_marginalrules [with_float_conversions = false, atol = 0.1] DeltaFn{add_1}(:ins) [
             (input = (m_out = NormalMeanVariance(1, 1), m_ins = ManyOf(NormalMeanVariance()), meta = test_meta), output = FactorizedJoint((NormalWeightedMeanPrecision(0, 2.0),))),
             (input = (m_out = NormalMeanVariance(2, 1), m_ins = ManyOf(NormalMeanVariance()), meta = test_meta), output = FactorizedJoint((NormalWeightedMeanPrecision(1, 2.0),))),
@@ -128,7 +128,7 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.01)
-        test_meta = DeltaMeta(method = CVI(rng, 1, 2000, optimizer, ForwardDiffGrad(), false, false))
+        test_meta = DeltaMeta(method = CVI(rng, 1, 2000, optimizer, ForwardDiffGrad(), 1, Val(false), false))
         @test_marginalrules [with_float_conversions = false, atol = 0.1] DeltaFn{two_into_one}(:ins) [(
             input = (m_out = MvGaussianMeanCovariance(ones(2), [2 0; 0 2]), m_ins = ManyOf(NormalMeanVariance(), NormalMeanVariance(1, 2)), meta = test_meta),
             output = FactorizedJoint((NormalWeightedMeanPrecision(1 / 2, 1.5), NormalWeightedMeanPrecision(1.0, 1.0)))
@@ -139,7 +139,7 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.001)
-        test_meta = DeltaMeta(method = CVI(rng, 1, 10000, optimizer, ForwardDiffGrad(), false, false))
+        test_meta = DeltaMeta(method = CVI(rng, 1, 10000, optimizer, ForwardDiffGrad(), 1, Val(false), false))
 
         @test_marginalrules [with_float_conversions = false, atol = 0.1] DeltaFn{extract_coordinate}(:ins) [(
             input = (m_out = NormalMeanVariance(0, 1), m_ins = ManyOf(MvGaussianMeanCovariance(ones(2), [1 0; 0 1])), meta = test_meta),
@@ -151,14 +151,13 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Flux.Descent(0.01)
-        test_meta = DeltaMeta(method = CVI(rng, 1, 1000, optimizer, ForwardDiffGrad(), false, true))
+        test_meta = DeltaMeta(method = CVI(rng, 1, 1000, optimizer, ForwardDiffGrad(), 1, Val(true), false))
 
         @test_marginalrules [with_float_conversions = false, atol = 0.2] DeltaFn{identity}(:ins) [
             (input = (m_out = GammaShapeRate(1, 1), m_ins = ManyOf(GammaShapeRate(1, 1)), meta = test_meta), output = FactorizedJoint((GammaShapeRate(1, 2),))),
             (input = (m_out = GammaShapeRate(1, 1), m_ins = ManyOf(GammaShapeRate(1, 2)), meta = test_meta), output = FactorizedJoint((GammaShapeRate(1, 3),)))
         ]
 
-        seed = 123
         @test_marginalrules [with_float_conversions = false, atol = 0.3] DeltaFn{identity}(:ins) [
             (
                 input = (

--- a/test/rules/delta/cvi/test_marginals.jl
+++ b/test/rules/delta/cvi/test_marginals.jl
@@ -26,7 +26,7 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.01)
-        test_meta = DeltaMeta(method = CVIApproximation(rng, 1, 500, optimizer, ForwardDiffGrad(), false, false))
+        test_meta = DeltaMeta(method = CVI(rng, 1, 500, optimizer, ForwardDiffGrad(), false, false))
         @test_marginalrules [with_float_conversions = false, atol = 0.1] DeltaFn{identity}(:ins) [
             (
                 input = (m_out = NormalMeanVariance(1, 1), m_ins = ManyOf(NormalMeanVariance()), meta = test_meta),
@@ -46,7 +46,7 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.01)
-        test_meta = DeltaMeta(method = CVIApproximation(rng, 1, 500, optimizer, ForwardDiffGrad(), false, true))
+        test_meta = DeltaMeta(method = CVI(rng, 1, 500, optimizer, ForwardDiffGrad(), false, true))
         @test_marginalrules [with_float_conversions = false, atol = 0.1] DeltaFn{identity}(:ins) [
             (
                 input = (m_out = NormalMeanVariance(1, 1), m_ins = ManyOf(NormalMeanVariance()), meta = test_meta),
@@ -70,7 +70,7 @@ end
                 input = (
                     m_out = NormalMeanVariance(1, 1),
                     m_ins = ManyOf(NormalMeanVariance()),
-                    meta = DeltaMeta(method = CVIApproximation(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), false, false))
+                    meta = DeltaMeta(method = CVI(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), false, false))
                 ),
                 output = FactorizedJoint((NormalWeightedMeanPrecision(1.0, 2.0),))
             ),
@@ -78,7 +78,7 @@ end
                 input = (
                     m_out = NormalMeanVariance(2, 1),
                     m_ins = ManyOf(NormalMeanVariance()),
-                    meta = DeltaMeta(method = CVIApproximation(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), false, false))
+                    meta = DeltaMeta(method = CVI(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), false, false))
                 ),
                 output = FactorizedJoint((NormalWeightedMeanPrecision(2.0, 2.0),))
             ),
@@ -86,7 +86,7 @@ end
                 input = (
                     m_out = NormalMeanVariance(10, 1),
                     m_ins = ManyOf(NormalMeanVariance()),
-                    meta = DeltaMeta(method = CVIApproximation(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), false, false))
+                    meta = DeltaMeta(method = CVI(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), false, false))
                 ),
                 output = FactorizedJoint((NormalWeightedMeanPrecision(10.0, 2.0),))
             )
@@ -96,7 +96,7 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.01)
-        test_meta = DeltaMeta(method = CVIApproximation(rng, 1, 1000, optimizer, ForwardDiffGrad(), false, false))
+        test_meta = DeltaMeta(method = CVI(rng, 1, 1000, optimizer, ForwardDiffGrad(), false, false))
         @test_marginalrules [with_float_conversions = false, atol = 0.1] DeltaFn{identity}(:ins) [
             (
                 input = (m_out = MvGaussianMeanCovariance(ones(2)), m_ins = ManyOf(MvGaussianMeanCovariance(zeros(2))), meta = test_meta),
@@ -116,7 +116,7 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.01)
-        test_meta = DeltaMeta(method = CVIApproximation(rng, 1, 500, optimizer, ForwardDiffGrad(), false, false))
+        test_meta = DeltaMeta(method = CVI(rng, 1, 500, optimizer, ForwardDiffGrad(), false, false))
         @test_marginalrules [with_float_conversions = false, atol = 0.1] DeltaFn{add_1}(:ins) [
             (input = (m_out = NormalMeanVariance(1, 1), m_ins = ManyOf(NormalMeanVariance()), meta = test_meta), output = FactorizedJoint((NormalWeightedMeanPrecision(0, 2.0),))),
             (input = (m_out = NormalMeanVariance(2, 1), m_ins = ManyOf(NormalMeanVariance()), meta = test_meta), output = FactorizedJoint((NormalWeightedMeanPrecision(1, 2.0),))),
@@ -128,7 +128,7 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.01)
-        test_meta = DeltaMeta(method = CVIApproximation(rng, 1, 2000, optimizer, ForwardDiffGrad(), false, false))
+        test_meta = DeltaMeta(method = CVI(rng, 1, 2000, optimizer, ForwardDiffGrad(), false, false))
         @test_marginalrules [with_float_conversions = false, atol = 0.1] DeltaFn{two_into_one}(:ins) [(
             input = (m_out = MvGaussianMeanCovariance(ones(2), [2 0; 0 2]), m_ins = ManyOf(NormalMeanVariance(), NormalMeanVariance(1, 2)), meta = test_meta),
             output = FactorizedJoint((NormalWeightedMeanPrecision(1 / 2, 1.5), NormalWeightedMeanPrecision(1.0, 1.0)))
@@ -139,7 +139,7 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Descent(0.001)
-        test_meta = DeltaMeta(method = CVIApproximation(rng, 1, 10000, optimizer, ForwardDiffGrad(), false, false))
+        test_meta = DeltaMeta(method = CVI(rng, 1, 10000, optimizer, ForwardDiffGrad(), false, false))
 
         @test_marginalrules [with_float_conversions = false, atol = 0.1] DeltaFn{extract_coordinate}(:ins) [(
             input = (m_out = NormalMeanVariance(0, 1), m_ins = ManyOf(MvGaussianMeanCovariance(ones(2), [1 0; 0 1])), meta = test_meta),
@@ -151,7 +151,7 @@ end
         seed = 123
         rng = StableRNG(seed)
         optimizer = Flux.Descent(0.01)
-        test_meta = DeltaMeta(method = CVIApproximation(rng, 1, 1000, optimizer, ForwardDiffGrad(), false, true))
+        test_meta = DeltaMeta(method = CVI(rng, 1, 1000, optimizer, ForwardDiffGrad(), false, true))
 
         @test_marginalrules [with_float_conversions = false, atol = 0.2] DeltaFn{identity}(:ins) [
             (input = (m_out = GammaShapeRate(1, 1), m_ins = ManyOf(GammaShapeRate(1, 1)), meta = test_meta), output = FactorizedJoint((GammaShapeRate(1, 2),))),
@@ -162,17 +162,13 @@ end
         @test_marginalrules [with_float_conversions = false, atol = 0.3] DeltaFn{identity}(:ins) [
             (
                 input = (
-                    m_out = GammaShapeRate(2, 1),
-                    m_ins = ManyOf(GammaShapeRate(1, 2)),
-                    meta = DeltaMeta(method = CVIApproximation(StableRNG(seed), 1, 2000, Flux.Descent(0.001), ZygoteGrad()))
+                    m_out = GammaShapeRate(2, 1), m_ins = ManyOf(GammaShapeRate(1, 2)), meta = DeltaMeta(method = CVI(StableRNG(seed), 1, 2000, Flux.Descent(0.001), ZygoteGrad()))
                 ),
                 output = FactorizedJoint((GammaShapeRate(2, 3),))
             ),
             (
                 input = (
-                    m_out = GammaShapeRate(2, 2),
-                    m_ins = ManyOf(GammaShapeRate(2, 3)),
-                    meta = DeltaMeta(method = CVIApproximation(StableRNG(seed), 1, 5000, Flux.Descent(0.001), ZygoteGrad()))
+                    m_out = GammaShapeRate(2, 2), m_ins = ManyOf(GammaShapeRate(2, 3)), meta = DeltaMeta(method = CVI(StableRNG(seed), 1, 5000, Flux.Descent(0.001), ZygoteGrad()))
                 ),
                 output = FactorizedJoint((GammaShapeRate(3, 5),))
             )

--- a/test/rules/delta/cvi/test_marginals.jl
+++ b/test/rules/delta/cvi/test_marginals.jl
@@ -42,6 +42,36 @@ end
             )
         ]
     end
+    @testset "id, x~Normal, y~Normal (Zygote)" begin
+        seed = 123
+        optimizer = Descent(0.01)
+        @test_marginalrules [with_float_conversions = false, atol = 0.1] DeltaFn{identity}(:ins) [
+            (
+                input = (
+                    m_out = NormalMeanVariance(1, 1),
+                    m_ins = ManyOf(NormalMeanVariance()),
+                    meta = DeltaMeta(method = CVIApproximation(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), false, false))
+                ),
+                output = FactorizedJoint((NormalWeightedMeanPrecision(1.0, 2.0),))
+            ),
+            (
+                input = (
+                    m_out = NormalMeanVariance(2, 1),
+                    m_ins = ManyOf(NormalMeanVariance()),
+                    meta = DeltaMeta(method = CVIApproximation(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), false, false))
+                ),
+                output = FactorizedJoint((NormalWeightedMeanPrecision(2.0, 2.0),))
+            ),
+            (
+                input = (
+                    m_out = NormalMeanVariance(10, 1),
+                    m_ins = ManyOf(NormalMeanVariance()),
+                    meta = DeltaMeta(method = CVIApproximation(StableRNG(seed), 1, 1000, optimizer, ZygoteGrad(), false, false))
+                ),
+                output = FactorizedJoint((NormalWeightedMeanPrecision(10.0, 2.0),))
+            )
+        ]
+    end
     @testset "id, x ~ MvNormal, y ~ MvNormal" begin
         seed = 123
         rng = StableRNG(seed)

--- a/test/rules/delta/cvi/test_marginals.jl
+++ b/test/rules/delta/cvi/test_marginals.jl
@@ -42,6 +42,26 @@ end
             )
         ]
     end
+    @testset "id, x~Normal, y~Normal (proper message)" begin
+        seed = 123
+        rng = StableRNG(seed)
+        optimizer = Descent(0.01)
+        test_meta = DeltaMeta(method = CVIApproximation(rng, 1, 500, optimizer, ForwardDiffGrad(), false, true))
+        @test_marginalrules [with_float_conversions = false, atol = 0.1] DeltaFn{identity}(:ins) [
+            (
+                input = (m_out = NormalMeanVariance(1, 1), m_ins = ManyOf(NormalMeanVariance()), meta = test_meta),
+                output = FactorizedJoint((NormalWeightedMeanPrecision(1.0, 2.0),))
+            ),
+            (
+                input = (m_out = NormalMeanVariance(2, 1), m_ins = ManyOf(NormalMeanVariance()), meta = test_meta),
+                output = FactorizedJoint((NormalWeightedMeanPrecision(2.0, 2.0),))
+            ),
+            (
+                input = (m_out = NormalMeanVariance(10, 1), m_ins = ManyOf(NormalMeanVariance()), meta = test_meta),
+                output = FactorizedJoint((NormalWeightedMeanPrecision(10.0, 2.0),))
+            )
+        ]
+    end
     @testset "id, x~Normal, y~Normal (Zygote)" begin
         seed = 123
         optimizer = Descent(0.01)

--- a/test/rules/delta/cvi/test_marginals.jl
+++ b/test/rules/delta/cvi/test_marginals.jl
@@ -99,12 +99,14 @@ end
     @testset "id, x~Gamma out~Gamma" begin
         seed = 123
         rng = StableRNG(seed)
-        optimizer = Descent(0.005)
-        test_meta = DeltaMeta(method = CVIApproximation(rng, 1, 50000, optimizer))
+        optimizer = Flux.Descent(0.00)
+        test_meta = DeltaMeta(method = CVIApproximation(rng, 1, 10000, optimizer))
 
-        @test_marginalrules [with_float_conversions = false, atol = 0.3] DeltaFn{identity}(:ins) [
+        @test_marginalrules [with_float_conversions = false, atol = 0.2] DeltaFn{identity}(:ins) [
             (input = (m_out = GammaShapeRate(1, 1), m_ins = ManyOf(GammaShapeRate(1, 1)), meta = test_meta), output = FactorizedJoint((GammaShapeRate(1, 2),))),
-            (input = (m_out = GammaShapeRate(1, 1), m_ins = ManyOf(GammaShapeRate(1, 2)), meta = test_meta), output = FactorizedJoint((GammaShapeRate(1, 3),)))
+            (input = (m_out = GammaShapeRate(1, 1), m_ins = ManyOf(GammaShapeRate(1, 2)), meta = test_meta), output = FactorizedJoint((GammaShapeRate(1, 3),))),
+            (input = (m_out = GammaShapeRate(2, 1), m_ins = ManyOf(GammaShapeRate(1, 2)), meta = test_meta), output = FactorizedJoint((GammaShapeRate(2, 3),))),
+            (input = (m_out = GammaShapeRate(2, 1), m_ins = ManyOf(GammaShapeRate(1, 3)), meta = test_meta), output = FactorizedJoint((GammaShapeRate(2, 4),)))
         ]
     end
 end

--- a/test/rules/delta/cvi/test_out.jl
+++ b/test/rules/delta/cvi/test_out.jl
@@ -30,7 +30,7 @@ end
 @testset "rules:Delta:cvi:out" begin
     seed = 123
     rng = MersenneTwister(seed)
-    test_meta = DeltaMeta(method = CVIApproximation(rng, 1000, 1, EmptyOptimizer()))
+    test_meta = DeltaMeta(method = CVI(rng, 1000, 1, EmptyOptimizer()))
 
     @testset "Exact value comparison (Pointmass)" begin
         for i in 1:100

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -210,6 +210,7 @@ end
     addtests(testrunner, "approximations/test_shared.jl")
     addtests(testrunner, "approximations/test_unscented.jl")
     addtests(testrunner, "approximations/test_linearization.jl")
+    addtests(testrunner, "approximations/test_cvi.jl")
 
     addtests(testrunner, "constraints/prod/test_prod_analytical.jl")
     addtests(testrunner, "constraints/prod/test_prod_final.jl")
@@ -248,7 +249,6 @@ end
 
     addtests(testrunner, "test_node.jl")
     addtests(testrunner, "nodes/flow/test_flow.jl")
-    addtests(testrunner, "nodes/delta/cvi/test_cvi.jl")
     addtests(testrunner, "nodes/test_addition.jl")
     addtests(testrunner, "nodes/test_bifm.jl")
     addtests(testrunner, "nodes/test_bifm_helper.jl")


### PR DESCRIPTION
This PR makes the CVI Approximation more stable and a bit more:

1. New optional parameter `proper_message`: ensuring that after the division, the message will be a proper distribution
2. adds more tests for the CVI rules
3. adds  a CVI parameter `grad`: the user can use it to change the differentiation procedure (e.g., compute hessian with Zygote)
4. fixes the lognormalizer/hessian sing issue
5. adds clarification comments
6. rename `render_cvi` -> `prod(approximation::ProdCVI, ...)`
7. the `ForwardDiff`hessian/grade computation use 10% less memory.
8. added a new hyperparameter for the CVI `n_gradpoints`: optional, defaults to 1, the number of points to estimate the likelihood gradient (dist*logp). It radically improves CVI precision (a gamma test to prove it added).