### PR TITLE
Improve `MessageMapping` rules dispatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ examples/*Compiled
 
 **/.benchmarkci
 benchmark/*.json
+
+Session.vim

--- a/src/helpers/macrohelpers.jl
+++ b/src/helpers/macrohelpers.jl
@@ -66,11 +66,10 @@ function strip_type_parameters(type)
         return :(typeof($(ensure_symbol(T))))
     elseif @capture(type, T_{R_})
         return strip_type_parameters(T)
-    else 
+    else
         return ensure_symbol(type)
     end
 end
-
 
 """
     proxy_type(proxy, type)

--- a/src/helpers/macrohelpers.jl
+++ b/src/helpers/macrohelpers.jl
@@ -34,11 +34,12 @@ end
 """
     upper_type(type)
 
+This function returns `typeof(T)` expression for the `typeof(T)` input expression.
 This function returns `Type{ <: T }` expression for the following input expressions:
-1. typeof(T)
-2. Type{ <: T }
-3. Type{ T }
-4. T
+1. Type{ <: T }
+2. Type{ T }
+3. T
+
 
 # Arguments
 - `type`: Type expression to be extended
@@ -54,6 +55,22 @@ function upper_type(type)
         return :(Type{<:$(bottom_type(type))})
     end
 end
+
+"""
+    strip_type_parameters(type)
+
+This function strips all type parameters from the type expression (if any).
+"""
+function strip_type_parameters(type)
+    if @capture(type, typeof(T_))
+        return :(typeof($(ensure_symbol(T))))
+    elseif @capture(type, T_{R_})
+        return strip_type_parameters(T)
+    else 
+        return ensure_symbol(type)
+    end
+end
+
 
 """
     proxy_type(proxy, type)

--- a/src/message.jl
+++ b/src/message.jl
@@ -314,15 +314,7 @@ function materialize!(mapping::MessageMapping, dependencies)
     is_message_initial = !is_message_clamped && (__check_all(is_clamped_or_initial, messages) && __check_all(is_clamped_or_initial, marginals))
 
     result, addons = mapping.rulefn(
-        mapping.vtag,
-        mapping.vconstraint,
-        mapping.msgs_names,
-        messages,
-        mapping.marginals_names,
-        marginals,
-        mapping.meta,
-        mapping.addons,
-        mapping.factornode
+        mapping.vtag, mapping.vconstraint, mapping.msgs_names, messages, mapping.marginals_names, marginals, mapping.meta, mapping.addons, mapping.factornode
     )
 
     # Inject extra addons after the rule has been executed

--- a/src/nodes/delta/delta.jl
+++ b/src/nodes/delta/delta.jl
@@ -93,7 +93,7 @@ end
 # `DeltaFn` is defined by hand, hence, requires ``
 function rule_for_DeltaFn end
 
-node_rule_function(::Type{ <:DeltaFn }) = rule_for_DeltaFn
+node_rule_function(::Type{<:DeltaFn}) = rule_for_DeltaFn
 
 function interfaceindex(factornode::DeltaFnNode, iname::Symbol)
     # Julia's constant propagation should compile-out this if-else branch

--- a/src/nodes/delta/delta.jl
+++ b/src/nodes/delta/delta.jl
@@ -69,9 +69,11 @@ nodefunction(factornode::DeltaFnNode, ::Val{:in})             = getinverse(metad
 nodefunction(factornode::DeltaFnNode, ::Val{:in}, k::Integer) = getinverse(metadata(factornode), k)
 
 # Rules for `::Function` objects, but with the `DeltaFn` related meta and node should redirect to the `DeltaFn` rules
-function rule(::F, on, vconstraint, mnames, messages, qnames, marginals, meta::DeltaMeta, addons::Any, node::DeltaFnNode) where {F <: Function}
-    return rule(DeltaFn{F}, on, vconstraint, mnames, messages, qnames, marginals, meta, addons, node)
-end
+# function rule(::F, on, vconstraint, mnames, messages, qnames, marginals, meta::DeltaMeta, addons::Any, node::DeltaFnNode) where {F <: Function}
+    # return rule(DeltaFn{F}, on, vconstraint, mnames, messages, qnames, marginals, meta, addons, node)
+# end
+# NOTE: dispatch for `rule` is optimized by hand, the method above is no longer needed, but `marginalrule` are called 
+# in less efficient way, remove the `marginalrule` below when it is optimized in the same way as for the `rule`
 
 function marginalrule(::F, on, mnames, messages, qnames, marginals, meta::DeltaMeta, node::DeltaFnNode) where {F <: Function}
     return marginalrule(DeltaFn{F}, on, mnames, messages, qnames, marginals, meta, node)

--- a/src/nodes/delta/delta.jl
+++ b/src/nodes/delta/delta.jl
@@ -1,4 +1,5 @@
 export DeltaFn, DeltaFnNode, DeltaMeta
+export rule_for_DeltaFn
 
 """
     DeltaMeta(method = ..., [ inverse = ... ])
@@ -88,6 +89,11 @@ function call_rule_make_node(::CallRuleNodeRequired, fformtype::Type{<:DeltaFn},
     # Doing so will most likely throw an error
     return DeltaFnNode(nodetype, NodeInterface(:out, Marginalisation()), (), nothing, collect_meta(DeltaFn{F}, meta))
 end
+
+# `DeltaFn` is defined by hand, hence, requires ``
+function rule_for_DeltaFn end
+
+node_rule_function(::Type{ <:DeltaFn }) = rule_for_DeltaFn
 
 function interfaceindex(factornode::DeltaFnNode, iname::Symbol)
     # Julia's constant propagation should compile-out this if-else branch

--- a/src/nodes/delta/layouts/cvi.jl
+++ b/src/nodes/delta/layouts/cvi.jl
@@ -39,14 +39,14 @@ function deltafn_apply_layout(::CVIApproximationDeltaFnRuleLayout, ::Val{:m_out}
         marginals_observable = combineLatestUpdates((getstream(factornode.localmarginals.marginals[2]),), PushNew())
 
         fform       = functionalform(factornode)
+        rulefn      = node_rule_function(fform)
         vtag        = tag(interface)
         vconstraint = local_constraint(interface)
         meta        = metadata(factornode)
 
         vmessageout = combineLatest((msgs_observable, marginals_observable), PushNew())
 
-        # TODO add addons
-        mapping = let messagemap = MessageMapping(fform, vtag, vconstraint, msgs_names, marginal_names, meta, addons, factornode)
+        mapping = let messagemap = MessageMapping(rulefn, vtag, vconstraint, msgs_names, marginal_names, meta, addons, factornode)
             (dependencies) -> VariationalMessage(dependencies[1], dependencies[2], messagemap)
         end
 

--- a/src/nodes/delta/layouts/default.jl
+++ b/src/nodes/delta/layouts/default.jl
@@ -62,13 +62,14 @@ function deltafn_apply_layout(::DeltaFnDefaultRuleLayout, ::Val{:m_out}, factorn
         marginals_observable = of(nothing)
 
         fform       = functionalform(factornode)
+        rulefn      = node_rule_function(fform)
         vtag        = tag(out)
         vconstraint = local_constraint(out)
         meta        = metadata(factornode)
 
         vmessageout = combineLatest((msgs_observable, marginals_observable), PushNew())
 
-        mapping = let messagemap = MessageMapping(fform, vtag, vconstraint, msgs_names, marginal_names, meta, addons, factornode)
+        mapping = let messagemap = MessageMapping(rulefn, vtag, vconstraint, msgs_names, marginal_names, meta, addons, factornode)
             (dependencies) -> VariationalMessage(dependencies[1], dependencies[2], messagemap)
         end
 
@@ -91,13 +92,14 @@ function deltafn_apply_layout(::DeltaFnDefaultRuleLayout, ::Val{:m_in}, factorno
         marginals_observable = combineLatestUpdates((getstream(factornode.localmarginals.marginals[2]),), PushNew())
 
         fform       = functionalform(factornode)
+        rulefn      = node_rule_function(fform)
         vtag        = tag(interface)
         vconstraint = local_constraint(interface)
         meta        = metadata(factornode)
 
         vmessageout = combineLatest((msgs_observable, marginals_observable), PushNew())
 
-        mapping = let messagemap = MessageMapping(fform, vtag, vconstraint, msgs_names, marginal_names, meta, addons, factornode)
+        mapping = let messagemap = MessageMapping(rulefn, vtag, vconstraint, msgs_names, marginal_names, meta, addons, factornode)
             (dependencies) -> VariationalMessage(dependencies[1], dependencies[2], messagemap)
         end
 
@@ -159,14 +161,14 @@ function deltafn_apply_layout(::DeltaFnDefaultKnownInverseRuleLayout, ::Val{:m_i
         marginals_observable = of(nothing)
 
         fform       = functionalform(factornode)
+        rulefn      = node_rule_function(fform)
         vtag        = tag(interface)
         vconstraint = local_constraint(interface)
         meta        = metadata(factornode)
 
         vmessageout = combineLatest((msgs_observable, marginals_observable), PushNew())
 
-        # TODO add addons
-        mapping = let messagemap = MessageMapping(fform, vtag, vconstraint, msgs_names, marginal_names, meta, addons, factornode)
+        mapping = let messagemap = MessageMapping(rulefn, vtag, vconstraint, msgs_names, marginal_names, meta, addons, factornode)
             (dependencies) -> VariationalMessage(dependencies[1], dependencies[2], messagemap)
         end
 

--- a/src/nodes/gamma_mixture.jl
+++ b/src/nodes/gamma_mixture.jl
@@ -1,4 +1,5 @@
 export GammaMixture, GammaMixtureNode
+export rule_for_GammaMixture
 
 # Gamma Mixture Functional Form
 struct GammaMixture{N} end
@@ -130,6 +131,12 @@ function get_marginals_observable(factornode::GammaMixtureNode{N, F}, marginal_d
 
     return marginal_names, marginals_observable
 end
+
+# Manual dispatch rule specification 
+
+function rule_for_GammaMixture end
+
+node_rule_function(::Type{GammaMixture}) = rule_for_GammaMixture
 
 # FreeEnergy related functions
 

--- a/src/nodes/gamma_mixture.jl
+++ b/src/nodes/gamma_mixture.jl
@@ -136,7 +136,7 @@ end
 
 function rule_for_GammaMixture end
 
-node_rule_function(::Type{GammaMixture}) = rule_for_GammaMixture
+node_rule_function(::Type{<:GammaMixture}) = rule_for_GammaMixture
 
 # FreeEnergy related functions
 

--- a/src/nodes/implication.jl
+++ b/src/nodes/implication.jl
@@ -1,7 +1,7 @@
 export IMPLY
 
 """
-IMPY node implements implication function that can be desribed by the followsing table:
+IMPLY node implements implication function that can be desribed by the followsing table:
 | in1  in2 | out |
 |  0    0  |  1  |
 |  0    1  |  1  |

--- a/src/nodes/mixture.jl
+++ b/src/nodes/mixture.jl
@@ -1,4 +1,5 @@
 export Mixture, MixtureNode
+export rule_for_Mixture
 
 # Mixture Functional Form
 struct Mixture{N} end
@@ -179,6 +180,12 @@ function get_marginals_observable(factornode::MixtureNode{N, F}, marginal_depend
 end
 
 as_node_functional_form(::Type{<:Mixture}) = ValidNodeFunctionalForm()
+
+# Manual dispatch rule specification 
+
+function rule_for_Mixture end
+
+node_rule_function(::Type{<:Mixture}) = rule_for_Mixture
 
 # Node creation related functions
 

--- a/src/nodes/normal_mixture.jl
+++ b/src/nodes/normal_mixture.jl
@@ -1,5 +1,6 @@
 export NormalMixture, NormalMixtureNode
 export GaussianMixture, GaussianMixtureNode
+export rule_for_NormalMixture
 
 # Normal Mixture Functional Form
 struct NormalMixture{N} end
@@ -134,6 +135,12 @@ function get_marginals_observable(factornode::NormalMixtureNode{N, F}, marginal_
 
     return marginal_names, marginals_observable
 end
+
+# Manual dispatch rule specification 
+
+function rule_for_NormalMixture end
+
+node_rule_function(::Type{ NormalMixture }) = rule_for_NormalMixture
 
 # FreeEnergy related functions
 

--- a/src/nodes/normal_mixture.jl
+++ b/src/nodes/normal_mixture.jl
@@ -140,7 +140,7 @@ end
 
 function rule_for_NormalMixture end
 
-node_rule_function(::Type{ NormalMixture }) = rule_for_NormalMixture
+node_rule_function(::Type{<:NormalMixture}) = rule_for_NormalMixture
 
 # FreeEnergy related functions
 

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -274,7 +274,7 @@ function rule_function_expression(body::Function, fformtype, fuppertype, on_type
         @static if !isdefined(@__MODULE__(), $(QuoteNode(update_rule_fn)))
             error($override_err_msg)
         end
-       
+
         # Keep for backward compatibility
         function ReactiveMP.rule(
             fform::$(fuppertype),
@@ -288,17 +288,7 @@ function rule_function_expression(body::Function, fformtype, fuppertype, on_type
             $(addonsvar),
             $(nodevar)
         ) where {$(whereargs...)}
-            return node_rule_function(fform)(
-                on, 
-                vconstraint, 
-                messages_names, 
-                messages, 
-                marginals_names, 
-                marginals, 
-                meta, 
-                $(addonsvar), 
-                $(nodevar)
-            )
+            return node_rule_function(fform)(on, vconstraint, messages_names, messages, marginals_names, marginals, meta, $(addonsvar), $(nodevar))
         end
 
         # Dispatch efficient version

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -264,7 +264,7 @@ function rule_function_expression(body::Function, fformtype, fuppertype, on_type
     update_rule_fn = Symbol(:rule_for_, nodeform)
     override_err_msg = """
     Trying to override a message update rule `$(update_rule_fn)` outside of the module it has been defined. 
-    Try to use `import ReactiveMP: $(update_rule_fn)` to supress this error.
+    Try to use `import ReactiveMP: $(update_rule_fn)` or `import ReactiveMP: var"$(update_rule_fn)"`to supress this error.
     If error does not disappear, replace the `import ReactiveMP` with `import XXX`, where `XXX` is the module where `$(nodeform)` has been defined.
     """
     return quote

--- a/src/rules/implication/in1.jl
+++ b/src/rules/implication/in1.jl
@@ -1,4 +1,4 @@
-@rule typeof(IMPLY)(:in1, Marginalisation) (m_out::Bernoulli, m_in2::Bernoulli) = begin
+@rule IMPLY(:in1, Marginalisation) (m_out::Bernoulli, m_in2::Bernoulli) = begin
     pout, pin2 = mean(m_out), mean(m_in2)
 
     return Bernoulli((1 - pout - pin2 + 2 * pout * pin2) / (1 - pin2 + 2 * pout * pin2))

--- a/src/rules/implication/in2.jl
+++ b/src/rules/implication/in2.jl
@@ -1,4 +1,4 @@
-@rule typeof(IMPLY)(:in2, Marginalisation) (m_out::Bernoulli, m_in1::Bernoulli) = begin
+@rule IMPLY(:in2, Marginalisation) (m_out::Bernoulli, m_in1::Bernoulli) = begin
     pout, pin1 = mean(m_out), mean(m_in1)
 
     return Bernoulli((pout) / (2 * pout + pin1 - 2 * pout * pin1))

--- a/src/rules/implication/out.jl
+++ b/src/rules/implication/out.jl
@@ -1,4 +1,4 @@
-@rule typeof(IMPLY)(:out, Marginalisation) (m_in1::Bernoulli, m_in2::Bernoulli) = begin
+@rule IMPLY(:out, Marginalisation) (m_in1::Bernoulli, m_in2::Bernoulli) = begin
     pin1, pin2 = mean(m_in1), mean(m_in2)
 
     return Bernoulli(1 - pin1 + pin1 * pin2)

--- a/test/helpers/test_macrohelpers.jl
+++ b/test/helpers/test_macrohelpers.jl
@@ -1,4 +1,4 @@
-module ReactiveMPMacroHelpersTest 
+module ReactiveMPMacroHelpersTest
 
 using Test
 using ReactiveMP
@@ -6,9 +6,8 @@ using MacroTools
 
 import ReactiveMP.MacroHelpers: bottom_type, upper_type, strip_type_parameters
 
-@testset "Macro helpers" begin 
-
-    @testset "bottom_type" begin 
+@testset "Macro helpers" begin
+    @testset "bottom_type" begin
         @test bottom_type(:(Int)) === :Int
         @test bottom_type(:(Type{Int})) === :Int
         @test bottom_type(:(Type{Vector{Int}})) == :(Vector{Int})
@@ -17,7 +16,7 @@ import ReactiveMP.MacroHelpers: bottom_type, upper_type, strip_type_parameters
         @test bottom_type(:(typeof(+))) === :+
     end
 
-    @testset "upper_type" begin 
+    @testset "upper_type" begin
         @test upper_type(:(Int)) == :(Type{<:Int})
         @test upper_type(:(Type{Int})) == :(Type{<:Int})
         @test upper_type(:(Type{Vector{Int}})) == :(Type{<:Vector{Int}})
@@ -26,8 +25,7 @@ import ReactiveMP.MacroHelpers: bottom_type, upper_type, strip_type_parameters
         @test upper_type(:(typeof(+))) == :(typeof(+))
     end
 
-
-    @testset "strip_type_parameters" begin 
+    @testset "strip_type_parameters" begin
         @test strip_type_parameters(:(Int)) === :Int
         @test strip_type_parameters(:(Type{Int})) === :Type
         @test strip_type_parameters(:(Vector{Int})) === :Vector

--- a/test/helpers/test_macrohelpers.jl
+++ b/test/helpers/test_macrohelpers.jl
@@ -1,0 +1,40 @@
+module ReactiveMPMacroHelpersTest 
+
+using Test
+using ReactiveMP
+using MacroTools
+
+import ReactiveMP.MacroHelpers: bottom_type, upper_type, strip_type_parameters
+
+@testset "Macro helpers" begin 
+
+    @testset "bottom_type" begin 
+        @test bottom_type(:(Int)) === :Int
+        @test bottom_type(:(Type{Int})) === :Int
+        @test bottom_type(:(Type{Vector{Int}})) == :(Vector{Int})
+        @test bottom_type(:(Type{<:Real})) === :Real
+        @test bottom_type(:(Type{<:Vector{Int}})) == :(Vector{Int})
+        @test bottom_type(:(typeof(+))) === :+
+    end
+
+    @testset "upper_type" begin 
+        @test upper_type(:(Int)) == :(Type{<:Int})
+        @test upper_type(:(Type{Int})) == :(Type{<:Int})
+        @test upper_type(:(Type{Vector{Int}})) == :(Type{<:Vector{Int}})
+        @test upper_type(:(Type{<:Real})) == :(Type{<:Real})
+        @test upper_type(:(Type{<:Vector{Int}})) == :(Type{<:Vector{Int}})
+        @test upper_type(:(typeof(+))) == :(typeof(+))
+    end
+
+
+    @testset "strip_type_parameters" begin 
+        @test strip_type_parameters(:(Int)) === :Int
+        @test strip_type_parameters(:(Type{Int})) === :Type
+        @test strip_type_parameters(:(Vector{Int})) === :Vector
+        @test strip_type_parameters(:(Type{<:Real})) === :Type
+        @test strip_type_parameters(:(Vector{<:Real})) === :Vector
+        @test strip_type_parameters(:(typeof(+))) == :(typeof(+))
+    end
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -206,6 +206,7 @@ end
     addtests(testrunner, "algebra/test_standard_basis_vector.jl")
 
     addtests(testrunner, "helpers/test_helpers.jl")
+    addtests(testrunner, "helpers/test_macrohelpers.jl")
 
     addtests(testrunner, "score/test_counting.jl")
 


### PR DESCRIPTION
This PR improves upon #290 and addresses #284 even further. 

This PR changes the way `MessageMapping` dispatches on a particular rule. I couldn't improve things further because it requires a lot of changes in the core, but there is definitely room for improvement and we can reduce allocation profile even further. This is very crucial for real-time applications.

The PR is breaking, but imo minor. After this PR, it is no longer possible to add/change/override built-in rules without explicit import statement, e.g:
```
import ReactiveMP: rule_for_NormalMeanVariance # `@rule` below will error without this import statement

@rule NormalMeanVariance(:out, ...) ... = begin 
 ...
end
```
There are no problems adding new rules with the explicit import statement. I could think more of possible solutions for that, but in general further improvements require a complete `rule` refactoring.

The benefits are improved allocation profile and faster inference in general, especially for the `rxinference` function from `RxInfer`. These are timing from the `Tiny Benchmark.ipynb`. 

### `master`

```
BenchmarkTools.Trial: 1834 samples with 1 evaluation.
 Range (min … max):  2.457 ms … 11.236 ms  ┊ GC (min … max): 0.00% … 74.35%
 Time  (median):     2.518 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.725 ms ±  1.177 ms  ┊ GC (mean ± σ):  6.67% ± 11.31%

  █▅▁                                                         
  ███▆▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅▆▇ █
  2.46 ms      Histogram: log(frequency) by time     10.1 ms <

 Memory estimate: 3.05 MiB, allocs estimate: 83828.
BenchmarkTools.Trial: 565 samples with 1 evaluation.
 Range (min … max):  7.731 ms … 21.617 ms  ┊ GC (min … max): 0.00% … 54.27%
 Time  (median):     7.899 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   8.850 ms ±  2.809 ms  ┊ GC (mean ± σ):  9.13% ± 14.68%

  █▆▂▂                                                        
  █████▆▅▆▆▅▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▄▆▆▁▄▅▆▇▆▅▇▅▄ ▆
  7.73 ms      Histogram: log(frequency) by time     18.8 ms <

 Memory estimate: 11.10 MiB, allocs estimate: 241913.
```

### `PR`

```
BenchmarkTools.Trial: 2831 samples with 1 evaluation.
 Range (min … max):  1.576 ms …   9.150 ms  ┊ GC (min … max): 0.00% … 79.29%
 Time  (median):     1.615 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.765 ms ± 998.268 μs  ┊ GC (mean ± σ):  8.03% ± 11.32%

  █▂                                                           
  ██▅▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ █
  1.58 ms      Histogram: log(frequency) by time      8.65 ms <

 Memory estimate: 2.56 MiB, allocs estimate: 67828.

BenchmarkTools.Trial: 603 samples with 1 evaluation.
 Range (min … max):  6.953 ms … 21.804 ms  ┊ GC (min … max):  0.00% … 55.96%
 Time  (median):     7.264 ms              ┊ GC (median):     0.00%
 Time  (mean ± σ):   8.295 ms ±  3.085 ms  ┊ GC (mean ± σ):  10.30% ± 15.45%

  █▆▅▃▂▁ ▁                                                    
  ████████▆▅▆▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▁▄▄▆▇██▆▆▅▅▁▄▄ ▇
  6.95 ms      Histogram: log(frequency) by time     19.8 ms <

 Memory estimate: 10.73 MiB, allocs estimate: 229906.
```

WDYT of the benefits and of the breaking change? 

@bartvanerp you might be interested.