### PR TITLE
Fix prod CVI Bernouilli

### DIFF
--- a/src/distributions/bernoulli.jl
+++ b/src/distributions/bernoulli.jl
@@ -108,11 +108,11 @@ function Base.:-(left::BernoulliNaturalParameters, right::BernoulliNaturalParame
 end
 
 function lognormalizer(params::BernoulliNaturalParameters)
-    return log(logistic(-params.η))
+    return -log(logistic(-params.η))
 end
 
 function Distributions.logpdf(params::BernoulliNaturalParameters, x)
-    return x * params.η + lognormalizer(params)
+    return x * params.η - lognormalizer(params)
 end
 
 function convert(::Type{<:Distribution}, params::BernoulliNaturalParameters)

--- a/test/approximations/test_cvi.jl
+++ b/test/approximations/test_cvi.jl
@@ -124,7 +124,7 @@ end
             b2 = Bernoulli(logistic(randn(rng)))
             b_analitical = prod(ProdAnalytical(), b1, b2)
             b_cvi = prod(test[:method], b1, b1)
-            @test all(isapprox.(mean_var(b_analitical), mean_var(b_cvi), atol = test[:tol]))
+            @test isapprox(mean(b_analitical), mean(b_cvi), atol = test[:tol])
         end
     end
 

--- a/test/approximations/test_cvi.jl
+++ b/test/approximations/test_cvi.jl
@@ -8,6 +8,7 @@ using Distributions
 using Zygote
 using Flux
 using DiffResults
+import StatsFuns: logistic
 
 import ReactiveMP: naturalparams, NaturalParameters, AbstractContinuousGenericLogPdf
 
@@ -118,6 +119,12 @@ end
                     @test prod(test[:method], ContinuousMultivariateLogPdf(d, (x) -> logpdf(mn1, x)), mn2) ≈ mn_analytical atol = test[:tol]
                 end
             end
+
+            b1 = Bernoulli(logistic(randn(rng)))
+            b2 = Bernoulli(logistic(randn(rng)))
+            b_analitical = prod(ProdAnalytical(), b1, b2)
+            b_cvi = prod(test[:method], b1, b1)
+            @test all(isapprox.(mean_var(b_analitical), mean_var(b_cvi), atol = test[:tol]))
         end
     end
 

--- a/test/distributions/test_bernoulli.jl
+++ b/test/distributions/test_bernoulli.jl
@@ -43,7 +43,7 @@ using ReactiveMP: AddonProdLogScale
 
     @testset "BernoulliNaturalParameters" begin
         @test naturalparams(Bernoulli(0.5)) == BernoulliNaturalParameters(0.0)
-        @test lognormalizer(naturalparams(Bernoulli(0.5))) ≈ -log(2)
+        @test lognormalizer(naturalparams(Bernoulli(0.5))) ≈ log(2)
         for i in 1:9
             bnp = naturalparams(Bernoulli(i / 10.0))
             @test convert(Distribution, bnp) ≈ Bernoulli(i / 10.0)

--- a/test/distributions/test_bernoulli.jl
+++ b/test/distributions/test_bernoulli.jl
@@ -44,8 +44,10 @@ using ReactiveMP: AddonProdLogScale
     @testset "BernoulliNaturalParameters" begin
         @test naturalparams(Bernoulli(0.5)) == BernoulliNaturalParameters(0.0)
         @test lognormalizer(naturalparams(Bernoulli(0.5))) ≈ log(2)
+        b_99 = Bernoulli(0.99)
         for i in 1:9
-            bnp = naturalparams(Bernoulli(i / 10.0))
+            b = Bernoulli(i / 10.0)
+            bnp = naturalparams(b)
             @test convert(Distribution, bnp) ≈ Bernoulli(i / 10.0)
             @test logpdf(bnp, 1) ≈ logpdf(Bernoulli(i / 10.0), 1)
             @test logpdf(bnp, 0) ≈ logpdf(Bernoulli(i / 10.0), 0)
@@ -55,6 +57,7 @@ using ReactiveMP: AddonProdLogScale
 
             @test as_naturalparams(BernoulliNaturalParameters, i / 10.0) == BernoulliNaturalParameters(i / 10.0)
             @test as_naturalparams(BernoulliNaturalParameters{Float64}, i / 10.0) == BernoulliNaturalParameters(i / 10.0)
+            @test prod(ProdAnalytical(), convert(Distribution, naturalparams(b_99) - bnp), b) ≈ b_99
         end
         @test isproper(BernoulliNaturalParameters(10)) === true
     end


### PR DESCRIPTION
The purpose of this pull request is to make the functionality of the CVI to work with the Bernoulli distribution. The following changes have been made:

1. The sign of the Bernoulli log-normalizer has been corrected.
2. A new test has been added to ensure that the Bernoulli natural parameters align with `ProdAnalytical()`.
3. A test has been added to verify that `prod(::CVI, ::Bernoulli, ::Bernoulli)` operates as intended.

With these changes in place, the CVI with Bernoulli distribution works.