### PR TITLE
Add multiplication rules for two univariate random variables

### DIFF
--- a/src/rules/multiplication/A.jl
+++ b/src/rules/multiplication/A.jl
@@ -57,23 +57,23 @@ end
 @rule typeof(*)(:A, Marginalisation) (m_out::UnivariateGaussianDistributionsFamily, m_in::UnivariateGaussianDistributionsFamily, meta::Union{<:AbstractCorrection, Nothing}) = begin
     μ_in, var_in = mean_var(m_in)
     μ_out, var_out = mean_var(m_out)
-    log_backwardpass = (x) -> -log(abs(x)) - 0.5*log(2π * (var_in + var_out / x^2))  - 1/2 * (μ_out  - x*μ_in)^2 / (var_in*x^2 + var_out)
+    log_backwardpass = (x) -> -log(abs(x)) - 0.5 * log(2π * (var_in + var_out / x^2)) - 1 / 2 * (μ_out - x * μ_in)^2 / (var_in * x^2 + var_out)
     return ContinuousUnivariateLogPdf(log_backwardpass)
 end
 
 # m_in and m_out are in Univariate Distribution family 
 @rule typeof(*)(:A, Marginalisation) (m_out::UnivariateDistribution, m_in::UnivariateDistribution, meta::Union{<:AbstractCorrection, Nothing}) = begin
-    nsamples    = 3000
-    samples_in = rand(m_in,nsamples)
-    p = make_inversedist_message(samples_in,m_out)
+    nsamples = 3000
+    samples_in = rand(m_in, nsamples)
+    p = make_inversedist_message(samples_in, m_out)
     return ContinuousUnivariateLogPdf(p)
 end
 
-function make_inversedist_message(samples_in,d_out)
-    return let samples_in=samples_in,d_out=d_out
+function make_inversedist_message(samples_in, d_out)
+    return let samples_in = samples_in, d_out = d_out
         (x) -> begin
-            result = mapreduce(+, zip(samples_in,)) do (samplein,)
-                return abs(samplein) * pdf(d_out,x*samplein) 
+            result = mapreduce(+, zip(samples_in)) do (samplein,)
+                return abs(samplein) * pdf(d_out, x * samplein)
             end
             return log(result)
         end

--- a/src/rules/multiplication/A.jl
+++ b/src/rules/multiplication/A.jl
@@ -53,7 +53,6 @@ end
     return NormalWeightedMeanPrecision(dot(tmp, μ_out), W)
 end
 
-#----- Univariate Distributions ---#
 @rule typeof(*)(:A, Marginalisation) (m_out::UnivariateGaussianDistributionsFamily, m_in::UnivariateGaussianDistributionsFamily, meta::Union{<:AbstractCorrection, Nothing}) = begin
     μ_in, var_in = mean_var(m_in)
     μ_out, var_out = mean_var(m_out)
@@ -61,7 +60,6 @@ end
     return ContinuousUnivariateLogPdf(log_backwardpass)
 end
 
-# m_in and m_out are in Univariate Distribution family 
 @rule typeof(*)(:A, Marginalisation) (m_out::UnivariateDistribution, m_in::UnivariateDistribution, meta::Union{<:AbstractCorrection, Nothing}) = begin
     nsamples = 3000
     samples_in = rand(m_in, nsamples)
@@ -72,7 +70,7 @@ end
 function make_inversedist_message(samples_in, d_out)
     return let samples_in = samples_in, d_out = d_out
         (x) -> begin
-            result = mapreduce(+, zip(samples_in)) do (samplein,)
+            result = mapreduce(+, samples_in) do samplein
                 return abs(samplein) * pdf(d_out, x * samplein)
             end
             return log(result)

--- a/src/rules/multiplication/A.jl
+++ b/src/rules/multiplication/A.jl
@@ -53,8 +53,7 @@ end
     return NormalWeightedMeanPrecision(dot(tmp, μ_out), W)
 end
 
-#--------
-# m_in, m_out are Univariate Gaussian 
+#----- Univariate Distributions ---#
 @rule typeof(*)(:A, Marginalisation) (m_out::UnivariateGaussianDistributionsFamily, m_in::UnivariateGaussianDistributionsFamily, meta::Union{<:AbstractCorrection, Nothing}) = begin
     μ_in, var_in = mean_var(m_in)
     μ_out, var_out = mean_var(m_out)
@@ -62,11 +61,10 @@ end
     return ContinuousUnivariateLogPdf(log_backwardpass)
 end
 
-# m_in and m_out are any (they should be in univariate distribution family)
-@rule typeof(*)(:A, Marginalisation) (m_out::Any, m_in::Any, meta::Union{<:AbstractCorrection, Nothing}) = begin
+# m_in and m_out are in Univariate Distribution family 
+@rule typeof(*)(:A, Marginalisation) (m_out::UnivariateDistribution, m_in::UnivariateDistribution, meta::Union{<:AbstractCorrection, Nothing}) = begin
     nsamples    = 3000
     samples_in = rand(m_in,nsamples)
-    samples_out = rand(m_out,nsamples)
     p = make_inversedist_message(samples_in,m_out)
     return ContinuousUnivariateLogPdf(p)
 end

--- a/src/rules/multiplication/A.jl
+++ b/src/rules/multiplication/A.jl
@@ -52,3 +52,32 @@ end
 
     return NormalWeightedMeanPrecision(dot(tmp, μ_out), W)
 end
