### PR TITLE
Add rules for univariate normal

### DIFF
--- a/src/rules/normal_mean_precision/mean.jl
+++ b/src/rules/normal_mean_precision/mean.jl
@@ -15,6 +15,8 @@ end
 
 @rule NormalMeanPrecision(:μ, Marginalisation) (q_out::Any, q_τ::Any) = NormalMeanPrecision(mean(q_out), mean(q_τ))
 
+@rule NormalMeanPrecision(:μ, Marginalisation) (m_out::PointMass, q_τ::Any) = NormalMeanPrecision(mean(m_out), mean(q_τ))
+
 @rule NormalMeanPrecision(:μ, Marginalisation) (m_out::UnivariateNormalDistributionsFamily, q_τ::Any) = begin
     m_out_mean, m_out_cov = mean_cov(m_out)
     return NormalMeanVariance(m_out_mean, m_out_cov + cholinv(mean(q_τ)))

--- a/src/rules/normal_mean_precision/out.jl
+++ b/src/rules/normal_mean_precision/out.jl
@@ -15,6 +15,8 @@ end
 
 @rule NormalMeanPrecision(:out, Marginalisation) (q_μ::Any, q_τ::Any) = NormalMeanPrecision(mean(q_μ), mean(q_τ))
 
+@rule NormalMeanPrecision(:out, Marginalisation) (m_μ::PointMass, q_τ::Any) = NormalMeanPrecision(mean(m_μ), mean(q_τ))
+
 @rule NormalMeanPrecision(:out, Marginalisation) (m_μ::UnivariateNormalDistributionsFamily, q_τ::Any) = begin
     m_μ_mean, m_μ_cov = mean_cov(m_μ)
     return NormalMeanPrecision(m_μ_mean, cholinv(m_μ_cov + cholinv(mean(q_τ))))

--- a/src/rules/normal_mean_variance/mean.jl
+++ b/src/rules/normal_mean_variance/mean.jl
@@ -15,6 +15,8 @@ end
 
 @rule NormalMeanVariance(:μ, Marginalisation) (q_out::Any, q_v::Any) = NormalMeanVariance(mean(q_out), mean(q_v))
 
+@rule NormalMeanVariance(:μ, Marginalisation) (m_out::PointMass, q_v::Any) = NormalMeanVariance(mean(m_out), mean(q_v))
+
 @rule NormalMeanVariance(:μ, Marginalisation) (m_out::UnivariateNormalDistributionsFamily, q_v::Any) = begin
     m_out_mean, m_out_cov = mean_cov(m_out)
     return NormalMeanVariance(m_out_mean, m_out_cov + mean(q_v))

--- a/src/rules/normal_mean_variance/out.jl
+++ b/src/rules/normal_mean_variance/out.jl
@@ -15,6 +15,8 @@ end
 
 @rule NormalMeanVariance(:out, Marginalisation) (q_μ::Any, q_v::Any) = NormalMeanVariance(mean(q_μ), mean(q_v))
 
+@rule NormalMeanVariance(:out, Marginalisation) (m_μ::PointMass, q_v::Any) = NormalMeanVariance(mean(m_μ), mean(q_v))
+
 @rule NormalMeanVariance(:out, Marginalisation) (m_μ::UnivariateNormalDistributionsFamily, q_v::Any) = begin
     m_μ_mean, m_μ_cov = mean_cov(m_μ)
     return NormalMeanVariance(m_μ_mean, m_μ_cov + mean(q_v))

--- a/test/rules/normal_mean_precision/test_mean.jl
+++ b/test/rules/normal_mean_precision/test_mean.jl
@@ -55,6 +55,14 @@ import ReactiveMP: @test_rules
         ]
     end
 
+    @testset "Variational: (m_out::PointMass, q_τ::Any)" begin
+        @test_rules [with_float_conversions = true] NormalMeanPrecision(:μ, Marginalisation) [
+            (input = (m_out = PointMass(-1.0), q_τ = GammaShapeRate(1.0, 1.0)), output = NormalMeanPrecision(-1.0, 1.0)),
+            (input = (m_out = PointMass(1.0), q_τ = GammaShapeScale(1.0, 1.0)), output = NormalMeanPrecision(1.0, 1.0)),
+            (input = (m_out = PointMass(2.0), q_τ = PointMass(1.0)), output = NormalMeanPrecision(2.0, 1.0))
+        ]
+    end
+
     @testset "Variational: (q_out::Any, q_τ::Any)" begin
         @test_rules [with_float_conversions = true] NormalMeanPrecision(:μ, Marginalisation) [
             (input = (q_out = PointMass(-1.0), q_τ = PointMass(2.0)), output = NormalMeanPrecision(-1.0, 2.0)),

--- a/test/rules/normal_mean_precision/test_out.jl
+++ b/test/rules/normal_mean_precision/test_out.jl
@@ -54,6 +54,14 @@ import ReactiveMP: @test_rules
             (input = (m_μ = NormalWeightedMeanPrecision(2.0, 0.5), q_τ = GammaShapeScale(10.0, 0.1)), output = NormalMeanPrecision(4.0, 1.0 / 3.0))
         ]
     end
