### PR TITLE
Fix bernoulli

### DIFF
--- a/src/distributions/bernoulli.jl
+++ b/src/distributions/bernoulli.jl
@@ -6,7 +6,7 @@ import StatsFuns: logistic
 
 vague(::Type{<:Bernoulli}) = Bernoulli(0.5)
 
-probvec(dist::Bernoulli) = (succprob(dist), failprob(dist))
+probvec(dist::Bernoulli) = (failprob(dist), succprob(dist))
 
 prod_analytical_rule(::Type{<:Bernoulli}, ::Type{<:Bernoulli}) = ProdAnalyticalRuleAvailable()
 

--- a/src/rules/bernoulli/p.jl
+++ b/src/rules/bernoulli/p.jl
@@ -13,6 +13,6 @@ end
 end
 
 @rule Bernoulli(:p, Marginalisation) (q_out::Bernoulli,) = begin
-    r = first(probvec(q_out))
+    r = succprob(q_out)
     return Beta(one(r) + r, 2one(r) - r)
 end

--- a/test/distributions/test_bernoulli.jl
+++ b/test/distributions/test_bernoulli.jl
@@ -19,7 +19,7 @@ using Random
         @test failprob(d) === 0.5
     end
 
-    @testset "prod" begin
+    @testset "prod Bernoulli-Bernoulli" begin
         @test prod(ProdAnalytical(), Bernoulli(0.5), Bernoulli(0.5)) ≈ Bernoulli(0.5)
         @test prod(ProdAnalytical(), Bernoulli(0.1), Bernoulli(0.6)) ≈ Bernoulli(0.14285714285714285)
         @test prod(ProdAnalytical(), Bernoulli(0.78), Bernoulli(0.05)) ≈ Bernoulli(0.1572580645161291)

--- a/test/distributions/test_bernoulli.jl
+++ b/test/distributions/test_bernoulli.jl
@@ -27,8 +27,8 @@ using Random
 
     @testset "probvec" begin
         @test probvec(Bernoulli(0.5)) === (0.5, 0.5)
-        @test probvec(Bernoulli(0.3)) === (0.3, 0.7)
-        @test probvec(Bernoulli(0.6)) === (0.6, 0.4)
+        @test probvec(Bernoulli(0.3)) === (0.7, 0.3)
+        @test probvec(Bernoulli(0.6)) === (0.4, 0.6)
     end
 
     @testset "BernoulliNaturalParameters" begin

--- a/test/distributions/test_common.jl
+++ b/test/distributions/test_common.jl
@@ -11,9 +11,11 @@ using Random
     # Here we test some extra ReactiveMP.jl specific functionality
 
     @testset "Bernoulli × Categorical" begin
-        @test prod(ProdAnalytical(), Bernoulli(0.3), Categorical([1 / 2, 1 / 2])) ≈ prod(ProdAnalytical(), Bernoulli(0.3), Bernoulli(0.5))
-        @test prod(ProdAnalytical(), Bernoulli(0.1), Categorical([0.2, 0.8])) ≈ prod(ProdAnalytical(), Bernoulli(0.1), Bernoulli(0.2))
-        @test prod(ProdAnalytical(), Bernoulli(0.9), Categorical([0.8, 0.2])) ≈ prod(ProdAnalytical(), Bernoulli(0.9), Bernoulli(0.8))
+        @test prod(ProdAnalytical(), Bernoulli(0.5), Categorical([0.5, 0.5])) ≈ Categorical([0.5, 0.5])
+        @test prod(ProdAnalytical(), Bernoulli(0.1), Categorical(0.4, 0.6)) ≈ Categorical([1 - 0.14285714285714285, 0.14285714285714285])
+        @test prod(ProdAnalytical(), Bernoulli(0.78), Categorical([0.95, 0.05])) ≈ Categorical([1 - 0.1572580645161291, 0.1572580645161291])
+        @test prod(ProdAnalytical(), Bernoulli(0.5), Categorical([0.3, 0.3, 0.4])) ≈ Categorical([0.5, 0.5, 0])
+        @test prod(ProdAnalytical(), Bernoulli(0.5), Categorical([1.0])) ≈ Categorical([1.0, 0])
     end
 end
 