+
+#--------
+# m_in, m_out are Univariate Gaussian 
+@rule typeof(*)(:A, Marginalisation) (m_out::UnivariateGaussianDistributionsFamily, m_in::UnivariateGaussianDistributionsFamily, meta::Union{<:AbstractCorrection, Nothing}) = begin
+    μ_in, var_in = mean_var(m_in)
+    μ_out, var_out = mean_var(m_out)
+    log_backwardpass = (x) -> -log(abs(x)) - 0.5*log(2π * (var_in + var_out / x^2))  - 1/2 * (μ_out  - x*μ_in)^2 / (var_in*x^2 + var_out)
+    return ContinuousUnivariateLogPdf(log_backwardpass)
+end
+
+# m_in and m_out are any (they should be in univariate distribution family)
+@rule typeof(*)(:A, Marginalisation) (m_out::Any, m_in::Any, meta::Union{<:AbstractCorrection, Nothing}) = begin
+    nsamples    = 3000
+    samples_in = rand(m_in,nsamples)
+    samples_out = rand(m_out,nsamples)
+    p = make_inversedist_message(samples_in,m_out)
+    return ContinuousUnivariateLogPdf(p)
+end
+
+function make_inversedist_message(samples_in,d_out)
+    return let samples_in=samples_in,d_out=d_out
+        (x) -> begin
+            result = mapreduce(+, zip(samples_in,)) do (samplein,)
+                return abs(samplein) * pdf(d_out,x*samplein) 
+            end
+            return log(result)
+        end
+    end
+end

--- a/src/rules/multiplication/in.jl
+++ b/src/rules/multiplication/in.jl
@@ -58,7 +58,7 @@ end
 @rule typeof(*)(:in, Marginalisation) (m_out::UnivariateGaussianDistributionsFamily, m_A::UnivariateGaussianDistributionsFamily, meta::Union{<:AbstractCorrection, Nothing}) = begin
     μ_A, var_A = mean_var(m_A)
     μ_out, var_out = mean_var(m_out)
-    log_backwardpass = (x) -> -log(abs(x)) - 0.5*log(2π * (var_A + var_out / x^2))  - 1/2 * (μ_out  - x*μ_A)^2 / (var_A*x^2 + var_out)
+    log_backwardpass = (x) -> -log(abs(x)) - 0.5 * log(2π * (var_A + var_out / x^2)) - 1 / 2 * (μ_out - x * μ_A)^2 / (var_A * x^2 + var_out)
     return ContinuousUnivariateLogPdf(log_backwardpass)
 end
 

--- a/src/rules/multiplication/in.jl
+++ b/src/rules/multiplication/in.jl
@@ -54,7 +54,6 @@ end
     return NormalWeightedMeanPrecision(dot(tmp, μ_out), W)
 end
 
-#---- Univariate Distribution ----# 
 @rule typeof(*)(:in, Marginalisation) (m_out::UnivariateGaussianDistributionsFamily, m_A::UnivariateGaussianDistributionsFamily, meta::Union{<:AbstractCorrection, Nothing}) = begin
     μ_A, var_A = mean_var(m_A)
     μ_out, var_out = mean_var(m_out)

--- a/src/rules/multiplication/in.jl
+++ b/src/rules/multiplication/in.jl
@@ -54,7 +54,7 @@ end
     return NormalWeightedMeanPrecision(dot(tmp, μ_out), W)
 end
 
-# m_in, m_out are Univariate Gaussian 
+#---- Univariate Distribution ----# 
 @rule typeof(*)(:in, Marginalisation) (m_out::UnivariateGaussianDistributionsFamily, m_A::UnivariateGaussianDistributionsFamily, meta::Union{<:AbstractCorrection, Nothing}) = begin
     μ_A, var_A = mean_var(m_A)
     μ_out, var_out = mean_var(m_out)
@@ -62,22 +62,6 @@ end
     return ContinuousUnivariateLogPdf(log_backwardpass)
 end
 
-# m_in and m_out are any (they should be in univariate distribution family)
-@rule typeof(*)(:in, Marginalisation) (m_out::Any, m_A::Any, meta::Union{<:AbstractCorrection, Nothing}) = begin
-    nsamples    = 3000
-    samples_A = rand(m_A,nsamples)
-    samples_out = rand(m_out,nsamples)
-    p = make_inversedist_message(samples_in,m_out)
-    return ContinuousUnivariateLogPdf(p)
-end
-
-function make_inversedist_message(samples_in,d_out)
-    return let samples_in=samples_in,d_out=d_out
-        (x) -> begin
-            result = mapreduce(+, zip(samples_in,)) do (samplein,)
-                return abs(samplein) * pdf(d_out,x*samplein) 
-            end
-            return log(result)
-        end
-    end
+@rule typeof(*)(:in, Marginalisation) (m_out::UnivariateDistribution, m_A::UnivariateDistribution, meta::Union{<:AbstractCorrection, Nothing}) = begin
+    return @call_rule typeof(*)(:A, Marginalisation) (m_out = m_out, m_in = m_A, meta = meta)
 end

--- a/src/rules/multiplication/out.jl
+++ b/src/rules/multiplication/out.jl
@@ -69,23 +69,23 @@ end
 # Univariate Normal * Univariate Normal 
 #----------------------
 @rule typeof(*)(:out, Marginalisation) (m_A::UnivariateGaussianDistributionsFamily, m_in::UnivariateGaussianDistributionsFamily, meta::Union{<:AbstractCorrection, Nothing}) = begin
-    μ_A, var_A = mean_var(m_A) 
+    μ_A, var_A = mean_var(m_A)
     μ_in, var_in = mean_var(m_in)
 
-    return ContinuousUnivariateLogPdf(besselmod(μ_in,var_in,μ_A,var_A,0.0))
+    return ContinuousUnivariateLogPdf(besselmod(μ_in, var_in, μ_A, var_A, 0.0))
 end
 
 # General rule for Univariate Distributions 
 @rule typeof(*)(:out, Marginalisation) (m_A::UnivariateDistribution, m_in::UnivariateDistribution, meta::Union{<:AbstractCorrection, Nothing}) = begin
-    nsamples    = 3000
-    samples_A  = rand(m_A,nsamples)
-    p = make_productdist_message(samples_A,m_in)
+    nsamples = 3000
+    samples_A = rand(m_A, nsamples)
+    p = make_productdist_message(samples_A, m_in)
 
     return ContinuousUnivariateLogPdf(p)
 end
 
 #modified-bessel function 
