### PR TITLE
Rename `AddonProd` for clarity

### DIFF
--- a/src/addons.jl
+++ b/src/addons.jl
@@ -3,7 +3,6 @@ import Base: string, show, +
 import TupleTools
 
 abstract type AbstractAddon end
-abstract type AbstractAddonProd end
 
 multiply_addons(::Nothing, ::Nothing, ::Any, ::Any, ::Any) = nothing
 multiply_addons(::Nothing, addon::Any, ::Any, ::Missing, ::Any) = addon

--- a/src/addons/logscale.jl
+++ b/src/addons/logscale.jl
@@ -10,8 +10,6 @@ end
 
 AddonLogScale() = AddonLogScale(nothing)
 
-struct AddonProdLogScale <: AbstractAddonProd end
-
 getlogscale(addon::AddonLogScale) = addon.logscale
 
 function getlogscale(addons::NTuple{N, AbstractAddon}) where {N}
@@ -61,7 +59,7 @@ function multiply_addons(left_addon::AddonLogScale, right_addon::AddonLogScale, 
     right_logscale = getlogscale(right_addon)
 
     # compute new logscale
-    new_logscale = prod(AddonProdLogScale(), new_dist, left_dist, right_dist)
+    new_logscale = compute_logscale(new_dist, left_dist, right_dist)
 
     # return updated logscale addon
     return AddonLogScale(left_logscale + right_logscale + new_logscale)

--- a/src/addons/memory.jl
+++ b/src/addons/memory.jl
@@ -8,8 +8,6 @@ end
 
 AddonMemory() = AddonMemory(nothing)
 
-struct AddonProdMemory <: AbstractAddonProd end
-
 getmemoryaddon(addons::NTuple{N, AbstractAddon}) where {N} = first(filter(x -> typeof(x) <: AddonMemory, addons))
 getmemory(addon::AddonMemory) = addon.memory
 getmemory(addons::NTuple{N, AbstractAddon}) where {N} = getmemoryaddon(addons).memory
@@ -30,24 +28,24 @@ function message_mapping_addon(::AddonMemory{Nothing}, mapping, messages, margin
 end
 
 function multiply_addons(left_addon::AddonMemory, right_addon::AddonMemory, new_dist, left_dist, right_dist)
-    return AddonMemory(prod(AddonProdMemory(), getmemory(left_addon), getmemory(right_addon)))
+    return AddonMemory(construct_memory(getmemory(left_addon), getmemory(right_addon)))
 end
 
-function prod(::AddonProdMemory, left::AddonMemoryMessageMapping, right::AddonMemoryMessageMapping)
+function construct_memory(left::AddonMemoryMessageMapping, right::AddonMemoryMessageMapping)
     return AddonMemoryProd(Any[left, right])
 end
 
-function prod(::AddonProdMemory, left::AddonMemoryMessageMapping, right::AddonMemoryProd)
+function construct_memory(left::AddonMemoryMessageMapping, right::AddonMemoryProd)
     pushfirst!(right.mappings, left)
     return right
 end
 
-function prod(::AddonProdMemory, left::AddonMemoryProd, right::AddonMemoryMessageMapping)
+function construct_memory(left::AddonMemoryProd, right::AddonMemoryMessageMapping)
     push!(left.mappings, right)
     return left
 end
 
-function prod(::AddonProdMemory, left::AddonMemoryProd, right::AddonMemoryProd)
+function construct_memory(left::AddonMemoryProd, right::AddonMemoryProd)
     append!(left.mappings, right.mappings)
     return left
 end

--- a/src/distributions/bernoulli.jl
+++ b/src/distributions/bernoulli.jl
@@ -47,14 +47,14 @@ function prod(::ProdAnalytical, left::Bernoulli, right::Categorical)
     return Categorical(ReactiveMP.normalize!(p_new, 1))
 end
 
-function prod(::AddonProdLogScale, new_dist::Bernoulli, left_dist::Bernoulli, right_dist::Bernoulli)
+function compute_logscale(new_dist::Bernoulli, left_dist::Bernoulli, right_dist::Bernoulli)
     left_p = succprob(left_dist)
     right_p = succprob(right_dist)
     a = left_p * right_p + (one(left_p) - left_p) * (one(right_p) - right_p)
     return log(a)
 end
 
-function prod(::AddonProdLogScale, new_dist::Categorical, left_dist::Bernoulli, right_dist::Categorical)
+function compute_logscale(new_dist::Categorical, left_dist::Bernoulli, right_dist::Categorical)
     # get probability vectors
     p_left = probvec(left_dist)
     p_right = probvec(right_dist)
@@ -70,7 +70,7 @@ function prod(::AddonProdLogScale, new_dist::Categorical, left_dist::Bernoulli, 
     return log(Z)
 end
 
-prod(::AddonProdLogScale, new_dist::Categorical, left_dist::Categorical, right_dist::Bernoulli) = prod(AddonProdLogScale(), new_dist, right_dist, left_dist)
+compute_logscale(new_dist::Categorical, left_dist::Categorical, right_dist::Bernoulli) = compute_logscale(new_dist, right_dist, left_dist)
 
 struct BernoulliNaturalParameters{T <: Real} <: NaturalParameters
     η::T

--- a/src/distributions/beta.jl
+++ b/src/distributions/beta.jl
@@ -14,7 +14,7 @@ function prod(::ProdAnalytical, left::Beta, right::Beta)
     return Beta(left_a + right_a - one(T), left_b + right_b - one(T))
 end
 
-function prod(::AddonProdLogScale, new_dist::Beta, left_dist::Beta, right_dist::Beta)
+function compute_logscale(new_dist::Beta, left_dist::Beta, right_dist::Beta)
     return logbeta(params(new_dist)...) - logbeta(params(left_dist)...) - logbeta(params(right_dist)...)
 end
 

--- a/src/distributions/categorical.jl
+++ b/src/distributions/categorical.jl
@@ -17,6 +17,6 @@ end
 
 probvec(dist::Categorical) = probs(dist)
 
-function prod(::AddonProdLogScale, new_dist::Categorical, left_dist::Categorical, right_dist::Categorical)
+function compute_logscale(new_dist::Categorical, left_dist::Categorical, right_dist::Categorical)
     return log(dot(probvec(left_dist), probvec(right_dist)))
 end

--- a/src/distributions/dirichlet.jl
+++ b/src/distributions/dirichlet.jl
@@ -27,6 +27,6 @@ promote_variate_type(::Type{Matrixvariate}, ::Type{<:Dirichlet}) = MatrixDirichl
 promote_variate_type(::Type{Multivariate}, ::Type{<:MatrixDirichlet})  = Dirichlet
 promote_variate_type(::Type{Matrixvariate}, ::Type{<:MatrixDirichlet}) = MatrixDirichlet
 
-function prod(::AddonProdLogScale, new_dist::Dirichlet, left_dist::Dirichlet, right_dist::Dirichlet)
+function compute_logscale(new_dist::Dirichlet, left_dist::Dirichlet, right_dist::Dirichlet)
     return logmvbeta(probvec(new_dist)) - logmvbeta(probvec(left_dist)) - logmvbeta(probvec(right_dist))
 end

--- a/src/distributions/gamma.jl
+++ b/src/distributions/gamma.jl
@@ -68,7 +68,7 @@ function prod(::ProdAnalytical, left::GammaShapeScale, right::GammaShapeRate)
     return GammaShapeScale(shape(left) + shape(right) - one(T), (scale(left) * scale(right)) / (scale(left) + scale(right)))
 end
 
-function prod(::AddonProdLogScale, new_dist::GammaDistributionsFamily, left_dist::GammaDistributionsFamily, right_dist::GammaDistributionsFamily)
+function compute_logscale(new_dist::GammaDistributionsFamily, left_dist::GammaDistributionsFamily, right_dist::GammaDistributionsFamily)
     ay, by = shape(new_dist), rate(new_dist)
     ax, bx = shape(left_dist), rate(left_dist)
     az, bz = shape(right_dist), rate(right_dist)

--- a/src/distributions/mixture_distribution.jl
+++ b/src/distributions/mixture_distribution.jl
@@ -101,7 +101,7 @@ function prod(::ProdAnalytical, left::MixtureDistribution, right::Any)
     dists_new = map(dist -> prod(ProdAnalytical(), dist, right), dists)
 
     # get scales
-    logscales = map((dist, dist_new) -> prod(AddonProdLogScale(), dist_new, dist, right), dists, dists_new)
+    logscales = map((dist, dist_new) -> compute_logscale(dist_new, dist, right), dists, dists_new)
 
     # compute updated weights
     logscales_new = log.(w) + logscales
@@ -117,7 +117,7 @@ Computes the analytical product between a `MixtureDistribution` and something el
 """
 prod(::ProdAnalytical, left::Any, right::MixtureDistribution) = prod(ProdAnalytical(), right, left)
 
-function prod(::AddonProdLogScale, new_dist::MixtureDistribution, left_dist::MixtureDistribution, right_dist::Any)
+function compute_logscale(new_dist::MixtureDistribution, left_dist::MixtureDistribution, right_dist::Any)
 
     # get prior weights and components
     w = left_dist.weights
@@ -127,7 +127,7 @@ function prod(::AddonProdLogScale, new_dist::MixtureDistribution, left_dist::Mix
     dists_new = map(dist -> prod(ProdAnalytical(), dist, right_dist), dists)
 
     # get scales
-    logscales = map((dist, dist_new) -> prod(AddonProdLogScale(), dist_new, dist, right_dist), dists, dists_new)
+    logscales = map((dist, dist_new) -> compute_logscale(dist_new, dist, right_dist), dists, dists_new)
 
     # compute updated weights
     logscales_new = log.(w) + logscales
@@ -135,4 +135,4 @@ function prod(::AddonProdLogScale, new_dist::MixtureDistribution, left_dist::Mix
     return logsumexp(logscales_new)
 end
 
-prod(::AddonProdLogScale, new_dist::MixtureDistribution, left_dist::Any, right_dist::MixtureDistribution) = prod(AddonProdLogScale(), new_dist, right_dist, left_dist)
+compute_logscale(new_dist::MixtureDistribution, left_dist::Any, right_dist::MixtureDistribution) = compute_logscale(new_dist, right_dist, left_dist)

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -290,8 +290,8 @@ function Base.prod(::ProdAnalytical, left::L, right::R) where {L <: UnivariateNo
     return prod(ProdAnalytical(), wleft, wright)
 end
 
-function Base.prod(
-    ::AddonProdLogScale, ::N, left::L, right::R
+function compute_logscale(
+    ::N, left::L, right::R
 ) where {N <: UnivariateNormalDistributionsFamily, L <: UnivariateNormalDistributionsFamily, R <: UnivariateNormalDistributionsFamily}
     m_left, v_left   = mean_cov(left)
     m_right, v_right = mean_cov(right)
@@ -308,8 +308,8 @@ function Base.prod(::ProdAnalytical, left::L, right::R) where {L <: Multivariate
     return prod(ProdAnalytical(), wleft, wright)
 end
 
-function Base.prod(
-    ::AddonProdLogScale, ::N, left::L, right::R
+function compute_logscale(
+    ::N, left::L, right::R
 ) where {N <: MultivariateNormalDistributionsFamily, L <: MultivariateNormalDistributionsFamily, R <: MultivariateNormalDistributionsFamily}
     m_left, v_left   = mean_cov(left)
     m_right, v_right = mean_cov(right)

--- a/test/distributions/test_bernoulli.jl
+++ b/test/distributions/test_bernoulli.jl
@@ -4,7 +4,7 @@ using Test
 using ReactiveMP
 using Distributions
 using Random
-using ReactiveMP: AddonProdLogScale
+using ReactiveMP: compute_logscale
 
 @testset "Bernoulli" begin
 
@@ -33,12 +33,12 @@ using ReactiveMP: AddonProdLogScale
     end
 
     @testset "prod logscale Bernoulli-Bernoulli/Categorical" begin
-        @test prod(AddonProdLogScale(), Bernoulli(0.5), Bernoulli(0.5), Bernoulli(0.5)) ≈ log(0.5)
-        @test prod(AddonProdLogScale(), Bernoulli(1), Bernoulli(0.5), Bernoulli(1)) ≈ log(0.5)
-        @test prod(AddonProdLogScale(), Categorical([0.5, 0.5]), Bernoulli(0.5), Categorical([0.5, 0.5])) ≈ log(0.5)
-        @test prod(AddonProdLogScale(), Categorical([0.5, 0.5]), Categorical([0.5, 0.5]), Bernoulli(0.5)) ≈ log(0.5)
-        @test prod(AddonProdLogScale(), Categorical([1.0, 0.0]), Bernoulli(0.5), Categorical([1])) ≈ log(0.5)
-        @test prod(AddonProdLogScale(), Categorical([1.0, 0.0, 0.0]), Bernoulli(0.5), Categorical([1.0, 0, 0])) ≈ log(0.5)
+        @test compute_logscale(Bernoulli(0.5), Bernoulli(0.5), Bernoulli(0.5)) ≈ log(0.5)
+        @test compute_logscale(Bernoulli(1), Bernoulli(0.5), Bernoulli(1)) ≈ log(0.5)
+        @test compute_logscale(Categorical([0.5, 0.5]), Bernoulli(0.5), Categorical([0.5, 0.5])) ≈ log(0.5)
+        @test compute_logscale(Categorical([0.5, 0.5]), Categorical([0.5, 0.5]), Bernoulli(0.5)) ≈ log(0.5)
+        @test compute_logscale(Categorical([1.0, 0.0]), Bernoulli(0.5), Categorical([1])) ≈ log(0.5)
+        @test compute_logscale(Categorical([1.0, 0.0, 0.0]), Bernoulli(0.5), Categorical([1.0, 0, 0])) ≈ log(0.5)
     end
 
     @testset "BernoulliNaturalParameters" begin


### PR DESCRIPTION
This PR includes the following changes for resolving #259:
- removes `AddonProd` abstract types and children.
- renames `prod(::AddonProdLogScale, ...)` to `compute_logscale(...)`
- renames `prod(::AddonProdMemory, ...)` to `construct_memory(...)`