--- a/test/nodes/test_normal_mixture.jl
+++ b/test/nodes/test_normal_mixture.jl
@@ -24,8 +24,8 @@ import ReactiveMP: WishartMessage, ManyOf
             )
 
             ref_val =
-                0.2 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[1], q_p[1])), nothing)) +
-                0.8 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[2], q_p[2])), nothing))
+                0.8 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[1], q_p[1])), nothing)) +
+                0.2 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[2], q_p[2])), nothing))
             @test score(AverageEnergy(), NormalMixture, Val{(:out, :switch, :m, :p)}, marginals, nothing) ≈ ref_val
         end
 
@@ -43,8 +43,8 @@ import ReactiveMP: WishartMessage, ManyOf
             )
 
             ref_val =
-                0.4 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[1], q_p[1])), nothing)) +
-                0.6 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[2], q_p[2])), nothing))
+                0.6 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[1], q_p[1])), nothing)) +
+                0.4 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[2], q_p[2])), nothing))
             @test score(AverageEnergy(), NormalMixture, Val{(:out, :switch, :m, :p)}, marginals, nothing) ≈ ref_val
         end
 

--- a/test/rules/normal_mixture/test_m.jl
+++ b/test/rules/normal_mixture/test_m.jl
@@ -10,7 +10,7 @@ import ReactiveMP: @test_rules
 @testset "rules:NormalMixture:m" begin
     @testset "Variational : (m_out::UnivariateNormalDistributionsFamily..., m_p::GammaDistributionsFamily...) k=1" begin
         @test_rules [with_float_conversions = true] NormalMixture{2}((:m, k = 1), Marginalisation) [
-            (input = (q_out = NormalMeanVariance(8.5, 0.5), q_switch = Bernoulli(0.2), q_p = GammaShapeRate(1.0, 2.0)), output = NormalMeanPrecision(8.5, 0.1)),
+            (input = (q_out = NormalMeanVariance(8.5, 0.5), q_switch = Bernoulli(0.8), q_p = GammaShapeRate(1.0, 2.0)), output = NormalMeanPrecision(8.5, 0.1)),
             (
                 input = (q_out = NormalWeightedMeanPrecision(3 / 10, 6 / 10), q_switch = Categorical([0.5, 0.5]), q_p = GammaShapeRate(1.0, 1.0)),
                 output = NormalMeanPrecision(0.5, 0.5)
@@ -25,7 +25,7 @@ import ReactiveMP: @test_rules
 
     @testset "Variational : (m_out::UnivariateNormalDistributionsFamily..., m_p::GammaDistributionsFamily...) k=2" begin
         @test_rules [with_float_conversions = true] NormalMixture{2}((:m, k = 2), Marginalisation) [
-            (input = (q_out = NormalMeanVariance(8.5, 0.5), q_switch = Bernoulli(0.2), q_p = GammaShapeRate(1.0, 2.0)), output = NormalMeanPrecision(8.5, 0.4)),
+            (input = (q_out = NormalMeanVariance(8.5, 0.5), q_switch = Bernoulli(0.8), q_p = GammaShapeRate(1.0, 2.0)), output = NormalMeanPrecision(8.5, 0.4)),
             (
                 input = (q_out = NormalWeightedMeanPrecision(3 / 10, 6 / 10), q_switch = Categorical([0.5, 0.5]), q_p = GammaShapeRate(1.0, 1.0)),
                 output = NormalMeanPrecision(0.5, 0.5)
@@ -60,7 +60,7 @@ import ReactiveMP: @test_rules
 
     @testset "Variational : (m_out::UnivariateNormalDistributionsFamily..., m_p::GammaDistributionsFamily...) k=1" begin
         @test_rules [with_float_conversions = true] NormalMixture{2}((:m, k = 1), Marginalisation) [
-            (input = (q_out = PointMass(8.5), q_switch = Bernoulli(0.2), q_p = GammaShapeRate(1.0, 2.0)), output = NormalMeanPrecision(8.5, 0.1)),
+            (input = (q_out = PointMass(8.5), q_switch = Bernoulli(0.8), q_p = GammaShapeRate(1.0, 2.0)), output = NormalMeanPrecision(8.5, 0.1)),
             (input = (q_out = NormalWeightedMeanPrecision(3 / 10, 6 / 10), q_switch = Categorical([0.5, 0.5]), q_p = PointMass(1.0)), output = NormalMeanPrecision(0.5, 0.5))
         ]
     end

--- a/test/rules/normal_mixture/test_out.jl
+++ b/test/rules/normal_mixture/test_out.jl
@@ -37,7 +37,7 @@ import ReactiveMP: @test_rules
         @test_rules [with_float_conversions = true] NormalMixture{2}(:out, Marginalisation) [
             (
                 input = (
-                    q_switch = Bernoulli(0.2),
+                    q_switch = Bernoulli(0.8),
                     q_m = ManyOf(NormalMeanVariance(5.0, 2.0), NormalMeanVariance(10.0, 3.0)),
                     q_p = ManyOf(GammaShapeRate(1.0, 2.0), GammaShapeRate(2.0, 1.0))
                 ),

--- a/test/rules/normal_mixture/test_p.jl
+++ b/test/rules/normal_mixture/test_p.jl
@@ -11,7 +11,7 @@ import ReactiveMP: WishartMessage
 @testset "rules:NormalMixture:p" begin
     @testset "Variational : (m_out::UnivariateNormalDistributionsFamily..., m_μ::UnivariateNormalDistributionsFamily...) k=1" begin
         @test_rules [with_float_conversions = true] NormalMixture{2}((:p, k = 1), Marginalisation) [
-            (input = (q_out = NormalMeanVariance(8.5, 0.5), q_switch = Bernoulli(0.2), q_m = NormalMeanVariance(5.0, 2.0)), output = GammaShapeRate(1.1, 1.475)),
+            (input = (q_out = NormalMeanVariance(8.5, 0.5), q_switch = Bernoulli(0.8), q_m = NormalMeanVariance(5.0, 2.0)), output = GammaShapeRate(1.1, 1.475)),
             (input = (q_out = NormalMeanVariance(-3, 2.0), q_switch = Bernoulli(0.5), q_m = NormalMeanVariance(5.0, 2.0)), output = GammaShapeRate(1.25, 17.0))
         ]
     end
@@ -19,11 +19,11 @@ import ReactiveMP: WishartMessage
     @testset "Variational : (m_out::MultivariateNormalDistributionsFamily..., m_μ::MultivariateNormalDistributionsFamily...) k=1" begin
         @test_rules [with_float_conversions = true, atol = 1e-4] NormalMixture{2}((:p, k = 1), Marginalisation) [
             (
-                input = (q_out = MvNormalMeanPrecision([8.5], [0.5]), q_switch = Bernoulli(0.2), q_m = MvNormalMeanPrecision([3.0], [0.1])),
+                input = (q_out = MvNormalMeanPrecision([8.5], [0.5]), q_switch = Bernoulli(0.8), q_m = MvNormalMeanPrecision([3.0], [0.1])),
                 output = WishartMessage(2.2, fill(8.45, 1, 1))
             ),
             (
-                input = (q_out = MvNormalMeanPrecision([8.5, 5.1], [0.5 0.1; 0.1 4]), q_switch = Bernoulli(0.2), q_m = MvNormalMeanPrecision([3.0, 10], [0.1 0.2; 0.2 -0.3])),
+                input = (q_out = MvNormalMeanPrecision([8.5, 5.1], [0.5 0.1; 0.1 4]), q_switch = Bernoulli(0.8), q_m = MvNormalMeanPrecision([3.0, 10], [0.1 0.2; 0.2 -0.3])),
                 output = WishartMessage(3.2, [9.59487 -5.97148; -5.97148 5.13797])
             ),
             (


### PR DESCRIPTION
This PR fixes #255.

It has the following contributions:
- Reverses `probvec` of `Bernoulli` such that the ordering coincides with that of a `Categorical`.
- Fixes corresponding bug in `prod` function between `Bernoulli` and `Categorical`.
- Removes limitation of multiplying `Bernoulli` solely with `Categorical` of same size.
- Add/update tests.