+    
+    @testset "Variational: (m_μ::PointMass, q_τ::Any)" begin
+        @test_rules [with_float_conversions = true] NormalMeanPrecision(:out, Marginalisation) [
+            (input = (m_μ = PointMass(-1.0), q_τ = GammaShapeRate(1.0, 1.0)), output = NormalMeanPrecision(-1.0, 1.0)),
+            (input = (m_μ = PointMass(1.0), q_τ = GammaShapeScale(1.0, 1.0)), output = NormalMeanPrecision(1.0, 1.0)),
+            (input = (m_μ = PointMass(2.0), q_τ = PointMass(1.0)), output = NormalMeanPrecision(2.0, 1.0))
+        ]
+    end
 
     @testset "Variational: (q_μ::Any, q_τ::Any)" begin
         @test_rules [with_float_conversions = true] NormalMeanPrecision(:out, Marginalisation) [

--- a/test/rules/normal_mean_precision/test_out.jl
+++ b/test/rules/normal_mean_precision/test_out.jl
@@ -54,7 +54,7 @@ import ReactiveMP: @test_rules
             (input = (m_μ = NormalWeightedMeanPrecision(2.0, 0.5), q_τ = GammaShapeScale(10.0, 0.1)), output = NormalMeanPrecision(4.0, 1.0 / 3.0))
         ]
     end
-    
+
     @testset "Variational: (m_μ::PointMass, q_τ::Any)" begin
         @test_rules [with_float_conversions = true] NormalMeanPrecision(:out, Marginalisation) [
             (input = (m_μ = PointMass(-1.0), q_τ = GammaShapeRate(1.0, 1.0)), output = NormalMeanPrecision(-1.0, 1.0)),

--- a/test/rules/normal_mean_variance/test_mean.jl
+++ b/test/rules/normal_mean_variance/test_mean.jl
@@ -56,6 +56,14 @@ import ReactiveMP: @test_rules
         ]
     end
 
+    @testset "Variational: (m_out::PointMass, q_v::Any)" begin
+        @test_rules [with_float_conversions = true] NormalMeanVariance(:μ, Marginalisation) [
+            (input = (m_out = PointMass(-1.0), q_v = GammaShapeRate(1.0, 1.0)), output = NormalMeanVariance(-1.0, 1.0)),
+            (input = (m_out = PointMass(1.0), q_v = GammaShapeScale(1.0, 1.0)), output = NormalMeanVariance(1.0, 1.0)),
+            (input = (m_out = PointMass(2.0), q_v = PointMass(1.0)), output = NormalMeanVariance(2.0, 1.0))
+        ]
+    end
+
     @testset "Variational: (q_out::Any, q_v::Any)" begin
         @test_rules [with_float_conversions = true] NormalMeanVariance(:μ, Marginalisation) [
             (input = (q_out = PointMass(-1.0), q_v = PointMass(2.0)), output = NormalMeanVariance(-1.0, 2.0)),

--- a/test/rules/normal_mean_variance/test_out.jl
+++ b/test/rules/normal_mean_variance/test_out.jl
@@ -56,6 +56,14 @@ import ReactiveMP: @test_rules
         ]
     end
 
+    @testset "Variational: (m_μ::PointMass, q_v::Any)" begin
+        @test_rules [with_float_conversions = true] NormalMeanVariance(:out, Marginalisation) [
+            (input = (m_μ = PointMass(-1.0), q_v = GammaShapeRate(1.0, 1.0)), output = NormalMeanVariance(-1.0, 1.0)),
+            (input = (m_μ = PointMass(1.0), q_v = GammaShapeScale(1.0, 1.0)), output = NormalMeanVariance(1.0, 1.0)),
+            (input = (m_μ = PointMass(2.0), q_v = PointMass(1.0)), output = NormalMeanVariance(2.0, 1.0))
+        ]
+    end
+
     @testset "Variational: (q_μ::Any, q_v::Any)" begin
         @test_rules [with_float_conversions = true] NormalMeanVariance(:out, Marginalisation) [
             (input = (q_μ = PointMass(-1.0), q_v = PointMass(2.0)), output = NormalMeanVariance(-1.0, 2.0)),


### PR DESCRIPTION
This PR adds missing rules for univariate normal nodes. The rules are a mere copy of the multivariate node.