-function besselmod(mx, vx, my, vy, rho; truncation=10, jitter=1e-8)
+function besselmod(mx, vx, my, vy, rho; truncation = 10, jitter = 1e-8)
     """
     mx, vx : mean and variance of the random variable x 
     my, vy : mean and variance of the random variable y 
@@ -94,17 +94,17 @@ function besselmod(mx, vx, my, vy, rho; truncation=10, jitter=1e-8)
     # construct logpdf function
     logpdf = function (x)
         x += jitter
-        term1 = -1/(2*(1-rho^2)) * (mx^2/vx + my^2/vy - 2*rho*(x + mx*my)/sqrt(vx*vy))
+        term1 = -1 / (2 * (1 - rho^2)) * (mx^2 / vx + my^2 / vy - 2 * rho * (x + mx * my) / sqrt(vx * vy))
 
         term2 = 0.0
-        for n = 0:truncation
-            for m = 0:2*n
-                term2 += x^(2*n - m) * abs(x)^(m - n) * sqrt(vx)^(m - n - 1) /
-                    (pi * factorial(2*n) * (1 - rho^2)^(2*n + 1/2) * sqrt(vy)^(m - n + 1)) *
-                    (mx / vx - rho * my / sqrt(vx * vy) )^m *
-                    binomial(2*n, m) *
-                    (my / vy - rho*mx/sqrt(vx*vy))^(2 * n - m) *
-                    besselk( m-n, abs(x) / (( 1 - rho^2) * sqrt(vx*vy)) )
+        for n in 0:truncation
+            for m in 0:(2 * n)
+                term2 +=
+                    x^(2 * n - m) * abs(x)^(m - n) * sqrt(vx)^(m - n - 1) / (pi * factorial(2 * n) * (1 - rho^2)^(2 * n + 1 / 2) * sqrt(vy)^(m - n + 1)) *
+                    (mx / vx - rho * my / sqrt(vx * vy))^m *
+                    binomial(2 * n, m) *
+                    (my / vy - rho * mx / sqrt(vx * vy))^(2 * n - m) *
+                    besselk(m - n, abs(x) / ((1 - rho^2) * sqrt(vx * vy)))
             end
         end
         # return logpdf
@@ -112,13 +112,13 @@ function besselmod(mx, vx, my, vy, rho; truncation=10, jitter=1e-8)
     end
     # return logpdf
     return logpdf
-end 
+end
 
-function make_productdist_message(samples_A,d_in)
-    return let samples_A=samples_A,d_in=d_in
+function make_productdist_message(samples_A, d_in)
+    return let samples_A = samples_A, d_in = d_in
         (x) -> begin
-            result = mapreduce(+, zip(samples_A,)) do (sampleA,)
-                return 1/abs(sampleA) * pdf(d_in,x/sampleA)
+            result = mapreduce(+, zip(samples_A)) do (sampleA,)
+                return 1 / abs(sampleA) * pdf(d_in, x / sampleA)
             end
             return log(result)
         end

--- a/src/rules/multiplication/out.jl
+++ b/src/rules/multiplication/out.jl
@@ -74,8 +74,7 @@ end
 
     return ContinuousUnivariateLogPdf(besselmod(μ_in, var_in, μ_A, var_A, 0.0))
 end
-
-# General rule for Univariate Distributions 
+ 
 @rule typeof(*)(:out, Marginalisation) (m_A::UnivariateDistribution, m_in::UnivariateDistribution, meta::Union{<:AbstractCorrection, Nothing}) = begin
     nsamples = 3000
     samples_A = rand(m_A, nsamples)
@@ -84,14 +83,14 @@ end
     return ContinuousUnivariateLogPdf(p)
 end
 
-#modified-bessel function 
+"""
+Modified-bessel function of second kind
+
+mx, vx : mean and variance of the random variable x 
+my, vy : mean and variance of the random variable y 
+rho    : correlation coefficient
+"""
 function besselmod(mx, vx, my, vy, rho; truncation = 10, jitter = 1e-8)
-    """
-    mx, vx : mean and variance of the random variable x 
-    my, vy : mean and variance of the random variable y 
-    rho    : correlation coefficient
-    """
-    # construct logpdf function
     logpdf = function (x)
         x += jitter
         term1 = -1 / (2 * (1 - rho^2)) * (mx^2 / vx + my^2 / vy - 2 * rho * (x + mx * my) / sqrt(vx * vy))
@@ -107,17 +106,15 @@ function besselmod(mx, vx, my, vy, rho; truncation = 10, jitter = 1e-8)
                     besselk(m - n, abs(x) / ((1 - rho^2) * sqrt(vx * vy)))
             end
         end
-        # return logpdf
         return term1 + log(term2)
     end
-    # return logpdf
     return logpdf
 end
 
 function make_productdist_message(samples_A, d_in)
     return let samples_A = samples_A, d_in = d_in
         (x) -> begin
-            result = mapreduce(+, zip(samples_A)) do (sampleA,)
+            result = mapreduce(+, samples_A) do sampleA
                 return 1 / abs(sampleA) * pdf(d_in, x / sampleA)
             end
             return log(result)

--- a/src/rules/multiplication/out.jl
+++ b/src/rules/multiplication/out.jl
@@ -74,7 +74,7 @@ end
 
     return ContinuousUnivariateLogPdf(besselmod(μ_in, var_in, μ_A, var_A, 0.0))
 end
- 
+
 @rule typeof(*)(:out, Marginalisation) (m_A::UnivariateDistribution, m_in::UnivariateDistribution, meta::Union{<:AbstractCorrection, Nothing}) = begin
     nsamples = 3000
     samples_A = rand(m_A, nsamples)

--- a/src/rules/multiplication/out.jl
+++ b/src/rules/multiplication/out.jl
@@ -1,3 +1,4 @@
+import SpecialFunctions: besselk
 
 @rule typeof(*)(:out, Marginalisation) (m_A::PointMass, m_in::PointMass, meta::Union{<:AbstractCorrection, Nothing}) = PointMass(mean(m_A) * mean(m_in))
 
@@ -62,4 +63,67 @@ end
 
 @rule typeof(*)(:out, Marginalisation) (m_A::UnivariateNormalDistributionsFamily, m_in::PointMass{<:Real}, meta::Union{<:AbstractCorrection, Nothing}) = begin
     return @call_rule typeof(*)(:out, Marginalisation) (m_A = m_in, m_in = m_A, meta = meta, addons = getaddons()) # symmetric rule
+end
+
+#-----------------------
+# Univariate Normal * Univariate Normal 
+#----------------------
+@rule typeof(*)(:out, Marginalisation) (m_A::UnivariateGaussianDistributionsFamily, m_in::UnivariateGaussianDistributionsFamily, meta::Union{<:AbstractCorrection, Nothing}) = begin
+    μ_A, var_A = mean_var(m_A) 
+    μ_in, var_in = mean_var(m_in)
+
+    #the besselmod already returns a logpdf 
+    return ContinuousUnivariateLogPdf(besselmod(μ_in,var_in,μ_A,var_A,0.0))
+end
+
+#modified-bessel function 
+function besselmod(mx, vx, my, vy, rho; truncation=10, jitter=1e-8)
+    """
+    mx, vx : mean and variance of the random variable x 
+    my, vy : mean and variance of the random variable y 
+    rho    : correlation coefficient
+    """
+    # construct logpdf function
+    logpdf = function (x)
+        x += jitter
+        term1 = -1/(2*(1-rho^2)) * (mx^2/vx + my^2/vy - 2*rho*(x + mx*my)/sqrt(vx*vy))
+
+        term2 = 0.0
+        for n = 0:truncation
+            for m = 0:2*n
+                term2 += x^(2*n - m) * abs(x)^(m - n) * sqrt(vx)^(m - n - 1) /
+                    (pi * factorial(2*n) * (1 - rho^2)^(2*n + 1/2) * sqrt(vy)^(m - n + 1)) *
+                    (mx / vx - rho * my / sqrt(vx * vy) )^m *
+                    binomial(2*n, m) *
+                    (my / vy - rho*mx/sqrt(vx*vy))^(2 * n - m) *
+                    besselk( m-n, abs(x) / (( 1 - rho^2) * sqrt(vx*vy)) )
+            end
+        end
+        # return logpdf
+        return term1 + log(term2)
+    end
+    # return logpdf
+    return logpdf
+end 
+
+# General rule 
+@rule typeof(*)(:out, Marginalisation) (m_A::Any, m_in::Any, meta::Union{<:AbstractCorrection, Nothing}) = begin
+    nsamples    = 3000
+    samples_A  = rand(m_A,nsamples)
+    samples_in = rand(m_in,nsamples)
+
+    p = make_productdist_message(samples_A,m_in)
+
+    return ContinuousUnivariateLogPdf(p)
+end
+
+function make_productdist_message(samples_A,d_in)
+    return let samples_A=samples_A,d_in=d_in
+        (x) -> begin
+            result = mapreduce(+, zip(samples_A,)) do (sampleA,)
+                return 1/abs(sampleA) * pdf(d_in,x/sampleA)
+            end
+            return log(result)
+        end
+    end
 end

--- a/src/rules/multiplication/out.jl
+++ b/src/rules/multiplication/out.jl
@@ -72,8 +72,16 @@ end
     μ_A, var_A = mean_var(m_A) 
     μ_in, var_in = mean_var(m_in)
 
-    #the besselmod already returns a logpdf 
     return ContinuousUnivariateLogPdf(besselmod(μ_in,var_in,μ_A,var_A,0.0))
+end
+
+# General rule for Univariate Distributions 
+@rule typeof(*)(:out, Marginalisation) (m_A::UnivariateDistribution, m_in::UnivariateDistribution, meta::Union{<:AbstractCorrection, Nothing}) = begin
+    nsamples    = 3000
+    samples_A  = rand(m_A,nsamples)
+    p = make_productdist_message(samples_A,m_in)
+
+    return ContinuousUnivariateLogPdf(p)
 end
 
 #modified-bessel function 
@@ -105,17 +113,6 @@ function besselmod(mx, vx, my, vy, rho; truncation=10, jitter=1e-8)
     # return logpdf
     return logpdf
 end 
-
-# General rule 
-@rule typeof(*)(:out, Marginalisation) (m_A::Any, m_in::Any, meta::Union{<:AbstractCorrection, Nothing}) = begin
-    nsamples    = 3000
-    samples_A  = rand(m_A,nsamples)
-    samples_in = rand(m_in,nsamples)
-
-    p = make_productdist_message(samples_A,m_in)
-
-    return ContinuousUnivariateLogPdf(p)
-end
 
 function make_productdist_message(samples_A,d_in)
     return let samples_A=samples_A,d_in=d_in

--- a/test/rules/multiplication/test_A.jl
+++ b/test/rules/multiplication/test_A.jl
@@ -2,26 +2,26 @@ module RulesMultiplicationATest
 
 using Test
 using ReactiveMP
-using Random, Distributions 
+using Random, Distributions
 import ReactiveMP: make_inversedist_message
 
 @testset "rule:typeof(*):A" begin
     @testset "Univariate Gaussian messages" begin
-        d1 = NormalMeanVariance(0.,1.)
+        d1 = NormalMeanVariance(0.0, 1.0)
         d2 = NormalMeanVariance(0.5, 1.5)
-        d3 = NormalMeanVariance(2., 0.5)
-        OutMessage_1 = @call_rule typeof(*)(:A,Marginalisation) (m_out = d1, m_in = d2, meta=TinyCorrection())
-        OutMessage_2 = @call_rule typeof(*)(:A,Marginalisation) (m_out = d1, m_in = d3, meta=TinyCorrection())
-        OutMessage_3 = @call_rule typeof(*)(:A,Marginalisation) (m_out = d2, m_in = d3, meta=TinyCorrection())
-        groundtruthOutMessage_1 = (x) -> -log(abs(x)) - 0.5*log(2π * (var(d2) + var(d1) / x^2))  - 1/2 * (mean(d1)  - x*mean(d2))^2 / (var(d2)*x^2 + var(d1))
-        groundtruthOutMessage_2 = (x) -> -log(abs(x)) - 0.5*log(2π * (var(d3) + var(d1) / x^2))  - 1/2 * (mean(d1)  - x*mean(d3))^2 / (var(d3)*x^2 + var(d1))
-        groundtruthOutMessage_3 = (x) -> -log(abs(x)) - 0.5*log(2π * (var(d3) + var(d2) / x^2))  - 1/2 * (mean(d2)  - x*mean(d3))^2 / (var(d3)*x^2 + var(d2))
+        d3 = NormalMeanVariance(2.0, 0.5)
+        OutMessage_1 = @call_rule typeof(*)(:A, Marginalisation) (m_out = d1, m_in = d2, meta = TinyCorrection())
+        OutMessage_2 = @call_rule typeof(*)(:A, Marginalisation) (m_out = d1, m_in = d3, meta = TinyCorrection())
+        OutMessage_3 = @call_rule typeof(*)(:A, Marginalisation) (m_out = d2, m_in = d3, meta = TinyCorrection())
+        groundtruthOutMessage_1 = (x) -> -log(abs(x)) - 0.5 * log(2π * (var(d2) + var(d1) / x^2)) - 1 / 2 * (mean(d1) - x * mean(d2))^2 / (var(d2) * x^2 + var(d1))
+        groundtruthOutMessage_2 = (x) -> -log(abs(x)) - 0.5 * log(2π * (var(d3) + var(d1) / x^2)) - 1 / 2 * (mean(d1) - x * mean(d3))^2 / (var(d3) * x^2 + var(d1))
+        groundtruthOutMessage_3 = (x) -> -log(abs(x)) - 0.5 * log(2π * (var(d3) + var(d2) / x^2)) - 1 / 2 * (mean(d2) - x * mean(d3))^2 / (var(d3) * x^2 + var(d2))
 
         @test typeof(OutMessage_1) <: ContinuousUnivariateLogPdf
         @test typeof(OutMessage_2) <: ContinuousUnivariateLogPdf
-        @test typeof(OutMessage_3) <: ContinuousUnivariateLogPdf 
+        @test typeof(OutMessage_3) <: ContinuousUnivariateLogPdf
 
-        samples = rand(Uniform(0.5,4),10)
+        samples = rand(Uniform(0.5, 4), 10)
         for i in samples
             @test OutMessage_1(i) ≈ groundtruthOutMessage_1(i)
             @test OutMessage_2(i) ≈ groundtruthOutMessage_2(i)
@@ -29,19 +29,19 @@ import ReactiveMP: make_inversedist_message
         end
     end
     @testset "messages of type Any" begin
-        d1 = LogNormal(1.5, 1)
-        d2 = NormalMeanVariance(0.,1.)
+        d1          = LogNormal(1.5, 1)
+        d2          = NormalMeanVariance(0.0, 1.0)
         num_samples = 3000
-        samples_d2  = rand(d2,num_samples)
+        samples_d2  = rand(d2, num_samples)
 
-        OutMessage = @call_rule typeof(*)(:A,Marginalisation) (m_out = d1, m_in = d2, meta=TinyCorrection())
+        OutMessage = @call_rule typeof(*)(:A, Marginalisation) (m_out = d1, m_in = d2, meta = TinyCorrection())
 
         @test typeof(OutMessage) <: ContinuousUnivariateLogPdf
-        
+
         groundtruthOutMessage = make_inversedist_message(samples_d2, d1)
-        @test isapprox(OutMessage(1.), groundtruthOutMessage(1.);atol = 0.1)
-        @test isapprox(OutMessage(2.), groundtruthOutMessage(2.);atol = 0.1)
-        @test isapprox(OutMessage(3.1), groundtruthOutMessage(3.1);atol = 0.1)
+        @test isapprox(OutMessage(1.0), groundtruthOutMessage(1.0); atol = 0.1)
+        @test isapprox(OutMessage(2.0), groundtruthOutMessage(2.0); atol = 0.1)
+        @test isapprox(OutMessage(3.1), groundtruthOutMessage(3.1); atol = 0.1)
     end
 end
 

--- a/test/rules/multiplication/test_A.jl
+++ b/test/rules/multiplication/test_A.jl
@@ -1,0 +1,48 @@
+module RulesMultiplicationATest
+
+using Test
+using ReactiveMP
+using Random, Distributions 
+import ReactiveMP: make_inversedist_message
+
+@testset "rule:typeof(*):A" begin
+    @testset "Univariate Gaussian messages" begin
+        d1 = NormalMeanVariance(0.,1.)
+        d2 = NormalMeanVariance(0.5, 1.5)
+        d3 = NormalMeanVariance(2., 0.5)
+        OutMessage_1 = @call_rule typeof(*)(:A,Marginalisation) (m_out = d1, m_in = d2, meta=TinyCorrection())
+        OutMessage_2 = @call_rule typeof(*)(:A,Marginalisation) (m_out = d1, m_in = d3, meta=TinyCorrection())
+        OutMessage_3 = @call_rule typeof(*)(:A,Marginalisation) (m_out = d2, m_in = d3, meta=TinyCorrection())
+        groundtruthOutMessage_1 = (x) -> -log(abs(x)) - 0.5*log(2π * (var(d2) + var(d1) / x^2))  - 1/2 * (mean(d1)  - x*mean(d2))^2 / (var(d2)*x^2 + var(d1))
+        groundtruthOutMessage_2 = (x) -> -log(abs(x)) - 0.5*log(2π * (var(d3) + var(d1) / x^2))  - 1/2 * (mean(d1)  - x*mean(d3))^2 / (var(d3)*x^2 + var(d1))
+        groundtruthOutMessage_3 = (x) -> -log(abs(x)) - 0.5*log(2π * (var(d3) + var(d2) / x^2))  - 1/2 * (mean(d2)  - x*mean(d3))^2 / (var(d3)*x^2 + var(d2))
+
+        @test typeof(OutMessage_1) <: ContinuousUnivariateLogPdf
+        @test typeof(OutMessage_2) <: ContinuousUnivariateLogPdf
+        @test typeof(OutMessage_3) <: ContinuousUnivariateLogPdf 
+
+        samples = rand(Uniform(0.5,4),10)
+        for i in samples
+            @test OutMessage_1(i) ≈ groundtruthOutMessage_1(i)
+            @test OutMessage_2(i) ≈ groundtruthOutMessage_2(i)
+            @test OutMessage_3(i) ≈ groundtruthOutMessage_3(i)
+        end
+    end
+    @testset "messages of type Any" begin
+        d1 = LogNormal(1.5, 1)
+        d2 = NormalMeanVariance(0.,1.)
+        num_samples = 3000
+        samples_d2  = rand(d2,num_samples)
+
+        OutMessage = @call_rule typeof(*)(:A,Marginalisation) (m_out = d1, m_in = d2, meta=TinyCorrection())
+
+        @test typeof(OutMessage) <: ContinuousUnivariateLogPdf
+        
+        groundtruthOutMessage = make_inversedist_message(samples_d2, d1)
+        @test isapprox(OutMessage(1.), groundtruthOutMessage(1.);atol = 0.1)
+        @test isapprox(OutMessage(2.), groundtruthOutMessage(2.);atol = 0.1)
+        @test isapprox(OutMessage(3.1), groundtruthOutMessage(3.1);atol = 0.1)
+    end
+end
+
+end

--- a/test/rules/multiplication/test_in.jl
+++ b/test/rules/multiplication/test_in.jl
@@ -7,21 +7,21 @@ import ReactiveMP: @test_rules, make_inversedist_message
 
 @testset "rule:typeof(*):in" begin
     @testset "Univariate Gaussian messages" begin
-        d1 = NormalMeanVariance(0.,1.)
+        d1 = NormalMeanVariance(0.0, 1.0)
         d2 = NormalMeanVariance(0.5, 1.5)
-        d3 = NormalMeanVariance(2., 0.5)
-        OutMessage_1 = @call_rule typeof(*)(:in,Marginalisation) (m_out = d1, m_A = d2, meta=TinyCorrection())
-        OutMessage_2 = @call_rule typeof(*)(:in,Marginalisation) (m_out = d1, m_A = d3, meta=TinyCorrection())
-        OutMessage_3 = @call_rule typeof(*)(:in,Marginalisation) (m_out = d2, m_A = d3, meta=TinyCorrection())
-        groundtruthOutMessage_1 = (x) -> -log(abs(x)) - 0.5*log(2π * (var(d2) + var(d1) / x^2))  - 1/2 * (mean(d1)  - x*mean(d2))^2 / (var(d2)*x^2 + var(d1))
-        groundtruthOutMessage_2 = (x) -> -log(abs(x)) - 0.5*log(2π * (var(d3) + var(d1) / x^2))  - 1/2 * (mean(d1)  - x*mean(d3))^2 / (var(d3)*x^2 + var(d1))
-        groundtruthOutMessage_3 = (x) -> -log(abs(x)) - 0.5*log(2π * (var(d3) + var(d2) / x^2))  - 1/2 * (mean(d2)  - x*mean(d3))^2 / (var(d3)*x^2 + var(d2))
+        d3 = NormalMeanVariance(2.0, 0.5)
+        OutMessage_1 = @call_rule typeof(*)(:in, Marginalisation) (m_out = d1, m_A = d2, meta = TinyCorrection())
+        OutMessage_2 = @call_rule typeof(*)(:in, Marginalisation) (m_out = d1, m_A = d3, meta = TinyCorrection())
+        OutMessage_3 = @call_rule typeof(*)(:in, Marginalisation) (m_out = d2, m_A = d3, meta = TinyCorrection())
+        groundtruthOutMessage_1 = (x) -> -log(abs(x)) - 0.5 * log(2π * (var(d2) + var(d1) / x^2)) - 1 / 2 * (mean(d1) - x * mean(d2))^2 / (var(d2) * x^2 + var(d1))
+        groundtruthOutMessage_2 = (x) -> -log(abs(x)) - 0.5 * log(2π * (var(d3) + var(d1) / x^2)) - 1 / 2 * (mean(d1) - x * mean(d3))^2 / (var(d3) * x^2 + var(d1))
+        groundtruthOutMessage_3 = (x) -> -log(abs(x)) - 0.5 * log(2π * (var(d3) + var(d2) / x^2)) - 1 / 2 * (mean(d2) - x * mean(d3))^2 / (var(d3) * x^2 + var(d2))
 
         @test typeof(OutMessage_1) <: ContinuousUnivariateLogPdf
         @test typeof(OutMessage_2) <: ContinuousUnivariateLogPdf
-        @test typeof(OutMessage_3) <: ContinuousUnivariateLogPdf 
+        @test typeof(OutMessage_3) <: ContinuousUnivariateLogPdf
 
-        samples = rand(Uniform(0.5,4),10)
+        samples = rand(Uniform(0.5, 4), 10)
         for i in samples
             @test OutMessage_1(i) ≈ groundtruthOutMessage_1(i)
             @test OutMessage_2(i) ≈ groundtruthOutMessage_2(i)
@@ -29,19 +29,19 @@ import ReactiveMP: @test_rules, make_inversedist_message
         end
     end
     @testset "messages of type Any" begin
-        d1 = LogNormal(1.5, 1)
-        d2 = NormalMeanVariance(0.,1.)
+        d1          = LogNormal(1.5, 1)
+        d2          = NormalMeanVariance(0.0, 1.0)
         num_samples = 3000
-        samples_d2  = rand(d2,num_samples)
+        samples_d2  = rand(d2, num_samples)
 
-        OutMessage = @call_rule typeof(*)(:in,Marginalisation) (m_out = d1, m_A = d2, meta=TinyCorrection())
+        OutMessage = @call_rule typeof(*)(:in, Marginalisation) (m_out = d1, m_A = d2, meta = TinyCorrection())
 
         @test typeof(OutMessage) <: ContinuousUnivariateLogPdf
-        
+
         groundtruthOutMessage = make_inversedist_message(samples_d2, d1)
-        @test isapprox(OutMessage(1.), groundtruthOutMessage(1.);atol = 0.1)
-        @test isapprox(OutMessage(2.), groundtruthOutMessage(2.);atol = 0.1)
-        @test isapprox(OutMessage(3.1), groundtruthOutMessage(3.1);atol = 0.1)
+        @test isapprox(OutMessage(1.0), groundtruthOutMessage(1.0); atol = 0.1)
+        @test isapprox(OutMessage(2.0), groundtruthOutMessage(2.0); atol = 0.1)
+        @test isapprox(OutMessage(3.1), groundtruthOutMessage(3.1); atol = 0.1)
     end
 end
 

--- a/test/rules/multiplication/test_in.jl
+++ b/test/rules/multiplication/test_in.jl
@@ -1,0 +1,48 @@
+module RulesMultiplicationInTest
+
+using Test
+using ReactiveMP
+using Random, Distributions
+import ReactiveMP: @test_rules, make_inversedist_message
+
+@testset "rule:typeof(*):in" begin
+    @testset "Univariate Gaussian messages" begin
+        d1 = NormalMeanVariance(0.,1.)
+        d2 = NormalMeanVariance(0.5, 1.5)
+        d3 = NormalMeanVariance(2., 0.5)
+        OutMessage_1 = @call_rule typeof(*)(:in,Marginalisation) (m_out = d1, m_A = d2, meta=TinyCorrection())
+        OutMessage_2 = @call_rule typeof(*)(:in,Marginalisation) (m_out = d1, m_A = d3, meta=TinyCorrection())
+        OutMessage_3 = @call_rule typeof(*)(:in,Marginalisation) (m_out = d2, m_A = d3, meta=TinyCorrection())
+        groundtruthOutMessage_1 = (x) -> -log(abs(x)) - 0.5*log(2π * (var(d2) + var(d1) / x^2))  - 1/2 * (mean(d1)  - x*mean(d2))^2 / (var(d2)*x^2 + var(d1))
+        groundtruthOutMessage_2 = (x) -> -log(abs(x)) - 0.5*log(2π * (var(d3) + var(d1) / x^2))  - 1/2 * (mean(d1)  - x*mean(d3))^2 / (var(d3)*x^2 + var(d1))
+        groundtruthOutMessage_3 = (x) -> -log(abs(x)) - 0.5*log(2π * (var(d3) + var(d2) / x^2))  - 1/2 * (mean(d2)  - x*mean(d3))^2 / (var(d3)*x^2 + var(d2))
+
+        @test typeof(OutMessage_1) <: ContinuousUnivariateLogPdf
+        @test typeof(OutMessage_2) <: ContinuousUnivariateLogPdf
+        @test typeof(OutMessage_3) <: ContinuousUnivariateLogPdf 
+
+        samples = rand(Uniform(0.5,4),10)
+        for i in samples
+            @test OutMessage_1(i) ≈ groundtruthOutMessage_1(i)
+            @test OutMessage_2(i) ≈ groundtruthOutMessage_2(i)
+            @test OutMessage_3(i) ≈ groundtruthOutMessage_3(i)
+        end
+    end
+    @testset "messages of type Any" begin
+        d1 = LogNormal(1.5, 1)
+        d2 = NormalMeanVariance(0.,1.)
+        num_samples = 3000
+        samples_d2  = rand(d2,num_samples)
+
+        OutMessage = @call_rule typeof(*)(:in,Marginalisation) (m_out = d1, m_A = d2, meta=TinyCorrection())
+
+        @test typeof(OutMessage) <: ContinuousUnivariateLogPdf
+        
+        groundtruthOutMessage = make_inversedist_message(samples_d2, d1)
+        @test isapprox(OutMessage(1.), groundtruthOutMessage(1.);atol = 0.1)
+        @test isapprox(OutMessage(2.), groundtruthOutMessage(2.);atol = 0.1)
+        @test isapprox(OutMessage(3.1), groundtruthOutMessage(3.1);atol = 0.1)
+    end
+end
+
+end

--- a/test/rules/multiplication/test_out.jl
+++ b/test/rules/multiplication/test_out.jl
@@ -1,0 +1,48 @@
+module RulesMultiplicationOutTest
+
+using Test
+using ReactiveMP
+using Random, Distributions 
+import ReactiveMP: @test_rules, besselmod, make_productdist_message 
+
+@testset "rule:typeof(*):out" begin
+    @testset "Univariate Gaussian messages" begin
+        d1 = NormalMeanVariance(0.,1.)
+        d2 = NormalMeanVariance(0.5, 1.5)
+        d3 = NormalMeanVariance(2., 0.5)
+        OutMessage_1 = @call_rule typeof(*)(:out,Marginalisation) (m_A = d1, m_in = d2, meta=TinyCorrection())
+        OutMessage_2 = @call_rule typeof(*)(:out,Marginalisation) (m_A = d1, m_in = d3, meta=TinyCorrection())
+        OutMessage_3 = @call_rule typeof(*)(:out,Marginalisation) (m_A = d2, m_in = d3, meta=TinyCorrection())
+        groundtruthOutMessage_1 = besselmod(mean(d1),var(d1),mean(d2),var(d2),0.0)
+        groundtruthOutMessage_2 = besselmod(mean(d1),var(d1),mean(d3),var(d3),0.0)
+        groundtruthOutMessage_3 = besselmod(mean(d2),var(d2),mean(d3),var(d3),0.0)
+
+        @test typeof(OutMessage_1) <: ContinuousUnivariateLogPdf
+        @test typeof(OutMessage_2) <: ContinuousUnivariateLogPdf
+        @test typeof(OutMessage_3) <: ContinuousUnivariateLogPdf 
+
+        samples = rand(Uniform(0.5,4),10)
+        for i in samples
+            @test OutMessage_1(i) ≈ groundtruthOutMessage_1(i)
+            @test OutMessage_2(i) ≈ groundtruthOutMessage_2(i)
+            @test OutMessage_3(i) ≈ groundtruthOutMessage_3(i)
+        end
+    end
+    @testset "messages of type Any" begin
+        d1 = NormalMeanVariance(0.,1.)
+        d2 = LogNormal(0., 1.)
+        num_samples = 3000
+        samples_d1  = rand(d1,num_samples)
+
+        OutMessage = @call_rule typeof(*)(:out,Marginalisation) (m_A = d1, m_in = d2, meta=TinyCorrection())
+
+        @test typeof(OutMessage) <: ContinuousUnivariateLogPdf
+
+        groundtruthOutMessage = make_productdist_message(samples_d1, d2)
+        @test isapprox(OutMessage(1.), groundtruthOutMessage(1.);atol = 0.1)
+        @test isapprox(OutMessage(2.), groundtruthOutMessage(2.);atol = 0.1)
+        @test isapprox(OutMessage(3.1), groundtruthOutMessage(3.1);atol = 0.1)
+    end
+end
+
+end

--- a/test/rules/multiplication/test_out.jl
+++ b/test/rules/multiplication/test_out.jl
@@ -2,26 +2,26 @@ module RulesMultiplicationOutTest
 
 using Test
 using ReactiveMP
-using Random, Distributions 
-import ReactiveMP: @test_rules, besselmod, make_productdist_message 
+using Random, Distributions
+import ReactiveMP: @test_rules, besselmod, make_productdist_message
 
 @testset "rule:typeof(*):out" begin
     @testset "Univariate Gaussian messages" begin
-        d1 = NormalMeanVariance(0.,1.)
+        d1 = NormalMeanVariance(0.0, 1.0)
         d2 = NormalMeanVariance(0.5, 1.5)
-        d3 = NormalMeanVariance(2., 0.5)
-        OutMessage_1 = @call_rule typeof(*)(:out,Marginalisation) (m_A = d1, m_in = d2, meta=TinyCorrection())
-        OutMessage_2 = @call_rule typeof(*)(:out,Marginalisation) (m_A = d1, m_in = d3, meta=TinyCorrection())
-        OutMessage_3 = @call_rule typeof(*)(:out,Marginalisation) (m_A = d2, m_in = d3, meta=TinyCorrection())
-        groundtruthOutMessage_1 = besselmod(mean(d1),var(d1),mean(d2),var(d2),0.0)
-        groundtruthOutMessage_2 = besselmod(mean(d1),var(d1),mean(d3),var(d3),0.0)
-        groundtruthOutMessage_3 = besselmod(mean(d2),var(d2),mean(d3),var(d3),0.0)
+        d3 = NormalMeanVariance(2.0, 0.5)
+        OutMessage_1 = @call_rule typeof(*)(:out, Marginalisation) (m_A = d1, m_in = d2, meta = TinyCorrection())
+        OutMessage_2 = @call_rule typeof(*)(:out, Marginalisation) (m_A = d1, m_in = d3, meta = TinyCorrection())
+        OutMessage_3 = @call_rule typeof(*)(:out, Marginalisation) (m_A = d2, m_in = d3, meta = TinyCorrection())
+        groundtruthOutMessage_1 = besselmod(mean(d1), var(d1), mean(d2), var(d2), 0.0)
+        groundtruthOutMessage_2 = besselmod(mean(d1), var(d1), mean(d3), var(d3), 0.0)
+        groundtruthOutMessage_3 = besselmod(mean(d2), var(d2), mean(d3), var(d3), 0.0)
 
         @test typeof(OutMessage_1) <: ContinuousUnivariateLogPdf
         @test typeof(OutMessage_2) <: ContinuousUnivariateLogPdf
-        @test typeof(OutMessage_3) <: ContinuousUnivariateLogPdf 
+        @test typeof(OutMessage_3) <: ContinuousUnivariateLogPdf
 
-        samples = rand(Uniform(0.5,4),10)
+        samples = rand(Uniform(0.5, 4), 10)
         for i in samples
             @test OutMessage_1(i) ≈ groundtruthOutMessage_1(i)
             @test OutMessage_2(i) ≈ groundtruthOutMessage_2(i)
@@ -29,19 +29,19 @@ import ReactiveMP: @test_rules, besselmod, make_productdist_message
         end
     end
     @testset "messages of type Any" begin
-        d1 = NormalMeanVariance(0.,1.)
-        d2 = LogNormal(0., 1.)
+        d1          = NormalMeanVariance(0.0, 1.0)
+        d2          = LogNormal(0.0, 1.0)
         num_samples = 3000
-        samples_d1  = rand(d1,num_samples)
+        samples_d1  = rand(d1, num_samples)
 
-        OutMessage = @call_rule typeof(*)(:out,Marginalisation) (m_A = d1, m_in = d2, meta=TinyCorrection())
+        OutMessage = @call_rule typeof(*)(:out, Marginalisation) (m_A = d1, m_in = d2, meta = TinyCorrection())
 
         @test typeof(OutMessage) <: ContinuousUnivariateLogPdf
 
         groundtruthOutMessage = make_productdist_message(samples_d1, d2)
-        @test isapprox(OutMessage(1.), groundtruthOutMessage(1.);atol = 0.1)
-        @test isapprox(OutMessage(2.), groundtruthOutMessage(2.);atol = 0.1)
-        @test isapprox(OutMessage(3.1), groundtruthOutMessage(3.1);atol = 0.1)
+        @test isapprox(OutMessage(1.0), groundtruthOutMessage(1.0); atol = 0.1)
+        @test isapprox(OutMessage(2.0), groundtruthOutMessage(2.0); atol = 0.1)
+        @test isapprox(OutMessage(3.1), groundtruthOutMessage(3.1); atol = 0.1)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -347,6 +347,10 @@ end
     addtests(testrunner, "rules/normal_mean_precision/test_mean.jl")
     addtests(testrunner, "rules/normal_mean_precision/test_precision.jl")
 
+    addtests(testrunner, "rules/multiplication/test_out.jl")
+    addtests(testrunner, "rules/multiplication/test_A.jl")
+    addtests(testrunner, "rules/multiplication/test_in.jl")
+
     addtests(testrunner, "rules/mv_normal_mean_covariance/test_out.jl")
     addtests(testrunner, "rules/mv_normal_mean_covariance/test_mean.jl")
     addtests(testrunner, "rules/mv_normal_mean_covariance/test_covariance.jl")


### PR DESCRIPTION
This PR adds rules for the multiplication node. These additional rules cover the product of two random variables drawn from univariate distributions.
This PR relates to the issue #265 .  