### PR TITLE
283 the mean field rules for the transition node are not generic

### DIFF
--- a/src/distributions/bernoulli.jl
+++ b/src/distributions/bernoulli.jl
@@ -3,10 +3,11 @@ export Bernoulli, BernoulliNaturalParameters
 import Distributions: Bernoulli, Distribution, succprob, failprob, logpdf
 import Base
 import StatsFuns: logistic
+using StaticArrays
 
 vague(::Type{<:Bernoulli}) = Bernoulli(0.5)
 
-probvec(dist::Bernoulli) = (failprob(dist), succprob(dist))
+probvec(dist::Bernoulli) = @SArray [failprob(dist), succprob(dist)]
 
 prod_analytical_rule(::Type{<:Bernoulli}, ::Type{<:Bernoulli}) = ProdAnalyticalRuleAvailable()
 

--- a/src/rules/transition/in.jl
+++ b/src/rules/transition/in.jl
@@ -1,4 +1,11 @@
 
+@rule Transition(:in, Marginalisation) (m_out::Categorical, m_a::PointMass) = begin
+    @logscale log(sum(mean(A)' * probvec(m_out)))
+    p = mean(m_a)' * probvec(m_out)
+    normalize!(p, 1)
+    return Categorical(p)
+end
+
 @rule Transition(:in, Marginalisation) (q_out::Any, q_a::MatrixDirichlet) = begin
     a = clamp.(exp.(mean(log, q_a)' * probvec(q_out)), tiny, Inf)
     return Categorical(a ./ sum(a))
@@ -15,13 +22,6 @@ end
 
 @rule Transition(:in, Marginalisation) (q_out::PointMass, q_a::PointMass) = begin
     p = mean(q_a)' * mean(q_out)
-    normalize!(p, 1)
-    return Categorical(p)
-end
-
-@rule Transition(:in, Marginalisation) (m_out::Categorical, m_a::PointMass) = begin
-    @logscale log(sum(mean(A)' * probvec(m_out)))
-    p = mean(m_a)' * probvec(m_out)
     normalize!(p, 1)
     return Categorical(p)
 end

--- a/src/rules/transition/out.jl
+++ b/src/rules/transition/out.jl
@@ -1,5 +1,4 @@
 
- 
 # Belief Propagation                #
 # --------------------------------- #
 
@@ -32,5 +31,3 @@ end
 @rule Transition(:out, Marginalisation) (m_in::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin
     return @call_rule Transition(:out, Marginalisation) (m_in = m_in, m_a = q_a, meta = meta)
 end
-
-

--- a/src/rules/transition/out.jl
+++ b/src/rules/transition/out.jl
@@ -1,16 +1,13 @@
 
-@rule Transition(:out, Marginalisation) (q_in::Categorical, q_a::MatrixDirichlet) = begin
-    a = clamp.(exp.(mean(log, q_a) * probvec(q_in)), tiny, Inf)
-    return Categorical(a ./ sum(a))
-end
+ 
+# Belief Propagation                #
+# --------------------------------- #
 
-@rule Transition(:out, Marginalisation) (m_in::Categorical, q_a::MatrixDirichlet) = begin
-    a = clamp.(exp.(mean(log, q_a)) * probvec(m_in), tiny, Inf)
-    return Categorical(a ./ sum(a))
-end
-
-@rule Transition(:out, Marginalisation) (m_in::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin
-    return @call_rule Transition(:out, Marginalisation) (m_in = m_in, m_a = q_a, meta = meta)
+@rule Transition(:out, Marginalisation) (m_in::Categorical, m_a::PointMass) = begin
+    @logscale 0
+    p = mean(m_a) * probvec(m_in)
+    normalize!(p, 1)
+    return Categorical(p)
 end
 
 @rule Transition(:out, Marginalisation) (q_in::PointMass, q_a::PointMass) = begin
@@ -19,9 +16,21 @@ end
     return Categorical(p)
 end
 
-@rule Transition(:out, Marginalisation) (m_in::Categorical, m_a::PointMass) = begin
-    @logscale 0
-    p = mean(m_a) * probvec(m_in)
-    normalize!(p, 1)
-    return Categorical(p)
+# Variational                       # 
+# --------------------------------- #
+
+@rule Transition(:out, Marginalisation) (q_in::Categorical, q_a::Any) = begin
+    a = clamp.(exp.(mean(log, q_a) * probvec(q_in)), tiny, Inf)
+    return Categorical(a ./ sum(a))
 end
+
+@rule Transition(:out, Marginalisation) (m_in::Categorical, q_a::ContinuousMatrixDistribution) = begin
+    a = clamp.(exp.(mean(log, q_a)) * probvec(m_in), tiny, Inf)
+    return Categorical(a ./ sum(a))
+end
+
+@rule Transition(:out, Marginalisation) (m_in::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin
+    return @call_rule Transition(:out, Marginalisation) (m_in = m_in, m_a = q_a, meta = meta)
+end
+
+

--- a/test/distributions/test_bernoulli.jl
+++ b/test/distributions/test_bernoulli.jl
@@ -39,9 +39,9 @@ using ReactiveMP: compute_logscale
     end
 
     @testset "probvec" begin
-        @test probvec(Bernoulli(0.5)) === (0.5, 0.5)
-        @test probvec(Bernoulli(0.3)) === (0.7, 0.3)
-        @test probvec(Bernoulli(0.6)) === (0.4, 0.6)
+        @test all(probvec(Bernoulli(0.5)) .== (0.5, 0.5))
+        @test all(probvec(Bernoulli(0.3)) .== (0.7, 0.3))
+        @test all(probvec(Bernoulli(0.6)) .== (0.4, 0.6))
     end
 
     @testset "prod logscale Bernoulli-Bernoulli/Categorical" begin

--- a/test/rules/transition/test_a.jl
+++ b/test/rules/transition/test_a.jl
@@ -1,0 +1,26 @@
+module RulesTransitionATest
+
+using Test
+using ReactiveMP
+using Random
+
+import ReactiveMP: @test_rules
+
+@testset "rules:Transition:a" begin
+    @testset "Variational Bayes: (q_out::Any, q_in::Categorical)" begin
+        @test_rules [with_float_conversions = false] Transition(:a, Marginalisation) [
+            (input = (q_out = Categorical([0.2, 0.5, 0.3]), q_in = Categorical([0.1, 0.4, 0.5])), output = MatrixDirichlet([1.02 1.08 1.1; 1.05 1.2 1.25; 1.03 1.12 1.15])),
+            (input = (q_out = PointMass([0.2, 0.5, 0.3]), q_in = Categorical([0.1, 0.4, 0.5])), output = MatrixDirichlet([1.02 1.08 1.1; 1.05 1.2 1.25; 1.03 1.12 1.15])),
+            (input = (q_out = Dirichlet([0.2, 0.5, 0.3]), q_in = Categorical([0.1, 0.4, 0.5])), output = MatrixDirichlet([1.02 1.08 1.1; 1.05 1.2 1.25; 1.03 1.12 1.15])),
+            (input = (q_out = Bernoulli(0.3), q_in = Categorical([0.4, 0.6])), output = MatrixDirichlet([1.28 1.42 ; 1.12 1.18 ]))
+        ]
+    end
+
+    @testset "Variational Bayes: (q_out_in::Contingency)" begin
+        @test_rules [with_float_conversions = false] Transition(:a, Marginalisation) [
+            (input = (q_out_in = Contingency(diageye(3)),), output = MatrixDirichlet([1.333333333333333 1 1; 1 1.3333333333333 1; 1 1 1.33333333333333333])),
+        ]
+    end
+end
+
+end

--- a/test/rules/transition/test_a.jl
+++ b/test/rules/transition/test_a.jl
@@ -12,13 +12,13 @@ import ReactiveMP: @test_rules
             (input = (q_out = Categorical([0.2, 0.5, 0.3]), q_in = Categorical([0.1, 0.4, 0.5])), output = MatrixDirichlet([1.02 1.08 1.1; 1.05 1.2 1.25; 1.03 1.12 1.15])),
             (input = (q_out = PointMass([0.2, 0.5, 0.3]), q_in = Categorical([0.1, 0.4, 0.5])), output = MatrixDirichlet([1.02 1.08 1.1; 1.05 1.2 1.25; 1.03 1.12 1.15])),
             (input = (q_out = Dirichlet([0.2, 0.5, 0.3]), q_in = Categorical([0.1, 0.4, 0.5])), output = MatrixDirichlet([1.02 1.08 1.1; 1.05 1.2 1.25; 1.03 1.12 1.15])),
-            (input = (q_out = Bernoulli(0.3), q_in = Categorical([0.4, 0.6])), output = MatrixDirichlet([1.28 1.42 ; 1.12 1.18 ]))
+            (input = (q_out = Bernoulli(0.3), q_in = Categorical([0.4, 0.6])), output = MatrixDirichlet([1.28 1.42; 1.12 1.18]))
         ]
     end
 
     @testset "Variational Bayes: (q_out_in::Contingency)" begin
         @test_rules [with_float_conversions = false] Transition(:a, Marginalisation) [
-            (input = (q_out_in = Contingency(diageye(3)),), output = MatrixDirichlet([1.333333333333333 1 1; 1 1.3333333333333 1; 1 1 1.33333333333333333])),
+            (input = (q_out_in = Contingency(diageye(3)),), output = MatrixDirichlet([1.333333333333333 1 1; 1 1.3333333333333 1; 1 1 1.33333333333333333]))
         ]
     end
 end

--- a/test/rules/transition/test_a.jl
+++ b/test/rules/transition/test_a.jl
@@ -17,9 +17,9 @@ import ReactiveMP: @test_rules
     end
 
     @testset "Variational Bayes: (q_out_in::Contingency)" begin
-        @test_rules [with_float_conversions = false] Transition(:a, Marginalisation) [
-            (input = (q_out_in = Contingency(diageye(3)),), output = MatrixDirichlet([1.333333333333333 1 1; 1 1.3333333333333 1; 1 1 1.33333333333333333]))
-        ]
+        @test_rules [with_float_conversions = false] Transition(:a, Marginalisation) [(
+            input = (q_out_in = Contingency(diageye(3)),), output = MatrixDirichlet([1.333333333333333 1 1; 1 1.3333333333333 1; 1 1 1.33333333333333333])
+        )]
     end
 end
 

--- a/test/rules/transition/test_in.jl
+++ b/test/rules/transition/test_in.jl
@@ -1,0 +1,60 @@
+module RulesTransitionInTest
+
+using Test
+using ReactiveMP
+using Random
+
+import ReactiveMP: @test_rules
+
+@testset "rules:Transition:in" begin
+    @testset "Belief Propagation: (m_out::Categorical, m_a::PointMass)" begin
+        @test_rules [with_float_conversions = false] Transition(:in, Marginalisation) [
+            (
+                input = (m_out = Categorical([0.1, 0.4, 0.5]), m_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
+                output = Categorical([0.23000000000000004, 0.43, 0.33999999999999997])
+            )
+        ]
+    end
+
+    @testset "Variational Bayes: (q_out::Any, q_a::MatrixDirichlet)" begin
+        @test_rules [with_float_conversions = false] Transition(:in, Marginalisation) [
+            (
+                input = (q_out = PointMass([0.1, 0.4, 0.5]), q_a = MatrixDirichlet([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
+                output = Categorical([0.03245589526827472, 0.5950912160314408, 0.37245288870028453])
+            )
+        ]
+    end
+
+    @testset "Variational Bayes: (m_out::Categorical, q_a::MatrixDirichlet)" begin
+        @test_rules [with_float_conversions = false] Transition(:in, Marginalisation) [
+            (
+                input = (m_out = Categorical([0.1, 0.4, 0.5]), q_a = MatrixDirichlet([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
+                output = Categorical([0.27575594149188243, 0.5503434892576381, 0.17390056925047945])
+            ),
+            (
+                input = (m_out = Categorical([0.3, 0.3, 0.4]), q_a = MatrixDirichlet(diageye(3) .+ 1)),
+                output = Categorical([0.32119415576170857, 0.32119415576170857, 0.357611688476583])
+            )
+        ]
+    end
+
+    @testset "Variational Bayes: (m_out::Categorical, q_a::PointMass)" begin
+        @test_rules [with_float_conversions = false] Transition(:in, Marginalisation) [
+            (
+                input = (m_out = Categorical([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
+                output = Categorical([0.23000000000000004, 0.43, 0.33999999999999997])
+            )
+        ]
+    end
+
+    @testset "Variational Bayes: (q_out::PointMass, q_a::PointMass)" begin
+        @test_rules [with_float_conversions = false] Transition(:in, Marginalisation) [
+            (
+                input = (q_out = PointMass([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
+                output = Categorical([0.23000000000000004, 0.43, 0.33999999999999997])
+            )
+        ]
+    end
+end
+
+end

--- a/test/rules/transition/test_in.jl
+++ b/test/rules/transition/test_in.jl
@@ -8,21 +8,17 @@ import ReactiveMP: @test_rules
 
 @testset "rules:Transition:in" begin
     @testset "Belief Propagation: (m_out::Categorical, m_a::PointMass)" begin
-        @test_rules [with_float_conversions = false] Transition(:in, Marginalisation) [
-            (
-                input = (m_out = Categorical([0.1, 0.4, 0.5]), m_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
-                output = Categorical([0.23000000000000004, 0.43, 0.33999999999999997])
-            )
-        ]
+        @test_rules [with_float_conversions = false] Transition(:in, Marginalisation) [(
+            input = (m_out = Categorical([0.1, 0.4, 0.5]), m_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
+            output = Categorical([0.23000000000000004, 0.43, 0.33999999999999997])
+        )]
     end
 
     @testset "Variational Bayes: (q_out::Any, q_a::MatrixDirichlet)" begin
-        @test_rules [with_float_conversions = false] Transition(:in, Marginalisation) [
-            (
-                input = (q_out = PointMass([0.1, 0.4, 0.5]), q_a = MatrixDirichlet([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
-                output = Categorical([0.03245589526827472, 0.5950912160314408, 0.37245288870028453])
-            )
-        ]
+        @test_rules [with_float_conversions = false] Transition(:in, Marginalisation) [(
+            input = (q_out = PointMass([0.1, 0.4, 0.5]), q_a = MatrixDirichlet([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
+            output = Categorical([0.03245589526827472, 0.5950912160314408, 0.37245288870028453])
+        )]
     end
 
     @testset "Variational Bayes: (m_out::Categorical, q_a::MatrixDirichlet)" begin
@@ -39,21 +35,17 @@ import ReactiveMP: @test_rules
     end
 
     @testset "Variational Bayes: (m_out::Categorical, q_a::PointMass)" begin
-        @test_rules [with_float_conversions = false] Transition(:in, Marginalisation) [
-            (
-                input = (m_out = Categorical([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
-                output = Categorical([0.23000000000000004, 0.43, 0.33999999999999997])
-            )
-        ]
+        @test_rules [with_float_conversions = false] Transition(:in, Marginalisation) [(
+            input = (m_out = Categorical([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
+            output = Categorical([0.23000000000000004, 0.43, 0.33999999999999997])
+        )]
     end
 
     @testset "Variational Bayes: (q_out::PointMass, q_a::PointMass)" begin
-        @test_rules [with_float_conversions = false] Transition(:in, Marginalisation) [
-            (
-                input = (q_out = PointMass([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
-                output = Categorical([0.23000000000000004, 0.43, 0.33999999999999997])
-            )
-        ]
+        @test_rules [with_float_conversions = false] Transition(:in, Marginalisation) [(
+            input = (q_out = PointMass([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
+            output = Categorical([0.23000000000000004, 0.43, 0.33999999999999997])
+        )]
     end
 end
 

--- a/test/rules/transition/test_out.jl
+++ b/test/rules/transition/test_out.jl
@@ -34,12 +34,10 @@ import ReactiveMP: @test_rules
     end
 
     @testset "Variational Bayes: (q_in::Categorical, q_a::Any)" begin
-        @test_rules [with_float_conversions = false] Transition(:out, Marginalisation) [
-            (
-                input = (q_in = Categorical([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
-                output = Categorical([0.2994385327821292, 0.3260399327754116, 0.37452153444245917])
-            )
-        ]
+        @test_rules [with_float_conversions = false] Transition(:out, Marginalisation) [(
+            input = (q_in = Categorical([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
+            output = Categorical([0.2994385327821292, 0.3260399327754116, 0.37452153444245917])
+        )]
     end
 
     @testset "Variational Bayes: (m_in::Categorical, q_a::MatrixDirichlet)" begin

--- a/test/rules/transition/test_out.jl
+++ b/test/rules/transition/test_out.jl
@@ -9,35 +9,59 @@ import ReactiveMP: @test_rules
 @testset "rules:Transition:out" begin
     @testset "Belief Propagation: (q_in::PointMass, q_a::PointMass)" begin
         @test_rules [with_float_conversions = false] Transition(:out, Marginalisation) [
-            (input = (q_in = PointMass([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])), output = Categorical([0.3660714285714285, 0.27678571428571425, 0.35714285714285715])),
-            (input = (q_in = PointMass([0.2, 0.5, 0.3]), q_a = PointMass([0.1 0.8 0.1; 0.6 0.3 0.1; 0.2 0.4 0.4])), output = Categorical([0.40540540540540543, 0.2702702702702703, 0.32432432432432434])),
+            (
+                input = (q_in = PointMass([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
+                output = Categorical([0.3660714285714285, 0.27678571428571425, 0.35714285714285715])
+            ),
+            (
+                input = (q_in = PointMass([0.2, 0.5, 0.3]), q_a = PointMass([0.1 0.8 0.1; 0.6 0.3 0.1; 0.2 0.4 0.4])),
+                output = Categorical([0.40540540540540543, 0.2702702702702703, 0.32432432432432434])
+            )
         ]
     end
 
     @testset "Belief Propagation: (q_in::Categorical, q_a::PointMass)" begin
         @test_rules [with_float_conversions = false] Transition(:out, Marginalisation) [
-            (input = (m_in = Categorical([0.1, 0.4, 0.5]), m_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])), output = Categorical([0.3660714285714285, 0.27678571428571425, 0.35714285714285715])),
-            (input = (m_in = Categorical([0.2, 0.5, 0.3]), m_a = PointMass([0.1 0.8 0.1; 0.6 0.3 0.1; 0.2 0.4 0.4])), output = Categorical([0.40540540540540543, 0.2702702702702703, 0.32432432432432434])),
+            (
+                input = (m_in = Categorical([0.1, 0.4, 0.5]), m_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
+                output = Categorical([0.3660714285714285, 0.27678571428571425, 0.35714285714285715])
+            ),
+            (
+                input = (m_in = Categorical([0.2, 0.5, 0.3]), m_a = PointMass([0.1 0.8 0.1; 0.6 0.3 0.1; 0.2 0.4 0.4])),
+                output = Categorical([0.40540540540540543, 0.2702702702702703, 0.32432432432432434])
+            )
         ]
     end
 
     @testset "Variational Bayes: (q_in::Categorical, q_a::Any)" begin
         @test_rules [with_float_conversions = false] Transition(:out, Marginalisation) [
-            (input = (q_in = Categorical([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])), output = Categorical([0.2994385327821292, 0.3260399327754116, 0.37452153444245917])),
+            (
+                input = (q_in = Categorical([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
+                output = Categorical([0.2994385327821292, 0.3260399327754116, 0.37452153444245917])
+            )
         ]
     end
 
     @testset "Variational Bayes: (m_in::Categorical, q_a::MatrixDirichlet)" begin
         @test_rules [with_float_conversions = false] Transition(:out, Marginalisation) [
             (input = (q_in = Categorical([0.1, 0.9]), q_a = MatrixDirichlet([0.1 0.1; 0.3 0.4])), output = Categorical([0.0004227712570263357, 0.9995772287429735])),
-            (input = (q_in = Categorical([0.2, 0.5, 0.3]), q_a = MatrixDirichlet([0.1 0.8 0.1; 0.6 0.3 0.1; 0.2 0.4 0.4])), output = Categorical([0.0626653372827384, 0.10413392154490132, 0.8332007411723602])),
+            (
+                input = (q_in = Categorical([0.2, 0.5, 0.3]), q_a = MatrixDirichlet([0.1 0.8 0.1; 0.6 0.3 0.1; 0.2 0.4 0.4])),
+                output = Categorical([0.0626653372827384, 0.10413392154490132, 0.8332007411723602])
+            )
         ]
     end
 
     @testset "Variational Bayes: (m_in::DiscreteNonParametric, q_a::PointMass)" begin
         @test_rules [with_float_conversions = false] Transition(:out, Marginalisation) [
-            (input = (m_in = Categorical([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])), output = Categorical([0.3660714285714285, 0.27678571428571425, 0.35714285714285715])),
-            (input = (m_in = Categorical([0.2, 0.5, 0.3]), q_a = PointMass([0.1 0.8 0.1; 0.6 0.3 0.1; 0.2 0.4 0.4])), output = Categorical([0.40540540540540543, 0.2702702702702703, 0.32432432432432434])),
+            (
+                input = (m_in = Categorical([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])),
+                output = Categorical([0.3660714285714285, 0.27678571428571425, 0.35714285714285715])
+            ),
+            (
+                input = (m_in = Categorical([0.2, 0.5, 0.3]), q_a = PointMass([0.1 0.8 0.1; 0.6 0.3 0.1; 0.2 0.4 0.4])),
+                output = Categorical([0.40540540540540543, 0.2702702702702703, 0.32432432432432434])
+            )
         ]
     end
 end

--- a/test/rules/transition/test_out.jl
+++ b/test/rules/transition/test_out.jl
@@ -1,0 +1,45 @@
+module RulesTransitionOutTest
+
+using Test
+using ReactiveMP
+using Random
+
+import ReactiveMP: @test_rules
+
+@testset "rules:Transition:out" begin
+    @testset "Belief Propagation: (q_in::PointMass, q_a::PointMass)" begin
+        @test_rules [with_float_conversions = false] Transition(:out, Marginalisation) [
+            (input = (q_in = PointMass([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])), output = Categorical([0.3660714285714285, 0.27678571428571425, 0.35714285714285715])),
+            (input = (q_in = PointMass([0.2, 0.5, 0.3]), q_a = PointMass([0.1 0.8 0.1; 0.6 0.3 0.1; 0.2 0.4 0.4])), output = Categorical([0.40540540540540543, 0.2702702702702703, 0.32432432432432434])),
+        ]
+    end
+
+    @testset "Belief Propagation: (q_in::Categorical, q_a::PointMass)" begin
+        @test_rules [with_float_conversions = false] Transition(:out, Marginalisation) [
+            (input = (m_in = Categorical([0.1, 0.4, 0.5]), m_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])), output = Categorical([0.3660714285714285, 0.27678571428571425, 0.35714285714285715])),
+            (input = (m_in = Categorical([0.2, 0.5, 0.3]), m_a = PointMass([0.1 0.8 0.1; 0.6 0.3 0.1; 0.2 0.4 0.4])), output = Categorical([0.40540540540540543, 0.2702702702702703, 0.32432432432432434])),
+        ]
+    end
+
+    @testset "Variational Bayes: (q_in::Categorical, q_a::Any)" begin
+        @test_rules [with_float_conversions = false] Transition(:out, Marginalisation) [
+            (input = (q_in = Categorical([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])), output = Categorical([0.2994385327821292, 0.3260399327754116, 0.37452153444245917])),
+        ]
+    end
+
+    @testset "Variational Bayes: (m_in::Categorical, q_a::MatrixDirichlet)" begin
+        @test_rules [with_float_conversions = false] Transition(:out, Marginalisation) [
+            (input = (q_in = Categorical([0.1, 0.9]), q_a = MatrixDirichlet([0.1 0.1; 0.3 0.4])), output = Categorical([0.0004227712570263357, 0.9995772287429735])),
+            (input = (q_in = Categorical([0.2, 0.5, 0.3]), q_a = MatrixDirichlet([0.1 0.8 0.1; 0.6 0.3 0.1; 0.2 0.4 0.4])), output = Categorical([0.0626653372827384, 0.10413392154490132, 0.8332007411723602])),
+        ]
+    end
+
+    @testset "Variational Bayes: (m_in::DiscreteNonParametric, q_a::PointMass)" begin
+        @test_rules [with_float_conversions = false] Transition(:out, Marginalisation) [
+            (input = (m_in = Categorical([0.1, 0.4, 0.5]), q_a = PointMass([0.2 0.1 0.7; 0.4 0.3 0.3; 0.1 0.6 0.3])), output = Categorical([0.3660714285714285, 0.27678571428571425, 0.35714285714285715])),
+            (input = (m_in = Categorical([0.2, 0.5, 0.3]), q_a = PointMass([0.1 0.8 0.1; 0.6 0.3 0.1; 0.2 0.4 0.4])), output = Categorical([0.40540540540540543, 0.2702702702702703, 0.32432432432432434])),
+        ]
+    end
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -392,6 +392,8 @@ end
     addtests(testrunner, "rules/implication/test_marginals.jl")
 
     addtests(testrunner, "rules/transition/test_out.jl")
+    addtests(testrunner, "rules/transition/test_a.jl")
+    addtests(testrunner, "rules/transition/test_in.jl")
 
     run(testrunner)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -391,5 +391,7 @@ end
     addtests(testrunner, "rules/implication/test_in2.jl")
     addtests(testrunner, "rules/implication/test_marginals.jl")
 
+    addtests(testrunner, "rules/transition/test_out.jl")
+
     run(testrunner)
 end


### PR DESCRIPTION
Please take a look at the rule redefinition for the out interface of the Transition node,  as I made it dispatch on ContinuousMatrixDistribution rather than MatrixDirichlet. This might break if the user supplies a transition matrix with negative values, as it will throw a DomainError on the log function.