### PR TITLE
Fix uniformscaling

### DIFF
--- a/src/distributions/mv_normal_mean_covariance.jl
+++ b/src/distributions/mv_normal_mean_covariance.jl
@@ -26,7 +26,7 @@ function MvNormalMeanCovariance(μ::AbstractVector{T}) where {T}
     return MvNormalMeanCovariance(μ, convert(AbstractArray{T}, ones(length(μ))))
 end
 
-function MvNormalMeanCovariance(μ::AbstractVector{T1}, Σ::UniformScaling{T2}) where { T1, T2 }
+function MvNormalMeanCovariance(μ::AbstractVector{T1}, Σ::UniformScaling{T2}) where {T1, T2}
     T = promote_type(T1, T2)
     μ_new = convert(AbstractArray{T}, μ)
     Σ_new = convert(UniformScaling{T}, Σ)(length(μ))
@@ -95,7 +95,9 @@ function Base.prod(::ProdAnalytical, left::MvNormalMeanCovariance, right::MvNorm
     return MvNormalWeightedMeanPrecision(xi_left + xi_right, W_left + W_right)
 end
 
-function Base.prod(::ProdAnalytical, left::MvNormalMeanCovariance{T1,<:AbstractVector,<:Matrix}, right::MvNormalMeanCovariance{T2,<:Vector,<:Matrix}) where {T1 <: LinearAlgebra.BlasFloat, T2 <: LinearAlgebra.BlasFloat}
+function Base.prod(
+    ::ProdAnalytical, left::MvNormalMeanCovariance{T1, <:AbstractVector, <:Matrix}, right::MvNormalMeanCovariance{T2, <:Vector, <:Matrix}
+) where {T1 <: LinearAlgebra.BlasFloat, T2 <: LinearAlgebra.BlasFloat}
 
     # start with parameters of left
     xi, W = weightedmean_precision(left)

--- a/src/distributions/mv_normal_mean_covariance.jl
+++ b/src/distributions/mv_normal_mean_covariance.jl
@@ -96,7 +96,7 @@ function Base.prod(::ProdAnalytical, left::MvNormalMeanCovariance, right::MvNorm
 end
 
 function Base.prod(
-    ::ProdAnalytical, left::MvNormalMeanCovariance{T1, <:AbstractVector, <:Matrix}, right::MvNormalMeanCovariance{T2, <:Vector, <:Matrix}
+    ::ProdAnalytical, left::MvNormalMeanCovariance{T1, <:AbstractVector, <:Matrix}, right::MvNormalMeanCovariance{T2, <:AbstractVector, <:Matrix}
 ) where {T1 <: LinearAlgebra.BlasFloat, T2 <: LinearAlgebra.BlasFloat}
 
     # start with parameters of left

--- a/src/distributions/mv_normal_mean_covariance.jl
+++ b/src/distributions/mv_normal_mean_covariance.jl
@@ -26,6 +26,13 @@ function MvNormalMeanCovariance(μ::AbstractVector{T}) where {T}
     return MvNormalMeanCovariance(μ, convert(AbstractArray{T}, ones(length(μ))))
 end
 
+function MvNormalMeanCovariance(μ::AbstractVector{T1}, Σ::UniformScaling{T2}) where { T1, T2 }
+    T = promote_type(T1, T2)
+    μ_new = convert(AbstractArray{T}, μ)
+    Σ_new = convert(UniformScaling{T}, Σ)(length(μ))
+    return MvNormalMeanCovariance(μ_new, Σ_new)
+end
+
 Distributions.distrname(::MvNormalMeanCovariance) = "MvNormalMeanCovariance"
 
 function weightedmean(dist::MvNormalMeanCovariance)

--- a/src/distributions/mv_normal_mean_covariance.jl
+++ b/src/distributions/mv_normal_mean_covariance.jl
@@ -95,7 +95,7 @@ function Base.prod(::ProdAnalytical, left::MvNormalMeanCovariance, right::MvNorm
     return MvNormalWeightedMeanPrecision(xi_left + xi_right, W_left + W_right)
 end
 
-function Base.prod(::ProdAnalytical, left::MvNormalMeanCovariance{T1}, right::MvNormalMeanCovariance{T2}) where {T1 <: LinearAlgebra.BlasFloat, T2 <: LinearAlgebra.BlasFloat}
+function Base.prod(::ProdAnalytical, left::MvNormalMeanCovariance{T1,<:AbstractVector,<:Matrix}, right::MvNormalMeanCovariance{T2,<:Vector,<:Matrix}) where {T1 <: LinearAlgebra.BlasFloat, T2 <: LinearAlgebra.BlasFloat}
 
     # start with parameters of left
     xi, W = weightedmean_precision(left)

--- a/src/distributions/mv_normal_mean_precision.jl
+++ b/src/distributions/mv_normal_mean_precision.jl
@@ -100,7 +100,7 @@ function Base.prod(::ProdAnalytical, left::MvNormalMeanPrecision, right::MvNorma
 end
 
 function Base.prod(
-    ::ProdAnalytical, left::MvNormalMeanPrecision{T1, <:Vector, <:Matrix}, right::MvNormalMeanPrecision{T2, <:Vector, <:Matrix}
+    ::ProdAnalytical, left::MvNormalMeanPrecision{T1, <:AbstractVector, <:Matrix}, right::MvNormalMeanPrecision{T2, <:AbstractVector, <:Matrix}
 ) where {T1 <: LinearAlgebra.BlasFloat, T2 <: LinearAlgebra.BlasFloat}
     W = precision(left) + precision(right)
 

--- a/src/distributions/mv_normal_mean_precision.jl
+++ b/src/distributions/mv_normal_mean_precision.jl
@@ -99,7 +99,7 @@ function Base.prod(::ProdAnalytical, left::MvNormalMeanPrecision, right::MvNorma
     return MvNormalWeightedMeanPrecision(xi, W)
 end
 
-function Base.prod(::ProdAnalytical, left::MvNormalMeanPrecision{T1}, right::MvNormalMeanPrecision{T2}) where {T1 <: LinearAlgebra.BlasFloat, T2 <: LinearAlgebra.BlasFloat}
+function Base.prod(::ProdAnalytical, left::MvNormalMeanPrecision{T1,<:Vector,<:Matrix}, right::MvNormalMeanPrecision{T2,<:Vector,<:Matrix}) where {T1 <: LinearAlgebra.BlasFloat, T2 <: LinearAlgebra.BlasFloat}
     W = precision(left) + precision(right)
 
     # fast & efficient implementation of xi = precision(right)*mean(right) + precision(left)*mean(left)

--- a/src/distributions/mv_normal_mean_precision.jl
+++ b/src/distributions/mv_normal_mean_precision.jl
@@ -26,6 +26,13 @@ function MvNormalMeanPrecision(μ::AbstractVector{T}) where {T}
     return MvNormalMeanPrecision(μ, convert(AbstractArray{T}, ones(length(μ))))
 end
 
+function MvNormalMeanPrecision(μ::AbstractVector{T1}, Λ::UniformScaling{T2}) where { T1, T2 }
+    T = promote_type(T1, T2)
+    μ_new = convert(AbstractArray{T}, μ)
+    Λ_new = convert(UniformScaling{T}, Λ)(length(μ))
+    return MvNormalMeanPrecision(μ_new, Λ_new)
+end
+
 Distributions.distrname(::MvNormalMeanPrecision) = "MvNormalMeanPrecision"
 
 weightedmean(dist::MvNormalMeanPrecision) = precision(dist) * mean(dist)

--- a/src/distributions/mv_normal_mean_precision.jl
+++ b/src/distributions/mv_normal_mean_precision.jl
@@ -26,7 +26,7 @@ function MvNormalMeanPrecision(μ::AbstractVector{T}) where {T}
     return MvNormalMeanPrecision(μ, convert(AbstractArray{T}, ones(length(μ))))
 end
 
-function MvNormalMeanPrecision(μ::AbstractVector{T1}, Λ::UniformScaling{T2}) where { T1, T2 }
+function MvNormalMeanPrecision(μ::AbstractVector{T1}, Λ::UniformScaling{T2}) where {T1, T2}
     T = promote_type(T1, T2)
     μ_new = convert(AbstractArray{T}, μ)
     Λ_new = convert(UniformScaling{T}, Λ)(length(μ))
@@ -99,7 +99,9 @@ function Base.prod(::ProdAnalytical, left::MvNormalMeanPrecision, right::MvNorma
     return MvNormalWeightedMeanPrecision(xi, W)
 end
 
-function Base.prod(::ProdAnalytical, left::MvNormalMeanPrecision{T1,<:Vector,<:Matrix}, right::MvNormalMeanPrecision{T2,<:Vector,<:Matrix}) where {T1 <: LinearAlgebra.BlasFloat, T2 <: LinearAlgebra.BlasFloat}
+function Base.prod(
+    ::ProdAnalytical, left::MvNormalMeanPrecision{T1, <:Vector, <:Matrix}, right::MvNormalMeanPrecision{T2, <:Vector, <:Matrix}
+) where {T1 <: LinearAlgebra.BlasFloat, T2 <: LinearAlgebra.BlasFloat}
     W = precision(left) + precision(right)
 
     # fast & efficient implementation of xi = precision(right)*mean(right) + precision(left)*mean(left)

--- a/src/distributions/mv_normal_weighted_mean_precision.jl
+++ b/src/distributions/mv_normal_weighted_mean_precision.jl
@@ -26,7 +26,7 @@ function MvNormalWeightedMeanPrecision(xi::AbstractVector{T}) where {T}
     return MvNormalWeightedMeanPrecision(xi, convert(AbstractArray{T}, ones(length(xi))))
 end
 
-function MvNormalWeightedMeanPrecision(xi::AbstractVector{T1}, Λ::UniformScaling{T2}) where { T1, T2 }
+function MvNormalWeightedMeanPrecision(xi::AbstractVector{T1}, Λ::UniformScaling{T2}) where {T1, T2}
     T = promote_type(T1, T2)
     xi_new = convert(AbstractArray{T}, xi)
     Λ_new = convert(UniformScaling{T}, Λ)(length(xi))

--- a/src/distributions/mv_normal_weighted_mean_precision.jl
+++ b/src/distributions/mv_normal_weighted_mean_precision.jl
@@ -26,6 +26,13 @@ function MvNormalWeightedMeanPrecision(xi::AbstractVector{T}) where {T}
     return MvNormalWeightedMeanPrecision(xi, convert(AbstractArray{T}, ones(length(xi))))
 end
 
+function MvNormalWeightedMeanPrecision(xi::AbstractVector{T1}, Λ::UniformScaling{T2}) where { T1, T2 }
+    T = promote_type(T1, T2)
+    xi_new = convert(AbstractArray{T}, xi)
+    Λ_new = convert(UniformScaling{T}, Λ)(length(xi))
+    return MvNormalWeightedMeanPrecision(xi_new, Λ_new)
+end
+
 Distributions.distrname(::MvNormalWeightedMeanPrecision) = "MvNormalWeightedMeanPrecision"
 
 weightedmean(dist::MvNormalWeightedMeanPrecision) = dist.xi

--- a/src/distributions/normal_mean_precision.jl
+++ b/src/distributions/normal_mean_precision.jl
@@ -11,6 +11,12 @@ NormalMeanPrecision(μ::Real, w::Real)       = NormalMeanPrecision(promote(μ, w
 NormalMeanPrecision(μ::Integer, w::Integer) = NormalMeanPrecision(float(μ), float(w))
 NormalMeanPrecision(μ::Real)                = NormalMeanPrecision(μ, one(μ))
 NormalMeanPrecision()                       = NormalMeanPrecision(0.0, 1.0)
+function NormalMeanPrecision(μ::T1, w::UniformScaling{T2}) where { T1 <: Real, T2 }
+    T = promote_type(T1, T2)
+    μ_new = convert(T, μ)
+    w_new = convert(T, w.λ)
+    return NormalMeanPrecision(μ_new, w_new)
+end
 
 Distributions.@distr_support NormalMeanPrecision -Inf Inf
 

--- a/src/distributions/normal_mean_precision.jl
+++ b/src/distributions/normal_mean_precision.jl
@@ -11,7 +11,7 @@ NormalMeanPrecision(μ::Real, w::Real)       = NormalMeanPrecision(promote(μ, w
 NormalMeanPrecision(μ::Integer, w::Integer) = NormalMeanPrecision(float(μ), float(w))
 NormalMeanPrecision(μ::Real)                = NormalMeanPrecision(μ, one(μ))
 NormalMeanPrecision()                       = NormalMeanPrecision(0.0, 1.0)
-function NormalMeanPrecision(μ::T1, w::UniformScaling{T2}) where { T1 <: Real, T2 }
+function NormalMeanPrecision(μ::T1, w::UniformScaling{T2}) where {T1 <: Real, T2}
     T = promote_type(T1, T2)
     μ_new = convert(T, μ)
     w_new = convert(T, w.λ)

--- a/src/distributions/normal_mean_variance.jl
+++ b/src/distributions/normal_mean_variance.jl
@@ -11,6 +11,12 @@ NormalMeanVariance(μ::Real, v::Real)       = NormalMeanVariance(promote(μ, v).
 NormalMeanVariance(μ::Integer, v::Integer) = NormalMeanVariance(float(μ), float(v))
 NormalMeanVariance(μ::T) where {T <: Real} = NormalMeanVariance(μ, one(T))
 NormalMeanVariance()                       = NormalMeanVariance(0.0, 1.0)
+function NormalMeanVariance(μ::T1, v::UniformScaling{T2}) where { T1 <: Real, T2 }
+    T = promote_type(T1, T2)
+    μ_new = convert(T, μ)
+    v_new = convert(T, v.λ)
+    return NormalMeanVariance(μ_new, v_new)
+end
 
 Distributions.@distr_support NormalMeanVariance -Inf Inf
 

--- a/src/distributions/normal_mean_variance.jl
+++ b/src/distributions/normal_mean_variance.jl
@@ -11,7 +11,7 @@ NormalMeanVariance(μ::Real, v::Real)       = NormalMeanVariance(promote(μ, v).
 NormalMeanVariance(μ::Integer, v::Integer) = NormalMeanVariance(float(μ), float(v))
 NormalMeanVariance(μ::T) where {T <: Real} = NormalMeanVariance(μ, one(T))
 NormalMeanVariance()                       = NormalMeanVariance(0.0, 1.0)
-function NormalMeanVariance(μ::T1, v::UniformScaling{T2}) where { T1 <: Real, T2 }
+function NormalMeanVariance(μ::T1, v::UniformScaling{T2}) where {T1 <: Real, T2}
     T = promote_type(T1, T2)
     μ_new = convert(T, μ)
     v_new = convert(T, v.λ)

--- a/src/distributions/normal_weighted_mean_precision.jl
+++ b/src/distributions/normal_weighted_mean_precision.jl
@@ -11,6 +11,12 @@ NormalWeightedMeanPrecision(xi::Real, w::Real)       = NormalWeightedMeanPrecisi
 NormalWeightedMeanPrecision(xi::Integer, w::Integer) = NormalWeightedMeanPrecision(float(xi), float(w))
 NormalWeightedMeanPrecision(xi::Real)                = NormalWeightedMeanPrecision(xi, one(xi))
 NormalWeightedMeanPrecision()                        = NormalWeightedMeanPrecision(0.0, 1.0)
+function NormalWeightedMeanPrecision(xi::T1, w::UniformScaling{T2}) where { T1 <: Real, T2 }
+    T = promote_type(T1, T2)
+    xi_new = convert(T, xi)
+    w_new = convert(T, w.λ)
+    return NormalWeightedMeanPrecision(xi_new, w_new)
+end
 
 Distributions.@distr_support NormalWeightedMeanPrecision -Inf Inf
 

--- a/src/distributions/normal_weighted_mean_precision.jl
+++ b/src/distributions/normal_weighted_mean_precision.jl
@@ -11,7 +11,7 @@ NormalWeightedMeanPrecision(xi::Real, w::Real)       = NormalWeightedMeanPrecisi
 NormalWeightedMeanPrecision(xi::Integer, w::Integer) = NormalWeightedMeanPrecision(float(xi), float(w))
 NormalWeightedMeanPrecision(xi::Real)                = NormalWeightedMeanPrecision(xi, one(xi))
 NormalWeightedMeanPrecision()                        = NormalWeightedMeanPrecision(0.0, 1.0)
-function NormalWeightedMeanPrecision(xi::T1, w::UniformScaling{T2}) where { T1 <: Real, T2 }
+function NormalWeightedMeanPrecision(xi::T1, w::UniformScaling{T2}) where {T1 <: Real, T2}
     T = promote_type(T1, T2)
     xi_new = convert(T, xi)
     w_new = convert(T, w.λ)

--- a/src/distributions/pointmass.jl
+++ b/src/distributions/pointmass.jl
@@ -122,14 +122,14 @@ Distributions.logpdf(distribution::PointMass{M}, x::UniformScaling) where {T <: 
 
 Distributions.mean(distribution::PointMass{M}) where {T <: Real, M <: UniformScaling{T}} = getpointmass(distribution)
 Distributions.mode(distribution::PointMass{M}) where {T <: Real, M <: UniformScaling{T}} = mean(distribution)
-Distributions.var(distribution::PointMass{M}) where {T <: Real, M <: UniformScaling{T}}  = zero(T)*I
-Distributions.std(distribution::PointMass{M}) where {T <: Real, M <: UniformScaling{T}}  = zero(T)*I
+Distributions.var(distribution::PointMass{M}) where {T <: Real, M <: UniformScaling{T}}  = zero(T) * I
+Distributions.std(distribution::PointMass{M}) where {T <: Real, M <: UniformScaling{T}}  = zero(T) * I
 Distributions.cov(distribution::PointMass{M}) where {T <: Real, M <: UniformScaling{T}}  = error("Distributions.cov(::PointMass{ <: UniformScaling }) is not defined")
 
 probvec(distribution::PointMass{M}) where {T <: Real, M <: UniformScaling{T}} = error("probvec(::PointMass{ <: UniformScaling }) is not defined")
 
-mean(::typeof(inv), distribution::PointMass{M}) where {T <: Real, M <: UniformScaling{T}}       = inv(mean(distribution))
-mean(::typeof(cholinv), distribution::PointMass{M}) where {T <: Real, M <: UniformScaling{T}}   = inv(mean(distribution))
+mean(::typeof(inv), distribution::PointMass{M}) where {T <: Real, M <: UniformScaling{T}}     = inv(mean(distribution))
+mean(::typeof(cholinv), distribution::PointMass{M}) where {T <: Real, M <: UniformScaling{T}} = inv(mean(distribution))
 
 Base.precision(distribution::PointMass{M}) where {T <: Real, M <: UniformScaling{T}} = one(T) ./ cov(distribution)
 Base.ndims(distribution::PointMass{M}) where {T <: Real, M <: UniformScaling{T}}     = size(mean(distribution))
@@ -138,7 +138,6 @@ convert_eltype(::Type{PointMass}, ::Type{T}, distribution::PointMass{R}) where {
 convert_eltype(::Type{PointMass}, ::Type{T}, distribution::PointMass{R}) where {T <: AbstractMatrix, R <: UniformScaling} = PointMass(convert(T, getpointmass(distribution)))
 
 Base.eltype(::PointMass{M}) where {T <: Real, M <: UniformScaling{T}} = T
-
 
 Base.isapprox(left::PointMass, right::PointMass; kwargs...) = Base.isapprox(getpointmass(left), getpointmass(right); kwargs...)
 Base.isapprox(left::PointMass, right; kwargs...) = false

--- a/src/variables/constant.jl
+++ b/src/variables/constant.jl
@@ -50,8 +50,8 @@ function constvar end
 
 constvar(name::Symbol, constval, collection_type::AbstractVariableCollectionType = VariableIndividual())                 = ConstVariable(name, collection_type, constval, of(Message(constval, true, false, nothing)), 0)
 constvar(name::Symbol, constval::Real, collection_type::AbstractVariableCollectionType = VariableIndividual())           = constvar(name, PointMass(constval), collection_type)
-constvar(name::Symbol, constval::AbstractVector, collection_type::AbstractVariableCollectionType = VariableIndividual()) = constvar(name, PointMass(constval), collection_type)
-constvar(name::Symbol, constval::AbstractMatrix, collection_type::AbstractVariableCollectionType = VariableIndividual()) = constvar(name, PointMass(constval), collection_type)
+constvar(name::Symbol, constval::AbstractArray, collection_type::AbstractVariableCollectionType = VariableIndividual())  = constvar(name, PointMass(constval), collection_type)
+constvar(name::Symbol, constval::UniformScaling, collection_type::AbstractVariableCollectionType = VariableIndividual()) = constvar(name, PointMass(constval), collection_type)
 
 function constvar(name::Symbol, fn::Function, length::Int)
     return map(i -> constvar(name, fn(i), VariableVector(i)), 1:length)

--- a/test/distributions/test_mv_normal_mean_covariance.jl
+++ b/test/distributions/test_mv_normal_mean_covariance.jl
@@ -98,6 +98,12 @@ using Distributions
         dist = MvNormalMeanCovariance(μ, Σ)
 
         @test prod(ProdAnalytical(), dist, dist) ≈ MvNormalWeightedMeanPrecision([2.0, 2.0, 2.0], diagm([2.0, 1.0, 2 / 3]))
+
+        # diagonal covariance matrix/uniformscaling
+        @test prod(ProdAnalytical(), MvNormalMeanCovariance([-1, -1], [2 0; 0 2]), MvNormalMeanCovariance([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, -1 / 4], [1, 3 / 4])
+        @test prod(ProdAnalytical(), MvNormalMeanCovariance([-1, -1], [2, 2]), MvNormalMeanCovariance([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, -1 / 4], [1, 3 / 4])
+        @test prod(ProdAnalytical(), MvNormalMeanCovariance([-1, -1], 2*I), MvNormalMeanCovariance([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, -1 / 4], [1, 3 / 4])
+        
     end
 
     @testset "Primitive types conversion" begin

--- a/test/distributions/test_mv_normal_mean_covariance.jl
+++ b/test/distributions/test_mv_normal_mean_covariance.jl
@@ -18,7 +18,7 @@ using Distributions
         @test MvNormalMeanCovariance([1, 2], I) == MvNormalMeanCovariance([1, 2], Diagonal([1, 1]))
         @test MvNormalMeanCovariance([1, 2], 6*I) == MvNormalMeanCovariance([1, 2], Diagonal([6, 6]))
         @test MvNormalMeanCovariance([1.0, 2.0], I) == MvNormalMeanCovariance([1.0, 2.0], Diagonal([1.0, 1.0]))
-        @test MvNormalMeanCovariance([1.0, 2.0], 6*I) == MvNormalMeanCovariance([1.0, 2.0], Diagonal([6.0 6.0]))
+        @test MvNormalMeanCovariance([1.0, 2.0], 6*I) == MvNormalMeanCovariance([1.0, 2.0], Diagonal([6.0, 6.0]))
         @test MvNormalMeanCovariance([1, 2], 6.0*I) == MvNormalMeanCovariance([1.0, 2.0], Diagonal([6.0, 6.0]))
 
         @test eltype(MvNormalMeanCovariance([1.0, 1.0])) === Float64

--- a/test/distributions/test_mv_normal_mean_covariance.jl
+++ b/test/distributions/test_mv_normal_mean_covariance.jl
@@ -16,10 +16,10 @@ using Distributions
 
         # uniformscaling
         @test MvNormalMeanCovariance([1, 2], I) == MvNormalMeanCovariance([1, 2], Diagonal([1, 1]))
-        @test MvNormalMeanCovariance([1, 2], 6*I) == MvNormalMeanCovariance([1, 2], Diagonal([6, 6]))
+        @test MvNormalMeanCovariance([1, 2], 6 * I) == MvNormalMeanCovariance([1, 2], Diagonal([6, 6]))
         @test MvNormalMeanCovariance([1.0, 2.0], I) == MvNormalMeanCovariance([1.0, 2.0], Diagonal([1.0, 1.0]))
-        @test MvNormalMeanCovariance([1.0, 2.0], 6*I) == MvNormalMeanCovariance([1.0, 2.0], Diagonal([6.0, 6.0]))
-        @test MvNormalMeanCovariance([1, 2], 6.0*I) == MvNormalMeanCovariance([1.0, 2.0], Diagonal([6.0, 6.0]))
+        @test MvNormalMeanCovariance([1.0, 2.0], 6 * I) == MvNormalMeanCovariance([1.0, 2.0], Diagonal([6.0, 6.0]))
+        @test MvNormalMeanCovariance([1, 2], 6.0 * I) == MvNormalMeanCovariance([1.0, 2.0], Diagonal([6.0, 6.0]))
 
         @test eltype(MvNormalMeanCovariance([1.0, 1.0])) === Float64
         @test eltype(MvNormalMeanCovariance([1.0, 1.0], [1.0, 1.0])) === Float64
@@ -100,10 +100,12 @@ using Distributions
         @test prod(ProdAnalytical(), dist, dist) ≈ MvNormalWeightedMeanPrecision([2.0, 2.0, 2.0], diagm([2.0, 1.0, 2 / 3]))
 
         # diagonal covariance matrix/uniformscaling
-        @test prod(ProdAnalytical(), MvNormalMeanCovariance([-1, -1], [2 0; 0 2]), MvNormalMeanCovariance([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, -1 / 4], [1, 3 / 4])
-        @test prod(ProdAnalytical(), MvNormalMeanCovariance([-1, -1], [2, 2]), MvNormalMeanCovariance([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, -1 / 4], [1, 3 / 4])
-        @test prod(ProdAnalytical(), MvNormalMeanCovariance([-1, -1], 2*I), MvNormalMeanCovariance([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, -1 / 4], [1, 3 / 4])
-        
+        @test prod(ProdAnalytical(), MvNormalMeanCovariance([-1, -1], [2 0; 0 2]), MvNormalMeanCovariance([1, 1], Diagonal([2, 4]))) ≈
+            MvNormalWeightedMeanPrecision([0, -1 / 4], [1, 3 / 4])
+        @test prod(ProdAnalytical(), MvNormalMeanCovariance([-1, -1], [2, 2]), MvNormalMeanCovariance([1, 1], Diagonal([2, 4]))) ≈
+            MvNormalWeightedMeanPrecision([0, -1 / 4], [1, 3 / 4])
+        @test prod(ProdAnalytical(), MvNormalMeanCovariance([-1, -1], 2 * I), MvNormalMeanCovariance([1, 1], Diagonal([2, 4]))) ≈
+            MvNormalWeightedMeanPrecision([0, -1 / 4], [1, 3 / 4])
     end
 
     @testset "Primitive types conversion" begin

--- a/test/distributions/test_mv_normal_mean_covariance.jl
+++ b/test/distributions/test_mv_normal_mean_covariance.jl
@@ -14,6 +14,13 @@ using Distributions
         @test MvNormalMeanCovariance([1, 2]) == MvNormalMeanCovariance([1.0, 2.0], [1.0, 1.0])
         @test MvNormalMeanCovariance([1.0f0, 2.0f0]) == MvNormalMeanCovariance([1.0f0, 2.0f0], [1.0f0, 1.0f0])
 
+        # uniformscaling
+        @test MvNormalMeanCovariance([1, 2], I) == MvNormalMeanCovariance([1, 2], Diagonal([1, 1]))
+        @test MvNormalMeanCovariance([1, 2], 6*I) == MvNormalMeanCovariance([1, 2], Diagonal([6, 6]))
+        @test MvNormalMeanCovariance([1.0, 2.0], I) == MvNormalMeanCovariance([1.0, 2.0], Diagonal([1.0, 1.0]))
+        @test MvNormalMeanCovariance([1.0, 2.0], 6*I) == MvNormalMeanCovariance([1.0, 2.0], Diagonal([6.0 6.0]))
+        @test MvNormalMeanCovariance([1, 2], 6.0*I) == MvNormalMeanCovariance([1.0, 2.0], Diagonal([6.0, 6.0]))
+
         @test eltype(MvNormalMeanCovariance([1.0, 1.0])) === Float64
         @test eltype(MvNormalMeanCovariance([1.0, 1.0], [1.0, 1.0])) === Float64
         @test eltype(MvNormalMeanCovariance([1, 1])) === Float64

--- a/test/distributions/test_mv_normal_mean_precision.jl
+++ b/test/distributions/test_mv_normal_mean_precision.jl
@@ -98,6 +98,12 @@ using Distributions
         dist = MvNormalMeanPrecision(μ, Λ)
 
         @test prod(ProdAnalytical(), dist, dist) ≈ MvNormalWeightedMeanPrecision([2.0, 2.0, 2.0], diagm([2.0, 1.0, 2 / 3]))
+
+        # diagonal covariance matrix/uniformscaling
+        @test prod(ProdAnalytical(), MvNormalMeanPrecision([-1, -1], [2 0; 0 2]), MvNormalMeanPrecision([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, 2], [4, 6])
+        @test prod(ProdAnalytical(), MvNormalMeanPrecision([-1, -1], [2, 2]), MvNormalMeanPrecision([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, 2], [4, 6])
+        @test prod(ProdAnalytical(), MvNormalMeanPrecision([-1, -1], 2*I), MvNormalMeanPrecision([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, 2], [4, 6])
+        
     end
 
     @testset "Primitive types conversion" begin

--- a/test/distributions/test_mv_normal_mean_precision.jl
+++ b/test/distributions/test_mv_normal_mean_precision.jl
@@ -16,10 +16,10 @@ using Distributions
 
         # uniformscaling
         @test MvNormalMeanPrecision([1, 2], I) == MvNormalMeanPrecision([1, 2], Diagonal([1, 1]))
-        @test MvNormalMeanPrecision([1, 2], 6*I) == MvNormalMeanPrecision([1, 2], Diagonal([6, 6]))
+        @test MvNormalMeanPrecision([1, 2], 6 * I) == MvNormalMeanPrecision([1, 2], Diagonal([6, 6]))
         @test MvNormalMeanPrecision([1.0, 2.0], I) == MvNormalMeanPrecision([1.0, 2.0], Diagonal([1.0, 1.0]))
-        @test MvNormalMeanPrecision([1.0, 2.0], 6*I) == MvNormalMeanPrecision([1.0, 2.0], Diagonal([6.0, 6.0]))
-        @test MvNormalMeanPrecision([1, 2], 6.0*I) == MvNormalMeanPrecision([1.0, 2.0], Diagonal([6.0, 6.0]))
+        @test MvNormalMeanPrecision([1.0, 2.0], 6 * I) == MvNormalMeanPrecision([1.0, 2.0], Diagonal([6.0, 6.0]))
+        @test MvNormalMeanPrecision([1, 2], 6.0 * I) == MvNormalMeanPrecision([1.0, 2.0], Diagonal([6.0, 6.0]))
 
         @test eltype(MvNormalMeanPrecision([1.0, 1.0])) === Float64
         @test eltype(MvNormalMeanPrecision([1.0, 1.0], [1.0, 1.0])) === Float64
@@ -100,10 +100,9 @@ using Distributions
         @test prod(ProdAnalytical(), dist, dist) ≈ MvNormalWeightedMeanPrecision([2.0, 2.0, 2.0], diagm([2.0, 1.0, 2 / 3]))
 
         # diagonal covariance matrix/uniformscaling
-        @test prod(ProdAnalytical(), MvNormalMeanPrecision([-1, -1], [2 0; 0 2]), MvNormalMeanPrecision([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, 2], [4, 6])
-        @test prod(ProdAnalytical(), MvNormalMeanPrecision([-1, -1], [2, 2]), MvNormalMeanPrecision([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, 2], [4, 6])
-        @test prod(ProdAnalytical(), MvNormalMeanPrecision([-1, -1], 2*I), MvNormalMeanPrecision([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, 2], [4, 6])
-        
+        @test prod(ProdAnalytical(), MvNormalMeanPrecision([-1, -1], [2 0; 0 2]), MvNormalMeanPrecision([1, 1], Diagonal([2, 4]))) ≈ MvNormalWeightedMeanPrecision([0, 2], [4, 6])
+        @test prod(ProdAnalytical(), MvNormalMeanPrecision([-1, -1], [2, 2]), MvNormalMeanPrecision([1, 1], Diagonal([2, 4]))) ≈ MvNormalWeightedMeanPrecision([0, 2], [4, 6])
+        @test prod(ProdAnalytical(), MvNormalMeanPrecision([-1, -1], 2 * I), MvNormalMeanPrecision([1, 1], Diagonal([2, 4]))) ≈ MvNormalWeightedMeanPrecision([0, 2], [4, 6])
     end
 
     @testset "Primitive types conversion" begin

--- a/test/distributions/test_mv_normal_mean_precision.jl
+++ b/test/distributions/test_mv_normal_mean_precision.jl
@@ -18,7 +18,7 @@ using Distributions
         @test MvNormalMeanPrecision([1, 2], I) == MvNormalMeanPrecision([1, 2], Diagonal([1, 1]))
         @test MvNormalMeanPrecision([1, 2], 6*I) == MvNormalMeanPrecision([1, 2], Diagonal([6, 6]))
         @test MvNormalMeanPrecision([1.0, 2.0], I) == MvNormalMeanPrecision([1.0, 2.0], Diagonal([1.0, 1.0]))
-        @test MvNormalMeanPrecision([1.0, 2.0], 6*I) == MvNormalMeanPrecision([1.0, 2.0], Diagonal([6.0 6.0]))
+        @test MvNormalMeanPrecision([1.0, 2.0], 6*I) == MvNormalMeanPrecision([1.0, 2.0], Diagonal([6.0, 6.0]))
         @test MvNormalMeanPrecision([1, 2], 6.0*I) == MvNormalMeanPrecision([1.0, 2.0], Diagonal([6.0, 6.0]))
 
         @test eltype(MvNormalMeanPrecision([1.0, 1.0])) === Float64

--- a/test/distributions/test_mv_normal_mean_precision.jl
+++ b/test/distributions/test_mv_normal_mean_precision.jl
@@ -14,6 +14,13 @@ using Distributions
         @test MvNormalMeanPrecision([1, 2]) == MvNormalMeanPrecision([1.0, 2.0], [1.0, 1.0])
         @test MvNormalMeanPrecision([1.0f0, 2.0f0]) == MvNormalMeanPrecision([1.0f0, 2.0f0], [1.0f0, 1.0f0])
 
+        # uniformscaling
+        @test MvNormalMeanPrecision([1, 2], I) == MvNormalMeanPrecision([1, 2], Diagonal([1, 1]))
+        @test MvNormalMeanPrecision([1, 2], 6*I) == MvNormalMeanPrecision([1, 2], Diagonal([6, 6]))
+        @test MvNormalMeanPrecision([1.0, 2.0], I) == MvNormalMeanPrecision([1.0, 2.0], Diagonal([1.0, 1.0]))
+        @test MvNormalMeanPrecision([1.0, 2.0], 6*I) == MvNormalMeanPrecision([1.0, 2.0], Diagonal([6.0 6.0]))
+        @test MvNormalMeanPrecision([1, 2], 6.0*I) == MvNormalMeanPrecision([1.0, 2.0], Diagonal([6.0, 6.0]))
+
         @test eltype(MvNormalMeanPrecision([1.0, 1.0])) === Float64
         @test eltype(MvNormalMeanPrecision([1.0, 1.0], [1.0, 1.0])) === Float64
         @test eltype(MvNormalMeanPrecision([1, 1])) === Float64

--- a/test/distributions/test_mv_normal_weighted_mean_precision.jl
+++ b/test/distributions/test_mv_normal_weighted_mean_precision.jl
@@ -98,6 +98,12 @@ using Distributions
         dist = MvNormalWeightedMeanPrecision(xi, Λ)
 
         @test prod(ProdAnalytical(), dist, dist) ≈ MvNormalWeightedMeanPrecision([0.40, 6.00, 8.00], [3.00 -0.20 0.20; -0.20 3.60 0.00; 0.20 0.00 7.00])
+
+        # diagonal covariance matrix/uniformscaling
+        @test prod(ProdAnalytical(), MvNormalWeightedMeanPrecision([-1, -1], [2 0; 0 2]), MvNormalWeightedMeanPrecision([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, 0], [4, 6])
+        @test prod(ProdAnalytical(), MvNormalWeightedMeanPrecision([-1, -1], [2, 2]), MvNormalWeightedMeanPrecision([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, 0], [4, 6])
+        @test prod(ProdAnalytical(), MvNormalWeightedMeanPrecision([-1, -1], 2*I), MvNormalWeightedMeanPrecision([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, 0], [4, 6])
+
     end
 
     @testset "Primitive types conversion" begin

--- a/test/distributions/test_mv_normal_weighted_mean_precision.jl
+++ b/test/distributions/test_mv_normal_weighted_mean_precision.jl
@@ -18,7 +18,7 @@ using Distributions
         @test MvNormalWeightedMeanPrecision([1, 2], I) == MvNormalWeightedMeanPrecision([1, 2], Diagonal([1, 1]))
         @test MvNormalWeightedMeanPrecision([1, 2], 6*I) == MvNormalWeightedMeanPrecision([1, 2], Diagonal([6, 6]))
         @test MvNormalWeightedMeanPrecision([1.0, 2.0], I) == MvNormalWeightedMeanPrecision([1.0, 2.0], Diagonal([1.0, 1.0]))
-        @test MvNormalWeightedMeanPrecision([1.0, 2.0], 6*I) == MvNormalWeightedMeanPrecision([1.0, 2.0], Diagonal([6.0 6.0]))
+        @test MvNormalWeightedMeanPrecision([1.0, 2.0], 6*I) == MvNormalWeightedMeanPrecision([1.0, 2.0], Diagonal([6.0, 6.0]))
         @test MvNormalWeightedMeanPrecision([1, 2], 6.0*I) == MvNormalWeightedMeanPrecision([1.0, 2.0], Diagonal([6.0, 6.0]))
 
         @test eltype(MvNormalWeightedMeanPrecision([1.0, 1.0])) === Float64

--- a/test/distributions/test_mv_normal_weighted_mean_precision.jl
+++ b/test/distributions/test_mv_normal_weighted_mean_precision.jl
@@ -14,6 +14,13 @@ using Distributions
         @test MvNormalWeightedMeanPrecision([1, 2]) == MvNormalWeightedMeanPrecision([1.0, 2.0], [1.0, 1.0])
         @test MvNormalWeightedMeanPrecision([1.0f0, 2.0f0]) == MvNormalWeightedMeanPrecision([1.0f0, 2.0f0], [1.0f0, 1.0f0])
 
+        # uniformscaling
+        @test MvNormalWeightedMeanPrecision([1, 2], I) == MvNormalWeightedMeanPrecision([1, 2], Diagonal([1, 1]))
+        @test MvNormalWeightedMeanPrecision([1, 2], 6*I) == MvNormalWeightedMeanPrecision([1, 2], Diagonal([6, 6]))
+        @test MvNormalWeightedMeanPrecision([1.0, 2.0], I) == MvNormalWeightedMeanPrecision([1.0, 2.0], Diagonal([1.0, 1.0]))
+        @test MvNormalWeightedMeanPrecision([1.0, 2.0], 6*I) == MvNormalWeightedMeanPrecision([1.0, 2.0], Diagonal([6.0 6.0]))
+        @test MvNormalWeightedMeanPrecision([1, 2], 6.0*I) == MvNormalWeightedMeanPrecision([1.0, 2.0], Diagonal([6.0, 6.0]))
+
         @test eltype(MvNormalWeightedMeanPrecision([1.0, 1.0])) === Float64
         @test eltype(MvNormalWeightedMeanPrecision([1.0, 1.0], [1.0, 1.0])) === Float64
         @test eltype(MvNormalWeightedMeanPrecision([1, 1])) === Float64

--- a/test/distributions/test_mv_normal_weighted_mean_precision.jl
+++ b/test/distributions/test_mv_normal_weighted_mean_precision.jl
@@ -16,10 +16,10 @@ using Distributions
 
         # uniformscaling
         @test MvNormalWeightedMeanPrecision([1, 2], I) == MvNormalWeightedMeanPrecision([1, 2], Diagonal([1, 1]))
-        @test MvNormalWeightedMeanPrecision([1, 2], 6*I) == MvNormalWeightedMeanPrecision([1, 2], Diagonal([6, 6]))
+        @test MvNormalWeightedMeanPrecision([1, 2], 6 * I) == MvNormalWeightedMeanPrecision([1, 2], Diagonal([6, 6]))
         @test MvNormalWeightedMeanPrecision([1.0, 2.0], I) == MvNormalWeightedMeanPrecision([1.0, 2.0], Diagonal([1.0, 1.0]))
-        @test MvNormalWeightedMeanPrecision([1.0, 2.0], 6*I) == MvNormalWeightedMeanPrecision([1.0, 2.0], Diagonal([6.0, 6.0]))
-        @test MvNormalWeightedMeanPrecision([1, 2], 6.0*I) == MvNormalWeightedMeanPrecision([1.0, 2.0], Diagonal([6.0, 6.0]))
+        @test MvNormalWeightedMeanPrecision([1.0, 2.0], 6 * I) == MvNormalWeightedMeanPrecision([1.0, 2.0], Diagonal([6.0, 6.0]))
+        @test MvNormalWeightedMeanPrecision([1, 2], 6.0 * I) == MvNormalWeightedMeanPrecision([1.0, 2.0], Diagonal([6.0, 6.0]))
 
         @test eltype(MvNormalWeightedMeanPrecision([1.0, 1.0])) === Float64
         @test eltype(MvNormalWeightedMeanPrecision([1.0, 1.0], [1.0, 1.0])) === Float64
@@ -100,10 +100,12 @@ using Distributions
         @test prod(ProdAnalytical(), dist, dist) ≈ MvNormalWeightedMeanPrecision([0.40, 6.00, 8.00], [3.00 -0.20 0.20; -0.20 3.60 0.00; 0.20 0.00 7.00])
 
         # diagonal covariance matrix/uniformscaling
-        @test prod(ProdAnalytical(), MvNormalWeightedMeanPrecision([-1, -1], [2 0; 0 2]), MvNormalWeightedMeanPrecision([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, 0], [4, 6])
-        @test prod(ProdAnalytical(), MvNormalWeightedMeanPrecision([-1, -1], [2, 2]), MvNormalWeightedMeanPrecision([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, 0], [4, 6])
-        @test prod(ProdAnalytical(), MvNormalWeightedMeanPrecision([-1, -1], 2*I), MvNormalWeightedMeanPrecision([1, 1], Diagonal([2,4]))) ≈ MvNormalWeightedMeanPrecision([0, 0], [4, 6])
-
+        @test prod(ProdAnalytical(), MvNormalWeightedMeanPrecision([-1, -1], [2 0; 0 2]), MvNormalWeightedMeanPrecision([1, 1], Diagonal([2, 4]))) ≈
+            MvNormalWeightedMeanPrecision([0, 0], [4, 6])
+        @test prod(ProdAnalytical(), MvNormalWeightedMeanPrecision([-1, -1], [2, 2]), MvNormalWeightedMeanPrecision([1, 1], Diagonal([2, 4]))) ≈
+            MvNormalWeightedMeanPrecision([0, 0], [4, 6])
+        @test prod(ProdAnalytical(), MvNormalWeightedMeanPrecision([-1, -1], 2 * I), MvNormalWeightedMeanPrecision([1, 1], Diagonal([2, 4]))) ≈
+            MvNormalWeightedMeanPrecision([0, 0], [4, 6])
     end
 
     @testset "Primitive types conversion" begin

--- a/test/distributions/test_normal_mean_precision.jl
+++ b/test/distributions/test_normal_mean_precision.jl
@@ -20,6 +20,13 @@ using ReactiveMP
         @test NormalMeanPrecision(1.0f0, 2) == NormalMeanPrecision{Float32}(1.0f0, 2.0f0)
         @test NormalMeanPrecision(1.0f0, 2.0) == NormalMeanPrecision{Float64}(1.0, 2.0)
 
+        # uniformscaling
+        @test NormalMeanPrecision(2, I) == NormalMeanPrecision(2, 1)
+        @test NormalMeanPrecision(2, 6*I) == NormalMeanPrecision(2, 6)
+        @test NormalMeanPrecision(2.0, I) == NormalMeanPrecision(2.0, 1.0)
+        @test NormalMeanPrecision(2.0, 6*I) == NormalMeanPrecision(2.0, 6.0)
+        @test NormalMeanPrecision(2, 6.0*I) == NormalMeanPrecision(2.0, 6.0)
+
         @test eltype(NormalMeanPrecision()) === Float64
         @test eltype(NormalMeanPrecision(0.0)) === Float64
         @test eltype(NormalMeanPrecision(0.0, 1.0)) === Float64

--- a/test/distributions/test_normal_mean_precision.jl
+++ b/test/distributions/test_normal_mean_precision.jl
@@ -3,6 +3,8 @@ module NormalMeanPrecisionTest
 using Test
 using ReactiveMP
 
+using LinearAlgebra: I
+
 @testset "NormalMeanPrecision" begin
     @testset "Constructor" begin
         @test NormalMeanPrecision <: NormalDistributionsFamily

--- a/test/distributions/test_normal_mean_precision.jl
+++ b/test/distributions/test_normal_mean_precision.jl
@@ -24,10 +24,10 @@ using LinearAlgebra: I
 
         # uniformscaling
         @test NormalMeanPrecision(2, I) == NormalMeanPrecision(2, 1)
-        @test NormalMeanPrecision(2, 6*I) == NormalMeanPrecision(2, 6)
+        @test NormalMeanPrecision(2, 6 * I) == NormalMeanPrecision(2, 6)
         @test NormalMeanPrecision(2.0, I) == NormalMeanPrecision(2.0, 1.0)
-        @test NormalMeanPrecision(2.0, 6*I) == NormalMeanPrecision(2.0, 6.0)
-        @test NormalMeanPrecision(2, 6.0*I) == NormalMeanPrecision(2.0, 6.0)
+        @test NormalMeanPrecision(2.0, 6 * I) == NormalMeanPrecision(2.0, 6.0)
+        @test NormalMeanPrecision(2, 6.0 * I) == NormalMeanPrecision(2.0, 6.0)
 
         @test eltype(NormalMeanPrecision()) === Float64
         @test eltype(NormalMeanPrecision(0.0)) === Float64

--- a/test/distributions/test_normal_mean_variance.jl
+++ b/test/distributions/test_normal_mean_variance.jl
@@ -24,10 +24,10 @@ using LinearAlgebra: I
 
         # uniformscaling
         @test NormalMeanVariance(2, I) == NormalMeanVariance(2, 1)
-        @test NormalMeanVariance(2, 6*I) == NormalMeanVariance(2, 6)
+        @test NormalMeanVariance(2, 6 * I) == NormalMeanVariance(2, 6)
         @test NormalMeanVariance(2.0, I) == NormalMeanVariance(2.0, 1.0)
-        @test NormalMeanVariance(2.0, 6*I) == NormalMeanVariance(2.0, 6.0)
-        @test NormalMeanVariance(2, 6.0*I) == NormalMeanVariance(2.0, 6.0)
+        @test NormalMeanVariance(2.0, 6 * I) == NormalMeanVariance(2.0, 6.0)
+        @test NormalMeanVariance(2, 6.0 * I) == NormalMeanVariance(2.0, 6.0)
 
         @test eltype(NormalMeanVariance()) === Float64
         @test eltype(NormalMeanVariance(0.0)) === Float64

--- a/test/distributions/test_normal_mean_variance.jl
+++ b/test/distributions/test_normal_mean_variance.jl
@@ -3,6 +3,8 @@ module NormalMeanVarianceTest
 using Test
 using ReactiveMP
 
+using LinearAlgebra: I
+
 @testset "NormalMeanVariance" begin
     @testset "Constructor" begin
         @test NormalMeanVariance <: NormalDistributionsFamily

--- a/test/distributions/test_normal_mean_variance.jl
+++ b/test/distributions/test_normal_mean_variance.jl
@@ -20,6 +20,13 @@ using ReactiveMP
         @test NormalMeanVariance(1.0f0, 2) == NormalMeanVariance{Float32}(1.0f0, 2.0f0)
         @test NormalMeanVariance(1.0f0, 2.0) == NormalMeanVariance{Float64}(1.0, 2.0)
 
+        # uniformscaling
+        @test NormalMeanVariance(2, I) == NormalMeanVariance(2, 1)
+        @test NormalMeanVariance(2, 6*I) == NormalMeanVariance(2, 6)
+        @test NormalMeanVariance(2.0, I) == NormalMeanVariance(2.0, 1.0)
+        @test NormalMeanVariance(2.0, 6*I) == NormalMeanVariance(2.0, 6.0)
+        @test NormalMeanVariance(2, 6.0*I) == NormalMeanVariance(2.0, 6.0)
+
         @test eltype(NormalMeanVariance()) === Float64
         @test eltype(NormalMeanVariance(0.0)) === Float64
         @test eltype(NormalMeanVariance(0.0, 1.0)) === Float64

--- a/test/distributions/test_normal_weighted_mean_precision.jl
+++ b/test/distributions/test_normal_weighted_mean_precision.jl
@@ -18,6 +18,13 @@ using ReactiveMP
         @test NormalWeightedMeanPrecision(1.0f0) == NormalWeightedMeanPrecision{Float32}(1.0f0, 1.0f0)
         @test NormalWeightedMeanPrecision(1.0f0, 2.0f0) == NormalWeightedMeanPrecision{Float32}(1.0f0, 2.0f0)
         @test NormalWeightedMeanPrecision(1.0f0, 2.0) == NormalWeightedMeanPrecision{Float64}(1.0, 2.0)
+        
+        # uniformscaling
+        @test NormalWeightedMeanPrecision(2, I) == NormalWeightedMeanPrecision(2, 1)
+        @test NormalWeightedMeanPrecision(2, 6*I) == NormalWeightedMeanPrecision(2, 6)
+        @test NormalWeightedMeanPrecision(2.0, I) == NormalWeightedMeanPrecision(2.0, 1.0)
+        @test NormalWeightedMeanPrecision(2.0, 6*I) == NormalWeightedMeanPrecision(2.0, 6.0)
+        @test NormalWeightedMeanPrecision(2, 6.0*I) == NormalWeightedMeanPrecision(2.0, 6.0)
 
         @test eltype(NormalWeightedMeanPrecision()) === Float64
         @test eltype(NormalWeightedMeanPrecision(0.0)) === Float64

--- a/test/distributions/test_normal_weighted_mean_precision.jl
+++ b/test/distributions/test_normal_weighted_mean_precision.jl
@@ -20,13 +20,13 @@ using LinearAlgebra: I
         @test NormalWeightedMeanPrecision(1.0f0) == NormalWeightedMeanPrecision{Float32}(1.0f0, 1.0f0)
         @test NormalWeightedMeanPrecision(1.0f0, 2.0f0) == NormalWeightedMeanPrecision{Float32}(1.0f0, 2.0f0)
         @test NormalWeightedMeanPrecision(1.0f0, 2.0) == NormalWeightedMeanPrecision{Float64}(1.0, 2.0)
-        
+
         # uniformscaling
         @test NormalWeightedMeanPrecision(2, I) == NormalWeightedMeanPrecision(2, 1)
-        @test NormalWeightedMeanPrecision(2, 6*I) == NormalWeightedMeanPrecision(2, 6)
+        @test NormalWeightedMeanPrecision(2, 6 * I) == NormalWeightedMeanPrecision(2, 6)
         @test NormalWeightedMeanPrecision(2.0, I) == NormalWeightedMeanPrecision(2.0, 1.0)
-        @test NormalWeightedMeanPrecision(2.0, 6*I) == NormalWeightedMeanPrecision(2.0, 6.0)
-        @test NormalWeightedMeanPrecision(2, 6.0*I) == NormalWeightedMeanPrecision(2.0, 6.0)
+        @test NormalWeightedMeanPrecision(2.0, 6 * I) == NormalWeightedMeanPrecision(2.0, 6.0)
+        @test NormalWeightedMeanPrecision(2, 6.0 * I) == NormalWeightedMeanPrecision(2.0, 6.0)
 
         @test eltype(NormalWeightedMeanPrecision()) === Float64
         @test eltype(NormalWeightedMeanPrecision(0.0)) === Float64

--- a/test/distributions/test_normal_weighted_mean_precision.jl
+++ b/test/distributions/test_normal_weighted_mean_precision.jl
@@ -3,6 +3,8 @@ module NormalWeightedMeanPrecisionTest
 using Test
 using ReactiveMP
 
+using LinearAlgebra: I
+
 @testset "NormalWeightedMeanPrecision" begin
     @testset "Constructor" begin
         @test NormalWeightedMeanPrecision <: NormalDistributionsFamily

--- a/test/distributions/test_pointmass.jl
+++ b/test/distributions/test_pointmass.jl
@@ -176,12 +176,12 @@ import ReactiveMP: xtlog, mirrorlog
             @test dist[3, 3] === matrix[3, 3]
 
             @test pdf(dist, matrix) == one(T)
-            @test pdf(dist, matrix + convert(T, tiny)*I) == zero(T)
-            @test pdf(dist, matrix - convert(T, tiny)*I) == zero(T)
+            @test pdf(dist, matrix + convert(T, tiny) * I) == zero(T)
+            @test pdf(dist, matrix - convert(T, tiny) * I) == zero(T)
 
             @test logpdf(dist, matrix) == zero(T)
-            @test logpdf(dist, matrix + convert(T, tiny)*I) == convert(T, -Inf)
-            @test logpdf(dist, matrix - convert(T, tiny)*I) == convert(T, -Inf)
+            @test logpdf(dist, matrix + convert(T, tiny) * I) == convert(T, -Inf)
+            @test logpdf(dist, matrix - convert(T, tiny) * I) == convert(T, -Inf)
 
             @test_throws MethodError insupport(dist, one(T))
             @test_throws MethodError insupport(dist, ones(T, 2))
@@ -194,8 +194,8 @@ import ReactiveMP: xtlog, mirrorlog
 
             @test mean(dist) == matrix
             @test mode(dist) == matrix
-            @test var(dist) == zero(T)*I
-            @test std(dist) == zero(T)*I
+            @test var(dist) == zero(T) * I
+            @test std(dist) == zero(T) * I
 
             @test_throws ErrorException cov(dist)
             @test_throws ErrorException precision(dist)

--- a/test/rules/bernoulli/test_p.jl
+++ b/test/rules/bernoulli/test_p.jl
@@ -19,7 +19,7 @@ import ReactiveMP: @test_rules
     end
 
     @testset "Variational Message Passing: (q_out::DiscreteNonParametric)" begin
-        # `with_falot_conversions = false` here is because apparently 
+        # `with_float_conversions = false` here is because apparently 
         # BigFloat(0.7) + BigFloat(0.3) != BigFloat(1.0)
         @test_rules [with_float_conversions = false] Bernoulli(:p, Marginalisation) [
             (input = (q_out = Categorical([0.0, 1.0]),), output = Beta(2.0, 1.0)), (input = (q_out = Categorical([0.7, 0.3]),), output = Beta(13 / 10, 17 / 10))

--- a/test/variables/test_constant.jl
+++ b/test/variables/test_constant.jl
@@ -12,7 +12,7 @@ import ReactiveMP: israndom, isproxy
 
 @testset "ConstVariable" begin
     @testset "Simple creation" begin
-        for sym in (:x, :y, :z), value in (1.0, 1.0, "asd", I, 0.3*I, [1.0, 1.0], [1.0 0.0; 0.0 1.0], (x) -> 1)
+        for sym in (:x, :y, :z), value in (1.0, 1.0, "asd", I, 0.3 * I, [1.0, 1.0], [1.0 0.0; 0.0 1.0], (x) -> 1)
             v = constvar(sym, value)
 
             @test !israndom(v)

--- a/test/variables/test_constant.jl
+++ b/test/variables/test_constant.jl
@@ -4,13 +4,15 @@ using Test
 using ReactiveMP
 using Rocket
 
+using LinearAlgebra: I
+
 import ReactiveMP: collection_type, VariableIndividual, VariableVector, VariableArray, linear_index
 import ReactiveMP: getconst, proxy_variables
 import ReactiveMP: israndom, isproxy
 
 @testset "ConstVariable" begin
     @testset "Simple creation" begin
-        for sym in (:x, :y, :z), value in (1.0, 1.0, "asd", [1.0, 1.0], [1.0 0.0; 0.0 1.0], (x) -> 1)
+        for sym in (:x, :y, :z), value in (1.0, 1.0, "asd", I, 0.3*I, [1.0, 1.0], [1.0 0.0; 0.0 1.0], (x) -> 1)
             v = constvar(sym, value)
 
             @test !israndom(v)


### PR DESCRIPTION
This PR implements the following and closes #266 :
- Allows for using `UniformScaling` objects in `GraphPPL`.
- Implements multivariate normal constructors that convert `UniformScaling` objects into `Diagonal` matrices according to the length of the (weighted) mean vector.
- Further constrains the specialized `prod` function for multivariate normal distributions to exclude `Diagonal` matrices.