### PR TITLE
Optimize rule/marginalrule dispatch

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,6 +23,9 @@ makedocs(
                 "Overview" => "lib/nodes/nodes.md",
                 "Flow"     => "lib/nodes/flow.md"
             ],
+            "Message update rules" => [
+                "Overview" => "lib/rules/rules.md",
+            ],
             "Prod implementation" => "lib/prod.md",
             "Helper utils"        => "lib/helpers.md",
             "Algebra utils"       => [

--- a/docs/src/custom/custom-functional-form.md
+++ b/docs/src/custom/custom-functional-form.md
@@ -14,6 +14,7 @@ q(x) = f\left(\frac{\overrightarrow{\mu}(x)\overleftarrow{\mu}(x)}{\int \overrig
 
 ```@docs 
 AbstractFormConstraint
+CompositeFormConstraint
 ```
  
 ### Form check strategy

--- a/docs/src/lib/message.md
+++ b/docs/src/lib/message.md
@@ -14,16 +14,26 @@ AbstractMessage
 
 ## [Belief-Propagation (or Sum-Product) message](@id lib-belief-propagation-message)
 
-Belief propagation messages are encoded with type `Message`. 
-
 ![message](../assets/img/bp-message.svg)
 *Belief propagation message*
 
+## [Variational message](@id lib-variational-message)
+
+![message](../assets/img/vmp-message.svg)
+*Variational message with structured factorisation q(x, y)q(z) assumption*
+
+## Message type
+
+Messages are encoded with type `Message`. 
+
 ```@docs
 Message
+ReactiveMP.materialize!
 ```
 
-From implementation point a view `Message` structure does nothing but holds some `data` object and redirects most of the statistical related functions to that `data` object. However it used extensively in Julia's multiple dispatch. Implementation also uses extra `is_initial` and `is_clamped` fields to determine if product of two messages results in `is_initial` or `is_clamped` posterior marginal.
+From implementation point a view `Message` structure does nothing but holds some `data` object and redirects most of the statistical related functions to that `data` object. 
+However it used extensively in Julia's multiple dispatch. 
+Implementation also uses extra `is_initial` and `is_clamped` fields to determine if product of two messages results in `is_initial` or `is_clamped` posterior marginal.
 
 ```@setup bp-message
 using ReactiveMP
@@ -47,11 +57,4 @@ is_clamped(message), is_initial(message)
 ```
 
 The user should not really interact with `Message` structure while working with `ReactiveMP` unless doing some advanced inference procedures that involve prediction.
-
-## [Variational message](@id lib-variational-message)
-
-Variational messages are encoded with type `VariationalMessage`.
-
-![message](../assets/img/vmp-message.svg)
-*Variational message with structured factorisation q(x, y)q(z) assumption*
 

--- a/docs/src/lib/message.md
+++ b/docs/src/lib/message.md
@@ -1,8 +1,10 @@
 
 # [Messages implementation](@id lib-message)
 
-In message passing framework one of the most important concepts is (wow!) messages. Messages flow on edges of a factor graph and usually hold some information in a form of probability distribution.
-In ReactiveMP.jl we distinguish two major types of messages: Belief Propagation and Variational.  
+In our message passing framework one of the most important concepts is the message (wow!).
+Messages flow along edges of a factor graph and hold information about the part of the graph that it originates from.
+Usually this information is in a form of a probability distribution.
+Two common messages are belief propagation messages and variational messages, with are computed differently as shown below.
 
 ## Abstract message type
 
@@ -24,16 +26,17 @@ AbstractMessage
 
 ## Message type
 
-Messages are encoded with type `Message`. 
+All messages are encoded with the type `Message`. 
 
 ```@docs
 Message
 ReactiveMP.materialize!
 ```
 
-From implementation point a view `Message` structure does nothing but holds some `data` object and redirects most of the statistical related functions to that `data` object. 
-However it used extensively in Julia's multiple dispatch. 
-Implementation also uses extra `is_initial` and `is_clamped` fields to determine if product of two messages results in `is_initial` or `is_clamped` posterior marginal.
+From an implementation point a view the `Message` structure does nothing but hold some `data` object and redirects most of the statistical related functions to that `data` object. 
+However, this object is used extensively in Julia's multiple dispatch. 
+Our implementation also uses extra `is_initial` and `is_clamped` fields to determine if product of two messages results in `is_initial` or `is_clamped` posterior marginal.
+The final field contains the addons. These contain additional information on top of the functional form of the distribution, such as its scaling or computation history.
 
 ```@setup bp-message
 using ReactiveMP

--- a/docs/src/lib/nodes/flow.md
+++ b/docs/src/lib/nodes/flow.md
@@ -1,6 +1,6 @@
 # [Flow node](@id lib-nodes-flow)
 
-See also [Flow tutorial](@ref examples-flow) for a comprehensive guide on using flows in `ReactiveMP`.
+See also [Flow tutorial](https://biaslab.github.io/RxInfer.jl/stable/examples/overview/) for a comprehensive guide on using flows in `ReactiveMP`.
 
 ```@docs
 PlanarFlow

--- a/docs/src/lib/nodes/nodes.md
+++ b/docs/src/lib/nodes/nodes.md
@@ -95,10 +95,12 @@ ReactiveMP.RequireEverythingFunctionalDependencies
 
 ## [Node traits](@id lib-node-traits)
 
-Each factor node has to define the [`as_node_functional_form`](@ref) trait function and to specify a [`ValidNodeFunctionalForm`](@ref) singleton as a return object. By default [`as_node_functional_form`](@ref) returns [`UndefinedNodeFunctionalForm`](@ref). Objects that do not specify this property correctly cannot be used in model specification.
+Each factor node has to define the [`ReactiveMP.as_node_functional_form`](@ref) trait function and to specify a [`ReactiveMP.ValidNodeFunctionalForm`](@ref) 
+singleton as a return object. By default [`ReactiveMP.as_node_functional_form`](@ref) returns [`ReactiveMP.UndefinedNodeFunctionalForm`](@ref). 
+Objects that do not specify this property correctly cannot be used in model specification.
 
 !!! note
-    [`@node`](@ref) macro does that automatically
+    `@node` macro does that automatically
 
 ```@docs
 ReactiveMP.ValidNodeFunctionalForm

--- a/docs/src/lib/rules/rules.md
+++ b/docs/src/lib/rules/rules.md
@@ -1,0 +1,18 @@
+# [Rules implementation](@id lib-rules)
+
+## [Message update rules](@id lib-message-rules)
+
+```@docs
+rule
+@rule
+@call_rule
+```
+
+## [Marginal update rules](@id lib-marginal-rules)
+
+
+```@docs
+marginalrule
+@marginalrule
+@call_marginalrule
+```

--- a/src/constraints/form.jl
+++ b/src/constraints/form.jl
@@ -31,7 +31,7 @@ This form constraint check strategy checks functional form of the messages produ
 Usually if a variable has been connected to multiple nodes we want to perform multiple `prod` to obtain a posterior marginal.
 With this form check strategy `constrain_form` function will be executed after each subsequent `prod` function.
 
-See also: [`FormConstraintCheckLast`](@ref), [`default_form_check_strategy`](@ref), [`constrain_form`](@ref), [`multiply_messages`](@ref)
+See also: [`FormConstraintCheckLast`](@ref), [`default_form_check_strategy`](@ref), [`constrain_form`](@ref)
 """
 struct FormConstraintCheckEach end
 
@@ -42,7 +42,7 @@ This form constraint check strategy checks functional form of the last messages 
 Usually if a variable has been connected to multiple nodes we want to perform multiple `prod` to obtain a posterior marginal.
 With this form check strategy `constrain_form` function will be executed only once after all subsequenct `prod` functions have been executed.
 
-See also: [`FormConstraintCheckLast`](@ref), [`default_form_check_strategy`](@ref), [`constrain_form`](@ref), [`multiply_messages`](@ref)
+See also: [`FormConstraintCheckLast`](@ref), [`default_form_check_strategy`](@ref), [`constrain_form`](@ref)
 """
 struct FormConstraintCheckLast end
 

--- a/src/helpers/helpers.jl
+++ b/src/helpers/helpers.jl
@@ -113,52 +113,6 @@ __check_all(fn::Function, ::Nothing)    = true
 
 is_clamped_or_initial(something) = is_clamped(something) || is_initial(something)
 
-## Meta utils
-
-"""
-    @symmetrical `function_definition`
-Duplicate a method definition with the order of the first two arguments swapped.
-This macro is used to duplicate methods that are symmetrical in their first two input arguments,
-but require explicit definitions for the different argument orders.
-Example:
-    @symmetrical function prod!(x, y, z)
-        ...
-    end
-"""
-macro symmetrical(fn::Expr)
-    # Check if macro is applied to a function definition
-    # Valid function definitions include:
-    # 1. foo([ args... ]) [ where ... [ where ... [ ... ] ] ] = :block
-    # 2. function foo([ args... ]) [ where ... [ where ... [ ... ] ] ]
-    #        :block
-    #    end
-    if (fn.head === :(=) || fn.head === :function) && (fn.args[1] isa Expr && fn.args[2] isa Expr) && (fn.args[2].head === :block)
-        return esc(
-            quote
-                $fn
-                $(swap_arguments(fn))
-            end
-        )
-    else
-        error("@symmetrical macro can be applied only to function definitions")
-    end
-end
-
-function swap_arguments(fn::Expr)
-    swapped = copy(fn)
-
-    if swapped.args[1].head === :where
-        swapped.args[1] = swap_arguments(swapped.args[1])
-    elseif swapped.args[1].head === :call && length(fn.args[1].args) >= 3 # Note: >= 3, because the first argument is a function name
-        swapped.args[1].args[2] = fn.args[1].args[3]
-        swapped.args[1].args[3] = fn.args[1].args[2]
-    else
-        error("Function method passed for @symmetrical macro must have more than 2 arguments")
-    end
-
-    return swapped
-end
-
 ## Other helpers 
 
 """

--- a/src/helpers/helpers.jl
+++ b/src/helpers/helpers.jl
@@ -1,4 +1,4 @@
-export skipindex, @symmetrical
+export skipindex
 
 using SpecialFunctions
 using Rocket

--- a/src/helpers/helpers.jl
+++ b/src/helpers/helpers.jl
@@ -78,13 +78,13 @@ union_types(x::Type)  = (x,)
 
 # Symbol helpers
 
-__extract_val_type(::Type{Type{Val{S}}}) where {S} = S
-__extract_val_type(::Type{Val{S}}) where {S}       = S
+__extract_val_type(::Type{Val{S}}) where {S} = S
+__extract_val_type(::Val{S}) where {S} = S
 
 @generated function split_underscored_symbol(symbol_val)
     S = __extract_val_type(symbol_val)
     R = tuple(map(Symbol, split(string(S), "_"))...)
-    return :(Val{$R})
+    return :(Val{$R}())
 end
 
 # NamedTuple helpers

--- a/src/message.jl
+++ b/src/message.jl
@@ -313,10 +313,11 @@ function MessageMapping(::F, vtag::T, vconstraint::C, msgs_names::N, marginals_n
     return MessageMapping{F, T, C, N, M, A, X, R}(vtag, vconstraint, msgs_names, marginals_names, meta, addons, factornode)
 end
 
-function materialize!(mapping::MessageMapping, dependencies)
-    messages  = dependencies[1]
-    marginals = dependencies[2]
+function materialize!(mapping::MessageMapping, dependencies) 
+    return materialize!(mapping, dependencies[1], dependencies[2])
+end
 
+function materialize!(mapping::MessageMapping, messages, marginals)
     # Message is clamped if all of the inputs are clamped
     is_message_clamped = __check_all(is_clamped, messages) && __check_all(is_clamped, marginals)
 

--- a/src/message.jl
+++ b/src/message.jl
@@ -61,7 +61,7 @@ true
 
 ```
 
-See also: [`AbstractMessage`](@ref), [`materialize!`](@ref)
+See also: [`AbstractMessage`](@ref), [`ReactiveMP.materialize!`](@ref)
 """
 struct Message{D, A} <: AbstractMessage
     data       :: D

--- a/src/message.jl
+++ b/src/message.jl
@@ -313,7 +313,7 @@ function MessageMapping(::F, vtag::T, vconstraint::C, msgs_names::N, marginals_n
     return MessageMapping{F, T, C, N, M, A, X, R}(vtag, vconstraint, msgs_names, marginals_names, meta, addons, factornode)
 end
 
-function materialize!(mapping::MessageMapping, dependencies) 
+function materialize!(mapping::MessageMapping, dependencies)
     return materialize!(mapping, dependencies[1], dependencies[2])
 end
 

--- a/src/node.jl
+++ b/src/node.jl
@@ -21,7 +21,7 @@ import Base: getindex, setindex!, firstindex, lastindex
 
 Trait specification for an object that can be used in model specification as a factor node.
 
-See also: [`as_node_functional_form`](@ref), [`UndefinedNodeFunctionalForm`](@ref)
+See also: [`ReactiveMP.as_node_functional_form`](@ref), [`ReactiveMP.UndefinedNodeFunctionalForm`](@ref)
 """
 struct ValidNodeFunctionalForm end
 
@@ -30,7 +30,7 @@ struct ValidNodeFunctionalForm end
 
 Trait specification for an object that can **not** be used in model specification as a factor node.
 
-See also: [`as_node_functional_form`](@ref), [`ValidNodeFunctionalForm`](@ref)
+See also: [`ReactiveMP.as_node_functional_form`](@ref), [`ReactiveMP.ValidNodeFunctionalForm`](@ref)
 """
 struct UndefinedNodeFunctionalForm end
 
@@ -40,7 +40,7 @@ struct UndefinedNodeFunctionalForm end
 Determines `object` node functional form trait specification.
 Returns either `ValidNodeFunctionalForm()` or `UndefinedNodeFunctionalForm()`.
 
-See also: [`ValidNodeFunctionalForm`](@ref), [`UndefinedNodeFunctionalForm`](@ref)
+See also: [`ReactiveMP.ValidNodeFunctionalForm`](@ref), [`ReactiveMP.UndefinedNodeFunctionalForm`](@ref)
 """
 function as_node_functional_form end
 

--- a/src/node.jl
+++ b/src/node.jl
@@ -319,7 +319,7 @@ Base.show(io::IO, interface::IndexedNodeInterface) = print(io, string("IndexedIn
 name(interface::IndexedNodeInterface)             = name(interface.interface)
 local_constraint(interface::IndexedNodeInterface) = local_constraint(interface.interface)
 index(interface::IndexedNodeInterface)            = interface.index
-tag(interface::IndexedNodeInterface)              = (Val{name(interface)}(), index(interface))
+tag(interface::IndexedNodeInterface)              = (tag(interface.interface), index(interface))
 
 messageout(interface::IndexedNodeInterface) = messageout(interface.interface)
 messagein(interface::IndexedNodeInterface)  = messagein(interface.interface)

--- a/src/node.jl
+++ b/src/node.jl
@@ -392,7 +392,7 @@ Base.first(localmarginal::FactorNodeLocalMarginal) = localmarginal.first
 
 index(localmarginal::FactorNodeLocalMarginal) = localmarginal.index
 name(localmarginal::FactorNodeLocalMarginal)  = localmarginal.name
-tag(localmarginal::FactorNodeLocalMarginal) = Val{name(localmarginal)}()
+tag(localmarginal::FactorNodeLocalMarginal)   = Val{name(localmarginal)}()
 
 getstream(localmarginal::FactorNodeLocalMarginal)              = localmarginal.stream
 setstream!(localmarginal::FactorNodeLocalMarginal, observable) = localmarginal.stream = observable

--- a/src/nodes/delta/layouts/cvi.jl
+++ b/src/nodes/delta/layouts/cvi.jl
@@ -35,7 +35,7 @@ function deltafn_apply_layout(::CVIApproximationDeltaFnRuleLayout, ::Val{:m_out}
         msgs_observable = of(nothing)
 
         # CVI requires `q_ins`
-        marginal_names       = Val{(:ins,)}
+        marginal_names       = Val{(:ins,)}()
         marginals_observable = combineLatestUpdates((getstream(factornode.localmarginals.marginals[2]),), PushNew())
 
         fform       = functionalform(factornode)

--- a/src/nodes/delta/layouts/default.jl
+++ b/src/nodes/delta/layouts/default.jl
@@ -32,7 +32,7 @@ function deltafn_apply_layout(::DeltaFnDefaultRuleLayout, ::Val{:q_ins}, factorn
         setstream!(localmarginal, cmarginal)
 
         # By default to compute `q_ins` we need messages both from `:out` and `:ins`
-        msgs_names      = Val{(:out, :ins)}
+        msgs_names      = Val{(:out, :ins)}()
         msgs_observable = combineLatestUpdates((messagein(out), combineLatestMessagesInUpdates(ins)), PushNew())
 
         # By default, we should not need any local marginals
@@ -40,7 +40,7 @@ function deltafn_apply_layout(::DeltaFnDefaultRuleLayout, ::Val{:q_ins}, factorn
         marginals_observable = of(nothing)
 
         fform = functionalform(factornode)
-        vtag  = Val{:ins}
+        vtag  = Val{:ins}()
         meta  = metadata(factornode)
 
         mapping     = MarginalMapping(fform, vtag, msgs_names, marginal_names, meta, factornode)
@@ -54,7 +54,7 @@ end
 function deltafn_apply_layout(::DeltaFnDefaultRuleLayout, ::Val{:m_out}, factornode::DeltaFnNode, pipeline_stages, scheduler, addons)
     let out = factornode.out, ins = factornode.ins
         # By default we simply request all inbound messages from `ins` edges
-        msgs_names      = Val{(:ins,)}
+        msgs_names      = Val{(:ins,)}()
         msgs_observable = combineLatestUpdates((combineLatestMessagesInUpdates(ins),), PushNew())
 
         # By default we don't need any marginals
@@ -62,7 +62,7 @@ function deltafn_apply_layout(::DeltaFnDefaultRuleLayout, ::Val{:m_out}, factorn
         marginals_observable = of(nothing)
 
         fform       = functionalform(factornode)
-        vtag        = tag(out)
+        vtag        = Val{:out}()
         vconstraint = local_constraint(out)
         meta        = metadata(factornode)
 
@@ -84,10 +84,10 @@ end
 function deltafn_apply_layout(::DeltaFnDefaultRuleLayout, ::Val{:m_in}, factornode::DeltaFnNode, pipeline_stages, scheduler, addons)
     # For each outbound message from `in_k` edge we need an inbound message on this edge and a joint marginal over `:ins` edges
     foreach(factornode.ins) do interface
-        msgs_names      = Val{(:in,)}
+        msgs_names      = Val{(:in,)}()
         msgs_observable = combineLatestUpdates((messagein(interface),), PushNew())
 
-        marginal_names       = Val{(:ins,)}
+        marginal_names       = Val{(:ins,)}()
         marginals_observable = combineLatestUpdates((getstream(factornode.localmarginals.marginals[2]),), PushNew())
 
         fform       = functionalform(factornode)
@@ -152,7 +152,7 @@ function deltafn_apply_layout(::DeltaFnDefaultKnownInverseRuleLayout, ::Val{:m_i
             combineLatestMessagesInUpdates(TupleTools.deleteat(factornode.ins, index))
         end
 
-        msgs_names      = Val{(:out, :ins)}
+        msgs_names      = Val{(:out, :ins)}()
         msgs_observable = combineLatestUpdates((messagein(factornode.out), msgs_ins_stream), PushNew())
 
         marginal_names       = nothing

--- a/src/nodes/gamma_mixture.jl
+++ b/src/nodes/gamma_mixture.jl
@@ -102,7 +102,7 @@ function get_marginals_observable(
     asinterfaces = marginal_dependencies[2]
     bsinterfaces = marginal_dependencies[3]
 
-    marginal_names = Val{(name(varinterface), name(asinterfaces[1]), name(bsinterfaces[1]))}
+    marginal_names = Val{(name(varinterface), name(asinterfaces[1]), name(bsinterfaces[1]))}()
     marginals_observable =
         combineLatest(
             (
@@ -125,7 +125,7 @@ function get_marginals_observable(factornode::GammaMixtureNode{N, F}, marginal_d
     switchinterface = marginal_dependencies[2]
     varinterface    = marginal_dependencies[3]
 
-    marginal_names       = Val{(name(outinterface), name(switchinterface), name(varinterface))}
+    marginal_names       = Val{(name(outinterface), name(switchinterface), name(varinterface))}()
     marginals_observable = combineLatestUpdates((getmarginal(connectedvar(outinterface), IncludeAll()), getmarginal(connectedvar(switchinterface), IncludeAll()), getmarginal(connectedvar(varinterface), IncludeAll())), PushNew())
 
     return marginal_names, marginals_observable
@@ -136,7 +136,7 @@ end
 @average_energy GammaMixture (q_out::Any, q_switch::Any, q_a::ManyOf{N, Any}, q_b::ManyOf{N, GammaShapeRate}) where {N} = begin
     z_bar = probvec(q_switch)
     return mapreduce(+, 1:N; init = 0.0) do i
-        return z_bar[i] * score(AverageEnergy(), GammaShapeRate, Val{(:out, :α, :β)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_a[i], q_b[i])), nothing)
+        return z_bar[i] * score(AverageEnergy(), GammaShapeRate, Val{(:out, :α, :β)}(), map((q) -> Marginal(q, false, false, nothing), (q_out, q_a[i], q_b[i])), nothing)
     end
 end
 
@@ -153,7 +153,7 @@ function score(::Type{T}, ::FactorBoundFreeEnergy, ::Stochastic, node::GammaMixt
 
     mapping = let fform = functionalform(node), meta = metadata(node)
         (marginals) -> begin
-            average_energy = score(AverageEnergy(), fform, Val{(:out, :switch, :a, :b)}, marginals, meta)
+            average_energy = score(AverageEnergy(), fform, Val{(:out, :switch, :a, :b)}(), marginals, meta)
 
             out_entropy    = score(DifferentialEntropy(), marginals[1])
             switch_entropy = score(DifferentialEntropy(), marginals[2])

--- a/src/nodes/mixture.jl
+++ b/src/nodes/mixture.jl
@@ -120,7 +120,7 @@ function get_messages_observable(
     output_or_switch_interface = messages[1]
     inputsinterfaces = messages[2]
 
-    msgs_names = Val{(name(output_or_switch_interface), name(inputsinterfaces[1]))}
+    msgs_names = Val{(name(output_or_switch_interface), name(inputsinterfaces[1]))}()
     msgs_observable =
         combineLatest((messagein(output_or_switch_interface), combineLatest(map((input) -> messagein(input), inputsinterfaces), PushNew())), PushNew()) |>
         map_to((messagein(output_or_switch_interface), ManyOf(map((input) -> messagein(input), inputsinterfaces))))
@@ -134,7 +134,7 @@ function get_messages_observable(
     switchinterface  = messages[1]
     inputsinterfaces = messages[2]
 
-    msgs_names = Val{(name(switchinterface), name(inputsinterfaces[1]))}
+    msgs_names = Val{(name(switchinterface), name(inputsinterfaces[1]))}()
     msgs_observable =
         combineLatest((messagein(switchinterface), combineLatest(map((input) -> messagein(input), inputsinterfaces), PushNew())), PushNew()) |>
         map_to((messagein(switchinterface), ManyOf(map((input) -> messagein(input), inputsinterfaces))))
@@ -147,7 +147,7 @@ function get_messages_observable(
 ) where {N, F <: FullFactorisation, P <: RequireMarginalFunctionalDependencies}
     inputsinterfaces = messages[1]
 
-    msgs_names = Val{(name(inputsinterfaces[1]),)}
+    msgs_names = Val{(name(inputsinterfaces[1]),)}()
     msgs_observable = combineLatest(map((input) -> messagein(input), inputsinterfaces), PushNew()) |> map_to((ManyOf(map((input) -> messagein(input), inputsinterfaces)),))
     return msgs_names, msgs_observable
 end
@@ -158,7 +158,7 @@ function get_messages_observable(
 ) where {N, F <: FullFactorisation, P <: RequireMarginalFunctionalDependencies}
     outputinterface = messages[1]
 
-    msgs_names = Val{(name(outputinterface),)}
+    msgs_names = Val{(name(outputinterface),)}()
     msgs_observable = combineLatestUpdates((messagein(outputinterface),), PushNew())
     return msgs_names, msgs_observable
 end
@@ -168,7 +168,7 @@ function get_marginals_observable(
 ) where {N, F <: FullFactorisation, P <: RequireMarginalFunctionalDependencies}
     switchinterface = marginals[1]
 
-    marginal_names       = Val{(name(switchinterface),)}
+    marginal_names       = Val{(name(switchinterface),)}()
     marginals_observable = combineLatestUpdates((getmarginal(connectedvar(switchinterface), IncludeAll()),), PushNew())
 
     return marginal_names, marginals_observable

--- a/src/nodes/normal_mixture.jl
+++ b/src/nodes/normal_mixture.jl
@@ -106,7 +106,7 @@ function get_marginals_observable(
     meansinterfaces = marginal_dependencies[2]
     precsinterfaces = marginal_dependencies[3]
 
-    marginal_names = Val{(name(varinterface), name(meansinterfaces[1]), name(precsinterfaces[1]))}
+    marginal_names = Val{(name(varinterface), name(meansinterfaces[1]), name(precsinterfaces[1]))}()
     marginals_observable =
         combineLatest(
             (
@@ -129,7 +129,7 @@ function get_marginals_observable(factornode::NormalMixtureNode{N, F}, marginal_
     switchinterface = marginal_dependencies[2]
     varinterface    = marginal_dependencies[3]
 
-    marginal_names       = Val{(name(outinterface), name(switchinterface), name(varinterface))}
+    marginal_names       = Val{(name(outinterface), name(switchinterface), name(varinterface))}()
     marginals_observable = combineLatestUpdates((getmarginal(connectedvar(outinterface), IncludeAll()), getmarginal(connectedvar(switchinterface), IncludeAll()), getmarginal(connectedvar(varinterface), IncludeAll())), PushNew())
 
     return marginal_names, marginals_observable
@@ -145,11 +145,11 @@ end
 end
 
 function avg_energy_nm(::Type{Univariate}, q_out, q_m, q_p, z_bar, i)
-    return z_bar[i] * score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[i], q_p[i])), nothing)
+    return z_bar[i] * score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}(), map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[i], q_p[i])), nothing)
 end
 
 function avg_energy_nm(::Type{Multivariate}, q_out, q_m, q_p, z_bar, i)
-    return z_bar[i] * score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[i], q_p[i])), nothing)
+    return z_bar[i] * score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}(), map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[i], q_p[i])), nothing)
 end
 
 function score(::Type{T}, ::FactorBoundFreeEnergy, ::Stochastic, node::NormalMixtureNode{N, MeanField}, skip_strategy, scheduler) where {T <: CountingReal, N}
@@ -165,7 +165,7 @@ function score(::Type{T}, ::FactorBoundFreeEnergy, ::Stochastic, node::NormalMix
 
     mapping = let fform = functionalform(node), meta = metadata(node)
         (marginals) -> begin
-            average_energy = score(AverageEnergy(), fform, Val{(:out, :switch, :m, :p)}, marginals, meta)
+            average_energy = score(AverageEnergy(), fform, Val{(:out, :switch, :m, :p)}(), marginals, meta)
 
             out_entropy     = score(DifferentialEntropy(), marginals[1])
             switch_entropy  = score(DifferentialEntropy(), marginals[2])

--- a/src/nodes/probit.jl
+++ b/src/nodes/probit.jl
@@ -18,8 +18,9 @@ default_meta(::Type{Probit}) = ProbitMeta(32)
 
 default_functional_dependencies_pipeline(::Type{<:Probit}) = RequireMessageFunctionalDependencies((2,), (vague(NormalMeanPrecision),))
 
-default_interface_local_constraint(::Type{<:Probit}, edge::Val{:in})  = MomentMatching()
-default_interface_local_constraint(::Type{<:Probit}, edge::Val{:out}) = Marginalisation()
+interface_default_local_constraint(::Type{<:Probit}, edge::Symbol) = interface_default_local_constraint(Probit, Val(edge))
+interface_default_local_constraint(::Type{<:Probit}, edge::Val{:in})  = MomentMatching()
+interface_default_local_constraint(::Type{<:Probit}, edge::Val{:out}) = Marginalisation()
 
 @average_energy Probit (q_out::Union{PointMass, Bernoulli}, q_in::UnivariateNormalDistributionsFamily, meta::ProbitMeta) = begin
 

--- a/src/nodes/probit.jl
+++ b/src/nodes/probit.jl
@@ -18,7 +18,7 @@ default_meta(::Type{Probit}) = ProbitMeta(32)
 
 default_functional_dependencies_pipeline(::Type{<:Probit}) = RequireMessageFunctionalDependencies((2,), (vague(NormalMeanPrecision),))
 
-interface_default_local_constraint(::Type{<:Probit}, edge::Symbol) = interface_default_local_constraint(Probit, Val(edge))
+interface_default_local_constraint(::Type{<:Probit}, edge::Symbol)    = interface_default_local_constraint(Probit, Val(edge))
 interface_default_local_constraint(::Type{<:Probit}, edge::Val{:in})  = MomentMatching()
 interface_default_local_constraint(::Type{<:Probit}, edge::Val{:out}) = Marginalisation()
 

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -25,7 +25,7 @@ This function is used to compute an outbound message for a given node
 - `meta`: Extra meta information
 - `__node`: Node reference
 
-See also: [`@rule`](@ref), [`RuleDispatcher`](@ref), [`marginalrule`](@ref), [`@marginalrule`](@ref)
+See also: [`@rule`](@ref), [`marginalrule`](@ref), [`@marginalrule`](@ref)
 """
 function rule end
 

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -23,6 +23,7 @@ This function is used to compute an outbound message for a given node
 - `qnames`: Ordered marginal names in form of the Val type, eg. `::Val{ (:mean, :precision) }`
 - `marginals`: Tuple of marginals of the same length as `qnames` used to compute an outbound message
 - `meta`: Extra meta information
+- `addons`: Extra addons information
 - `__node`: Node reference
 
 See also: [`@rule`](@ref), [`marginalrule`](@ref), [`@marginalrule`](@ref)
@@ -304,7 +305,54 @@ end
 import .MacroHelpers
 
 """
-    Documentation placeholder
+    @rule NodeType(:Edge, Constraint) (Arguments..., [ meta::MetaType ]) = begin
+        # rule body
+        return ...
+    end
+
+The `@rule` macro help to define new methods for the `rule` function. It works particularly well in combination with the `@node` macro.
+It has a specific structure, which must specify:
+
+- `NodeType`: must be a valid Julia type. If some attempt to define a rule for a Julia function (for example `+`), use `typeof(+)`
+- `Edge`: edge label, usually edge labels are defined with the `@node` macro
+- `Constrain`: DEPRECATED, please just use the `Marginalisation` label
+- `Arguments`: defines a list of the input arguments for the rule
+    - `m_*` prefix indicates that the argument is of type `Message` from the edge `*`
+    - `q_*` prefix indicates that the argument is of type `Marginal` on the edge `*`
+- `Meta::MetaType` - optionally, a user can specify a `Meta` object of type `MetaType`. 
+  This can be useful is some attempts to try different rules with different approximation methods or if the rule itself requires some temporary storage or cache. 
+  The default meta is `nothing`.
+
+
+Here are various examples of the `@rule` macro usage:
+
+1. Belief-Propagation (or Sum-Product) message update rule for the `NormalMeanVariance` node  toward the `:μ` edge with the `Marginalisation` constraint.
+   Input arguments are `m_out` and `m_v`, which are the messages from the corresponding edges `out` and `v` and have the type `PointMass`.
+
+```julia
+@rule NormalMeanVariance(:μ, Marginalisation) (m_out::PointMass, m_v::PointMass) = NormalMeanVariance(mean(m_out), mean(m_v))
+```
+
+2. Mean-field message update rule for the `NormalMeanVariance` node towards the `:μ` edge with the `Marginalisation` constraint.
+   Input arguments are `q_out` and `q_v`, which are the marginals on the corresponding edges `out` and `v` of type `Any`.
+
+```julia
+@rule NormalMeanVariance(:μ, Marginalisation) (q_out::Any, q_v::Any) = NormalMeanVariance(mean(q_out), mean(q_v))
+```
+
+
+3. Structured Variational message update rule for the `NormalMeanVariance` node towards the `:out` edge with the `Marginalisation` constraint.
+   Input arguments are `m_μ`, which is a message from the `μ` edge of type `UnivariateNormalDistributionsFamily`, and `q_v`, which is a marginal on the `v` edge of type `Any`.
+
+```julia
+@rule NormalMeanVariance(:out, Marginalisation) (m_μ::UnivariateNormalDistributionsFamily, q_v::Any) = begin
+    m_μ_mean, m_μ_cov = mean_cov(m_μ)
+    return NormalMeanVariance(m_μ_mean, m_μ_cov + mean(q_v))
+end
+```
+
+
+See also: [`rule`](@ref), [`marginalrule`](@ref), [`@marginalrule`], [`@call_rule`](@ref)
 """
 macro rule(fform, lambda)
     @capture(fform, fformtype_(on_, vconstraint_, options__)) ||
@@ -364,6 +412,14 @@ macro rule(fform, lambda)
     return esc(output)
 end
 
+"""
+    @call_rule NodeType(:edge, Constraint) (argument1 = value1, argument2 = value2, ..., [ meta = ... ])
+
+The `@call_rule` macro helps to call the `rule` method with an easier syntax. 
+The structure of the macro is almost the same as in the `@rule` macro, but there is no `begin ... end` block, but instead each argument must have a specified value with the `=` operator.
+
+See also: [`@rule`](@ref), [`rule`](@ref), [`@call_marginalrule`](@ref)
+"""
 macro call_rule(fform, args)
     @capture(fform, fformtype_(on_, vconstraint_)) || error("Error in macro. Functional form specification should in the form of 'fformtype_(on_, vconstraint_)'")
 
@@ -529,7 +585,55 @@ macro test_rules(on, test_sequence)
 end
 
 """
-    Documentation placeholder
+    @marginalrule NodeType(:Cluster) (Arguments..., [ meta::MetaType ]) = begin
+        # rule body
+        return ...
+    end
+
+The `@marginalrule` macro help to define new methods for the `marginalrule` function. It works particularly well in combination with the `@node` macro.
+It has a specific structure, which must specify:
+
+- `NodeType`: must be a valid Julia type. If some attempt to define a rule for a Julia function (for example `+`), use `typeof(+)`
+- `Cluster`: edge cluster that contains joined edge labels with the `_` symbol. Usually edge labels are defined with the `@node` macro
+- `Arguments`: defines a list of the input arguments for the rule
+    - `m_*` prefix indicates that the argument is of type `Message` from the edge `*`
+    - `q_*` prefix indicates that the argument is of type `Marginal` on the edge `*`
+- `Meta::MetaType` - optionally, a user can specify a `Meta` object of type `MetaType`. 
+  This can be useful is some attempts to try different rules with different approximation methods or if the rule itself requires some temporary storage or cache. 
+  The default meta is `nothing`.
+
+The `@marginalrule` can return a `NamedTuple` in the `return` statement. This would indicate some variables in the joint marginal 
+for the `Cluster` are independent and the joint itself is factorised. For example if some attempts to compute a marginal for the `q(x, y)` it is possible to return
+`(x = ..., y = ...)` as the result of the computation to indicate that `q(x, y) = q(x)q(y)`.
+
+Here are various examples of the `@marginalrule` macro usage:
+
+1. Marginal computation rule around the `NormalMeanPrecision` node for the `q(out, μ)`. The rule accepts arguments `m_out` and `m_μ`, which are the messages 
+from the `out` and `μ` edges respectively, and `q_τ` which is the marginal on the edge `τ`.
+
+```julia
+@marginalrule NormalMeanPrecision(:out_μ) (m_out::UnivariateNormalDistributionsFamily, m_μ::UnivariateNormalDistributionsFamily, q_τ::Any) = begin
+    xi_out, W_out = weightedmean_precision(m_out)
+    xi_μ, W_μ     = weightedmean_precision(m_μ)
+
+    W_bar = mean(q_τ)
+
+    W  = [W_out+W_bar -W_bar; -W_bar W_μ+W_bar]
+    xi = [xi_out; xi_μ]
+
+    return MvNormalWeightedMeanPrecision(xi, W)
+end
+```
+
+2. Marginal computation rule around the `NormalMeanPrecision` node for the `q(out, μ)`. The rule accepts arguments `m_out` and `m_μ`, which are the messages from the 
+`out` and `μ` edges respectively, and `q_τ` which is the marginal on the edge `τ`. In this example the result of the computation is a `NamedTuple`
+
+```julia
+@marginalrule NormalMeanPrecision(:out_μ) (m_out::PointMass, m_μ::UnivariateNormalDistributionsFamily, q_τ::Any) = begin
+    return (out = m_out, μ = prod(ProdAnalytical(), NormalMeanPrecision(mean(m_out), mean(q_τ)), m_μ))
+end
+```
+
 """
 macro marginalrule(fform, lambda)
     @capture(fform, fformtype_(on_)) || error("Error in macro. Functional form specification should in the form of 'fformtype_(on_)'")
@@ -567,6 +671,15 @@ macro marginalrule(fform, lambda)
     return esc(output)
 end
 
+"""
+    @call_marginalrule NodeType(:edge) (argument1 = value1, argument2 = value2, ..., [ meta = ... ])
+
+The `@call_marginalrule` macro helps to call the `marginalrule` method with an easier syntax. 
+The structure of the macro is almost the same as in the `@marginalrule` macro, but there is no `begin ... end` block, 
+but instead each argument must have a specified value with the `=` operator.
+
+See also: [`@marginalrule`](@ref), [`marginalrule`](@ref), [`@call_rule`](@ref)
+"""
 macro call_marginalrule(fform, args)
     @capture(fform, fformtype_(on_)) || error("Error in macro. Functional form specification should in the form of 'fformtype_(on_)'")
 

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -16,11 +16,11 @@ This function is used to compute an outbound message for a given node
 # Arguments
 
 - `fform`: Functional form of the node in form of a type of the node, e.g. `::Type{ <: NormalMeanVariance }` or `::typeof(+)`
-- `on`: Outbound interface's tag for which a message has to be computed, e.g. `::Type{ Val{:out} }` or `::Type{ Val{:μ} }`
+- `on`: Outbound interface's tag for which a message has to be computed, e.g. `::Val{:out}` or `::Val{:μ}`
 - `vconstraint`: Variable constraints for an outbound interface, e.g. `Marginalisation` or `MomentMatching`
-- `mnames`: Ordered messages names in form of the Val type, eg. `::Type{ Val{ (:mean, :precision) } }`
+- `mnames`: Ordered messages names in form of the Val type, eg. `::Val{ (:mean, :precision) }`
 - `messages`: Tuple of message of the same length as `mnames` used to compute an outbound message
-- `qnames`: Ordered marginal names in form of the Val type, eg. `::Type{ Val{ (:mean, :precision) } }`
+- `qnames`: Ordered marginal names in form of the Val type, eg. `::Val{ (:mean, :precision) }`
 - `marginals`: Tuple of marginals of the same length as `qnames` used to compute an outbound message
 - `meta`: Extra meta information
 - `__node`: Node reference
@@ -37,10 +37,10 @@ This function is used to compute a local joint marginal for a given node
 # Arguments
 
 - `fform`: Functional form of the node in form of a type of the node, e.g. `::Type{ <: NormalMeanVariance }` or `::typeof(+)`
-- `on`: Local joint marginal tag , e.g. `::Type{ Val{ :mean_precision } }` or `::Type{ Val{ :out_mean_precision } }`
-- `mnames`: Ordered messages names in form of the Val type, eg. `::Type{ Val{ (:mean, :precision) } }`
+- `on`: Local joint marginal tag , e.g. `::Val{ :mean_precision }` or `::Val{ :out_mean_precision }`
+- `mnames`: Ordered messages names in form of the Val type, eg. `::Val{ (:mean, :precision) }`
 - `messages`: Tuple of message of the same length as `mnames` used to compute an outbound message
-- `qnames`: Ordered marginal names in form of the Val type, eg. `::Type{ Val{ (:mean, :precision) } }`
+- `qnames`: Ordered marginal names in form of the Val type, eg. `::Val{ (:mean, :precision) }`
 - `marginals`: Tuple of marginals of the same length as `qnames` used to compute an outbound message
 - `meta`: Extra meta information
 - `__node`: Node reference

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -246,7 +246,7 @@ function call_rule_make_node(::CallRuleNodeNotRequired, fformtype, nodetype, met
     return nothing
 end
 
-function call_rule_macro_construct_on_arg(on_type, on_index::Nothing) 
+function call_rule_macro_construct_on_arg(on_type, on_index::Nothing)
     bottomtype = MacroHelpers.bottom_type(on_type)
     if @capture(bottomtype, Val{R_})
         return :(Val($R))

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -25,7 +25,7 @@ This function is used to compute an outbound message for a given node
 - `meta`: Extra meta information
 - `__node`: Node reference
 
-See also: [`@rule`](@ref), [`marginalrule`](@ref), [`@marginalrule`](@ref)
+See also: [`@rule`](@ref), [`RuleDispatcher`](@ref), [`marginalrule`](@ref), [`@marginalrule`](@ref)
 """
 function rule end
 
@@ -48,6 +48,26 @@ This function is used to compute a local joint marginal for a given node
 See also: [`rule`](@ref), [`@rule`](@ref) [`@marginalrule`](@ref)
 """
 function marginalrule end
+
+# Rule dispatcher
+
+"""
+    RuleDispatcher{F, T, C, M, Q}()
+
+This structure allows to dispatch many times on the same `rule` more efficiently by fixing some of the
+fields in the type parameters:
+- `F`: corresponds to the `fform`
+- `T`: corresponds to the `on`
+- `C`: corresponds to the `vconstraint`
+- `M`: corresponds to the `mnames`
+- `Q`: corresponds to the `qnames`
+
+See also: [`rule`](@ref)
+"""
+struct RuleDispatcher{F, T, C, M, Q} end
+
+RuleDispatcher(::Type{F}, ::Val{T}, ::C, ::Val{M}, ::Val{Q}) where {F, T, C, M, Q} = RuleDispatcher{F, T, C, M, Q}()
+RuleDispatcher(::F, ::Val{T}, ::C, ::Val{M}, ::Val{Q}) where {F, T, C, M, Q} = RuleDispatcher{F, T, C, M, Q}()
 
 # Macro code
 

--- a/src/rules/gamma_mixture/switch.jl
+++ b/src/rules/gamma_mixture/switch.jl
@@ -1,7 +1,7 @@
 
 @rule GammaMixture{N}(:switch, Marginalisation) (q_out::Any, q_a::ManyOf{N, Any}, q_b::ManyOf{N, GammaDistributionsFamily}) where {N} = begin
     U = map(zip(q_a, q_b)) do (a, b)
-        -score(AverageEnergy(), GammaShapeRate, Val{(:out, :α, :β)}, map((q) -> Marginal(q, false, false, nothing), (q_out, a, b)), nothing)
+        -score(AverageEnergy(), GammaShapeRate, Val{(:out, :α, :β)}(), map((q) -> Marginal(q, false, false, nothing), (q_out, a, b)), nothing)
     end
 
     ρ = clamp.(softmax(U), tiny, one(eltype(U)) - tiny)

--- a/src/rules/normal_mixture/switch.jl
+++ b/src/rules/normal_mixture/switch.jl
@@ -16,9 +16,9 @@ export rule
 end
 
 function rule_nm_switch_k(::Type{Univariate}, q_out, m, p)
-    return -score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, m, p)), nothing)
+    return -score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}(), map((q) -> Marginal(q, false, false, nothing), (q_out, m, p)), nothing)
 end
 
 function rule_nm_switch_k(::Type{Multivariate}, q_out, m, p)
-    return -score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, m, p)), nothing)
+    return -score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}(), map((q) -> Marginal(q, false, false, nothing), (q_out, m, p)), nothing)
 end

--- a/src/score/node.jl
+++ b/src/score/node.jl
@@ -17,8 +17,9 @@ function score(::Type{T}, ::FactorBoundFreeEnergy, ::Deterministic, node::Abstra
 
     stream = combineLatest(map(fnstream, interfaces(node)), PushNew())
 
-    vtag       = Val{inboundclustername(node)}
-    msgs_names = Val{map(name, interfaces(node))}
+    # TODO: (branch) replace with a function call
+    vtag       = Val{inboundclustername(node)}()
+    msgs_names = Val{map(name, interfaces(node))}()
 
     mapping = let fform = functionalform(node), vtag = vtag, meta = metadata(node), msgs_names = msgs_names, node = node
         (messages) -> begin
@@ -40,7 +41,8 @@ function score(::Type{T}, ::FactorBoundFreeEnergy, ::Stochastic, node::AbstractF
 
     stream = combineLatest(map(fnstream, localmarginals(node)), PushNew())
 
-    mapping = let fform = functionalform(node), meta = metadata(node), marginal_names = Val{localmarginalnames(node)}
+    # TODO: (branch) replace with a function call
+    mapping = let fform = functionalform(node), meta = metadata(node), marginal_names = Val{localmarginalnames(node)}()
         (marginals) -> begin
             average_energy   = score(AverageEnergy(), fform, marginal_names, marginals, meta)
             clusters_entropy = mapreduce(marginal -> score(DifferentialEntropy(), marginal), +, marginals)

--- a/src/score/node.jl
+++ b/src/score/node.jl
@@ -17,7 +17,6 @@ function score(::Type{T}, ::FactorBoundFreeEnergy, ::Deterministic, node::Abstra
 
     stream = combineLatest(map(fnstream, interfaces(node)), PushNew())
 
-    # TODO: (branch) replace with a function call
     vtag       = Val{inboundclustername(node)}()
     msgs_names = Val{map(name, interfaces(node))}()
 
@@ -41,7 +40,6 @@ function score(::Type{T}, ::FactorBoundFreeEnergy, ::Stochastic, node::AbstractF
 
     stream = combineLatest(map(fnstream, localmarginals(node)), PushNew())
 
-    # TODO: (branch) replace with a function call
     mapping = let fform = functionalform(node), meta = metadata(node), marginal_names = Val{localmarginalnames(node)}()
         (marginals) -> begin
             average_energy   = score(AverageEnergy(), fform, marginal_names, marginals, meta)

--- a/src/score/score.jl
+++ b/src/score/score.jl
@@ -11,14 +11,14 @@ struct DifferentialEntropy end
 
 ## Average energy function helpers
 
-function score(::AverageEnergy, fform, ::Type{<:Val}, marginals::Tuple{<:Marginal{<:NamedTuple{N}}}, meta) where {N}
+function score(::AverageEnergy, fform, ::Val, marginals::Tuple{<:Marginal{<:NamedTuple{N}}}, meta) where {N}
     joint = marginals[1]
 
     transform = let is_joint_clamped = is_clamped(joint), is_joint_initial = is_initial(joint)
         (data) -> Marginal(data, is_joint_clamped, is_joint_initial, nothing)
     end
 
-    return score(AverageEnergy(), fform, Val{N}, map(transform, values(getdata(joint))), meta)
+    return score(AverageEnergy(), fform, Val{N}(), map(transform, values(getdata(joint))), meta)
 end
 
 ## Differential entropy function helpers

--- a/test/nodes/test_bifm_helper.jl
+++ b/test/nodes/test_bifm_helper.jl
@@ -21,7 +21,7 @@ import ReactiveMP: @test_rules
         @test score(
             AverageEnergy(),
             BIFMHelper,
-            Val{(:out, :in)},
+            Val{(:out, :in)}(),
             (Marginal(MvNormalMeanCovariance([1, 1], [2 0; 0 3]), false, false, nothing), Marginal(MvNormalMeanCovariance([1, 1], [2 0; 0 3]), false, false, nothing)),
             nothing
         ) ≈ entropy(MvNormalMeanCovariance([1, 1], [2 0; 0 3]))
@@ -29,7 +29,7 @@ import ReactiveMP: @test_rules
         @test score(
             AverageEnergy(),
             BIFMHelper,
-            Val{(:out, :in)},
+            Val{(:out, :in)}(),
             (Marginal(MvNormalMeanCovariance([1, 2], [2 0; 0 1]), false, false, nothing), Marginal(MvNormalMeanPrecision([1, 2], [0.5 0; 0 1]), false, false, nothing)),
             nothing
         ) ≈ entropy(MvNormalMeanCovariance([1, 2], [2 0; 0 1]))

--- a/test/nodes/test_gamma_inverse.jl
+++ b/test/nodes/test_gamma_inverse.jl
@@ -29,7 +29,7 @@ import ReactiveMP: make_node
 
             marginals = (Marginal(q_out, false, false, nothing), Marginal(q_α, false, false, nothing), Marginal(q_θ, false, false, nothing))
 
-            @test score(AverageEnergy(), GammaInverse, Val{(:out, :α, :θ)}, marginals, nothing) ≈ -0.26835300529540684
+            @test score(AverageEnergy(), GammaInverse, Val{(:out, :α, :θ)}(), marginals, nothing) ≈ -0.26835300529540684
         end
         begin
             q_out = GammaInverse(42.0, 42.0)
@@ -38,7 +38,7 @@ import ReactiveMP: make_node
 
             marginals = (Marginal(q_out, false, false, nothing), Marginal(q_α, false, false, nothing), Marginal(q_θ, false, false, nothing))
 
-            @test score(AverageEnergy(), GammaInverse, Val{(:out, :α, :θ)}, marginals, nothing) ≈ -1.433976171558072
+            @test score(AverageEnergy(), GammaInverse, Val{(:out, :α, :θ)}(), marginals, nothing) ≈ -1.433976171558072
         end
     end # testset: AverageEnergy
 end # testset

--- a/test/nodes/test_mv_normal_mean_covariance.jl
+++ b/test/nodes/test_mv_normal_mean_covariance.jl
@@ -44,7 +44,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision)
                 marginals = (Marginal(q_out, false, false, nothing), Marginal(convert(N, q_μ), false, false, nothing), Marginal(q_Σ, false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanCovariance, Val{(:out, :μ, :Σ)}, marginals, nothing) ≈ 3.0310242469692907
+                @test score(AverageEnergy(), MvNormalMeanCovariance, Val{(:out, :μ, :Σ)}(), marginals, nothing) ≈ 3.0310242469692907
             end
         end
 
@@ -57,7 +57,7 @@ import ReactiveMP: make_node
                 N2 in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision)
 
                 marginals = (Marginal(convert(N1, q_out), false, false, nothing), Marginal(convert(N2, q_μ), false, false, nothing), Marginal(q_Σ, false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanCovariance, Val{(:out, :μ, :Σ)}, marginals, nothing) ≈ 4.863921806562866
+                @test score(AverageEnergy(), MvNormalMeanCovariance, Val{(:out, :μ, :Σ)}(), marginals, nothing) ≈ 4.863921806562866
             end
         end
 
@@ -70,7 +70,7 @@ import ReactiveMP: make_node
                 N2 in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision)
 
                 marginals = (Marginal(convert(N1, q_out), false, false, nothing), Marginal(convert(N2, q_μ), false, false, nothing), Marginal(q_Σ, false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanCovariance, Val{(:out, :μ, :Σ)}, marginals, nothing) ≈ 2.867156770180465
+                @test score(AverageEnergy(), MvNormalMeanCovariance, Val{(:out, :μ, :Σ)}(), marginals, nothing) ≈ 2.867156770180465
             end
         end
 
@@ -88,7 +88,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision)
                 marginals = (Marginal(convert(N, q_out_μ), false, false, nothing), Marginal(q_Σ, false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanCovariance, Val{(:out_μ, :Σ)}, marginals, nothing) ≈ 6.741420950973408
+                @test score(AverageEnergy(), MvNormalMeanCovariance, Val{(:out_μ, :Σ)}(), marginals, nothing) ≈ 6.741420950973408
             end
         end
 
@@ -106,7 +106,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision)
                 marginals = (Marginal(convert(N, q_out_μ), false, false, nothing), Marginal(q_Σ, false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanCovariance, Val{(:out_μ, :Σ)}, marginals, nothing) ≈ 60.075730792149585
+                @test score(AverageEnergy(), MvNormalMeanCovariance, Val{(:out_μ, :Σ)}(), marginals, nothing) ≈ 60.075730792149585
             end
         end
     end

--- a/test/nodes/test_mv_normal_mean_precision.jl
+++ b/test/nodes/test_mv_normal_mean_precision.jl
@@ -44,7 +44,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (Wishart,)
                 marginals = (Marginal(q_out, false, false, nothing), Marginal(convert(N, q_μ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}, marginals, nothing) ≈ 6.721945550750932
+                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}(), marginals, nothing) ≈ 6.721945550750932
             end
         end
 
@@ -55,7 +55,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (Wishart,)
                 marginals = (Marginal(q_out, false, false, nothing), Marginal(convert(N, q_μ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}, marginals, nothing) ≈ 57.362404928342
+                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}(), marginals, nothing) ≈ 57.362404928342
             end
         end
 
@@ -71,7 +71,7 @@ import ReactiveMP: make_node
                 marginals = (
                     Marginal(convert(N1, q_out), false, false, nothing), Marginal(convert(N2, q_μ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing)
                 )
-                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}, marginals, nothing) ≈ 114.57678973411974
+                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}(), marginals, nothing) ≈ 114.57678973411974
             end
         end
 
@@ -87,7 +87,7 @@ import ReactiveMP: make_node
                 marginals = (
                     Marginal(convert(N1, q_out), false, false, nothing), Marginal(convert(N2, q_μ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing)
                 )
-                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}, marginals, nothing) ≈ 14.92006071729396
+                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}(), marginals, nothing) ≈ 14.92006071729396
             end
         end
 
@@ -100,7 +100,7 @@ import ReactiveMP: make_node
                 N2 in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision)
 
                 marginals = (Marginal(convert(N1, q_out), false, false, nothing), Marginal(convert(N2, q_μ), false, false, nothing), Marginal(q_Λ, false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}, marginals, nothing) ≈ 38.31309509463591
+                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}(), marginals, nothing) ≈ 38.31309509463591
             end
         end
 
@@ -118,7 +118,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision)
                 marginals = (Marginal(convert(N, q_out_μ), false, false, nothing), Marginal(q_Λ, false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out_μ, :Λ)}, marginals, nothing) ≈ 87.02279699224562
+                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out_μ, :Λ)}(), marginals, nothing) ≈ 87.02279699224562
             end
         end
 
@@ -136,7 +136,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision)
                 marginals = (Marginal(convert(N, q_out_μ), false, false, nothing), Marginal(q_Λ, false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out_μ, :Λ)}, marginals, nothing) ≈ 11.240486862933556
+                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out_μ, :Λ)}(), marginals, nothing) ≈ 11.240486862933556
             end
         end
 
@@ -154,7 +154,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (Wishart,)
                 marginals = (Marginal(convert(N, q_out_μ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out_μ, :Λ)}, marginals, nothing) ≈ 28.552276936591902
+                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out_μ, :Λ)}(), marginals, nothing) ≈ 28.552276936591902
             end
         end
 
@@ -172,7 +172,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (Wishart,)
                 marginals = (Marginal(convert(N, q_out_μ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out_μ, :Λ)}, marginals, nothing) ≈ 1938.6631975673586
+                @test score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out_μ, :Λ)}(), marginals, nothing) ≈ 1938.6631975673586
             end
         end
     end

--- a/test/nodes/test_mv_normal_mean_scale_precision.jl
+++ b/test/nodes/test_mv_normal_mean_scale_precision.jl
@@ -44,7 +44,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), g in (Gamma,)
                 marginals = (Marginal(q_out, false, false, nothing), Marginal(convert(N, q_μ), false, false, nothing), Marginal(convert(g, q_γ), false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanScalePrecision, Val{(:out, :μ, :γ)}, marginals, nothing) ≈ 3.415092731310877
+                @test score(AverageEnergy(), MvNormalMeanScalePrecision, Val{(:out, :μ, :γ)}(), marginals, nothing) ≈ 3.415092731310877
             end
         end
 
@@ -60,7 +60,7 @@ import ReactiveMP: make_node
                 marginals = (
                     Marginal(convert(N1, q_out), false, false, nothing), Marginal(convert(N2, q_μ), false, false, nothing), Marginal(convert(g, q_γ), false, false, nothing)
                 )
-                @test score(AverageEnergy(), MvNormalMeanScalePrecision, Val{(:out, :μ, :γ)}, marginals, nothing) ≈ 188.7235844555108
+                @test score(AverageEnergy(), MvNormalMeanScalePrecision, Val{(:out, :μ, :γ)}(), marginals, nothing) ≈ 188.7235844555108
             end
         end
 
@@ -78,7 +78,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision)
                 marginals = (Marginal(convert(N, q_out_μ), false, false, nothing), Marginal(q_γ, false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanScalePrecision, Val{(:out_μ, :γ)}, marginals, nothing) ≈ 86.41549408285206
+                @test score(AverageEnergy(), MvNormalMeanScalePrecision, Val{(:out_μ, :γ)}(), marginals, nothing) ≈ 86.41549408285206
             end
         end
 
@@ -96,7 +96,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision)
                 marginals = (Marginal(convert(N, q_out_μ), false, false, nothing), Marginal(q_γ, false, false, nothing))
-                @test score(AverageEnergy(), MvNormalMeanScalePrecision, Val{(:out_μ, :γ)}, marginals, nothing) ≈ 11.887416710256351
+                @test score(AverageEnergy(), MvNormalMeanScalePrecision, Val{(:out_μ, :γ)}(), marginals, nothing) ≈ 11.887416710256351
             end
         end
     end

--- a/test/nodes/test_normal_mean_precision.jl
+++ b/test/nodes/test_normal_mean_precision.jl
@@ -44,7 +44,7 @@ import ReactiveMP: make_node
 
             for N in (NormalMeanPrecision, NormalMeanVariance, NormalWeightedMeanPrecision), G in (GammaShapeRate, GammaShapeScale)
                 marginals = (Marginal(q_out, false, false, nothing), Marginal(convert(N, q_μ), false, false, nothing), Marginal(convert(G, q_τ), false, false, nothing))
-                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, marginals, nothing) ≈ 1.6034261002694663
+                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}(), marginals, nothing) ≈ 1.6034261002694663
             end
         end
 
@@ -55,7 +55,7 @@ import ReactiveMP: make_node
 
             for N in (NormalMeanPrecision, NormalMeanVariance, NormalWeightedMeanPrecision), G in (GammaShapeRate, GammaShapeScale)
                 marginals = (Marginal(q_out, false, false, nothing), Marginal(convert(N, q_μ), false, false, nothing), Marginal(convert(G, q_τ), false, false, nothing))
-                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, marginals, nothing) ≈ 2.1034261002694663
+                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}(), marginals, nothing) ≈ 2.1034261002694663
             end
         end
 
@@ -66,7 +66,7 @@ import ReactiveMP: make_node
 
             for N in (NormalMeanPrecision, NormalMeanVariance, NormalWeightedMeanPrecision), G in (GammaShapeRate, GammaShapeScale)
                 marginals = (Marginal(q_out, false, false, nothing), Marginal(convert(N, q_μ), false, false, nothing), Marginal(convert(G, q_τ), false, false, nothing))
-                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, marginals, nothing) ≈ 2.209338084063204
+                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}(), marginals, nothing) ≈ 2.209338084063204
             end
         end
 
@@ -77,7 +77,7 @@ import ReactiveMP: make_node
 
             for N in (NormalMeanPrecision, NormalMeanVariance, NormalWeightedMeanPrecision), G in (GammaShapeRate, GammaShapeScale)
                 marginals = (Marginal(q_out, false, false, nothing), Marginal(convert(N, q_μ), false, false, nothing), Marginal(convert(G, q_τ), false, false, nothing))
-                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, marginals, nothing) ≈ 4.155913074139921
+                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}(), marginals, nothing) ≈ 4.155913074139921
             end
         end
 
@@ -87,7 +87,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (GammaShapeRate, GammaShapeScale)
                 marginals = (Marginal(convert(N, q_out_μ), false, false, nothing), Marginal(convert(G, q_τ), false, false, nothing))
-                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out_μ, :τ)}, marginals, nothing) ≈ 38.88138702883774
+                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out_μ, :τ)}(), marginals, nothing) ≈ 38.88138702883774
             end
         end
 
@@ -97,7 +97,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (GammaShapeRate, GammaShapeScale)
                 marginals = (Marginal(convert(N, q_out_μ), false, false, nothing), Marginal(convert(G, q_τ), false, false, nothing))
-                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out_μ, :τ)}, marginals, nothing) ≈ 138.6947657738283
+                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out_μ, :τ)}(), marginals, nothing) ≈ 138.6947657738283
             end
         end
     end

--- a/test/nodes/test_normal_mean_variance.jl
+++ b/test/nodes/test_normal_mean_variance.jl
@@ -44,7 +44,7 @@ import ReactiveMP: make_node
 
             for N in (NormalMeanPrecision, NormalMeanVariance, NormalWeightedMeanPrecision), G in (GammaShapeRate, GammaShapeScale)
                 marginals = (Marginal(q_out, false, false, nothing), Marginal(convert(N, q_μ), false, false, nothing), Marginal(convert(G, q_τ), false, false, nothing))
-                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, marginals, nothing) ≈ 1.8879401707928936
+                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}(), marginals, nothing) ≈ 1.8879401707928936
             end
         end
 
@@ -55,7 +55,7 @@ import ReactiveMP: make_node
 
             for N in (NormalMeanPrecision, NormalMeanVariance, NormalWeightedMeanPrecision), G in (GammaShapeRate, GammaShapeScale)
                 marginals = (Marginal(q_out, false, false, nothing), Marginal(convert(N, q_μ), false, false, nothing), Marginal(convert(G, q_v), false, false, nothing))
-                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, marginals, nothing) ≈ 2.86416186172411
+                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}(), marginals, nothing) ≈ 2.86416186172411
             end
         end
 
@@ -65,7 +65,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (GammaShapeRate, GammaShapeScale)
                 marginals = (Marginal(convert(N, q_out_μ), false, false, nothing), Marginal(convert(G, q_v), false, false, nothing))
-                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out_μ, :τ)}, marginals, nothing) ≈ 1.6231194045861121
+                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out_μ, :τ)}(), marginals, nothing) ≈ 1.6231194045861121
             end
         end
 
@@ -75,7 +75,7 @@ import ReactiveMP: make_node
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (GammaShapeRate, GammaShapeScale)
                 marginals = (Marginal(convert(N, q_out_μ), false, false, nothing), Marginal(convert(G, q_v), false, false, nothing))
-                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out_μ, :τ)}, marginals, nothing) ≈ 1.969539193740776
+                @test score(AverageEnergy(), NormalMeanPrecision, Val{(:out_μ, :τ)}(), marginals, nothing) ≈ 1.969539193740776
             end
         end
     end

--- a/test/nodes/test_normal_mixture.jl
+++ b/test/nodes/test_normal_mixture.jl
@@ -24,9 +24,9 @@ import ReactiveMP: WishartMessage, ManyOf
             )
 
             ref_val =
-                0.8 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[1], q_p[1])), nothing)) +
-                0.2 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[2], q_p[2])), nothing))
-            @test score(AverageEnergy(), NormalMixture, Val{(:out, :switch, :m, :p)}, marginals, nothing) ≈ ref_val
+                0.8 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}(), map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[1], q_p[1])), nothing)) +
+                0.2 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}(), map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[2], q_p[2])), nothing))
+            @test score(AverageEnergy(), NormalMixture, Val{(:out, :switch, :m, :p)}(), marginals, nothing) ≈ ref_val
         end
 
         begin
@@ -43,9 +43,9 @@ import ReactiveMP: WishartMessage, ManyOf
             )
 
             ref_val =
-                0.6 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[1], q_p[1])), nothing)) +
-                0.4 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[2], q_p[2])), nothing))
-            @test score(AverageEnergy(), NormalMixture, Val{(:out, :switch, :m, :p)}, marginals, nothing) ≈ ref_val
+                0.6 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}(), map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[1], q_p[1])), nothing)) +
+                0.4 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}(), map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[2], q_p[2])), nothing))
+            @test score(AverageEnergy(), NormalMixture, Val{(:out, :switch, :m, :p)}(), marginals, nothing) ≈ ref_val
         end
 
         begin
@@ -62,9 +62,9 @@ import ReactiveMP: WishartMessage, ManyOf
             )
 
             ref_val =
-                0.5 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[1], q_p[1])), nothing)) +
-                0.5 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[2], q_p[2])), nothing))
-            @test score(AverageEnergy(), NormalMixture, Val{(:out, :switch, :m, :p)}, marginals, nothing) ≈ ref_val
+                0.5 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}(), map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[1], q_p[1])), nothing)) +
+                0.5 * (score(AverageEnergy(), NormalMeanPrecision, Val{(:out, :μ, :τ)}(), map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[2], q_p[2])), nothing))
+            @test score(AverageEnergy(), NormalMixture, Val{(:out, :switch, :m, :p)}(), marginals, nothing) ≈ ref_val
         end
 
         begin
@@ -81,9 +81,9 @@ import ReactiveMP: WishartMessage, ManyOf
             )
 
             ref_val =
-                0.5 * (score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[1], q_p[1])), nothing)) +
-                0.5 * (score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}, map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[2], q_p[2])), nothing))
-            @test score(AverageEnergy(), NormalMixture, Val{(:out, :switch, :m, :p)}, marginals, nothing) ≈ ref_val
+                0.5 * (score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}(), map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[1], q_p[1])), nothing)) +
+                0.5 * (score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}(), map((q) -> Marginal(q, false, false, nothing), (q_out, q_m[2], q_p[2])), nothing))
+            @test score(AverageEnergy(), NormalMixture, Val{(:out, :switch, :m, :p)}(), marginals, nothing) ≈ ref_val
         end
     end
 end

--- a/test/nodes/test_poisson.jl
+++ b/test/nodes/test_poisson.jl
@@ -27,7 +27,7 @@ import ReactiveMP: make_node
 
         for l in 1:20, k in 1:20
             @test isapprox(
-                score(AverageEnergy(), Poisson, Val{(:out, :l)}, (Marginal(PointMass(k), false, false, nothing), Marginal(PointMass(l), false, false, nothing)), nothing),
+                score(AverageEnergy(), Poisson, Val{(:out, :l)}(), (Marginal(PointMass(k), false, false, nothing), Marginal(PointMass(l), false, false, nothing)), nothing),
                 -logpdf(Poisson(l), k),
                 rtol = 1e-12
             )
@@ -35,7 +35,7 @@ import ReactiveMP: make_node
 
         for k in 1:100
             @test isapprox(
-                score(AverageEnergy(), Poisson, Val{(:out, :l)}, (Marginal(Poisson(k), false, false, nothing), Marginal(PointMass(k), false, false, nothing)), nothing),
+                score(AverageEnergy(), Poisson, Val{(:out, :l)}(), (Marginal(Poisson(k), false, false, nothing), Marginal(PointMass(k), false, false, nothing)), nothing),
                 entropy(Poisson(k)),
                 rtol = 1e-3
             )
@@ -43,7 +43,7 @@ import ReactiveMP: make_node
 
         for k in 101:110
             @test isapprox(
-                score(AverageEnergy(), Poisson, Val{(:out, :l)}, (Marginal(Poisson(k), false, false, nothing), Marginal(PointMass(k), false, false, nothing)), nothing),
+                score(AverageEnergy(), Poisson, Val{(:out, :l)}(), (Marginal(Poisson(k), false, false, nothing), Marginal(PointMass(k), false, false, nothing)), nothing),
                 entropy(Poisson(k)),
                 rtol = 1e-1
             )

--- a/test/nodes/test_probit.jl
+++ b/test/nodes/test_probit.jl
@@ -27,7 +27,11 @@ using Random
         node = make_node(Probit)
 
         @test score(
-            AverageEnergy(), Probit, Val{(:out, :in)}(), (Marginal(Bernoulli(1), false, false, nothing), Marginal(NormalMeanVariance(0.0, 1.0), false, false, nothing)), ProbitMeta()
+            AverageEnergy(),
+            Probit,
+            Val{(:out, :in)}(),
+            (Marginal(Bernoulli(1), false, false, nothing), Marginal(NormalMeanVariance(0.0, 1.0), false, false, nothing)),
+            ProbitMeta()
         ) ≈ 1.0
 
         @test score(

--- a/test/nodes/test_probit.jl
+++ b/test/nodes/test_probit.jl
@@ -27,13 +27,13 @@ using Random
         node = make_node(Probit)
 
         @test score(
-            AverageEnergy(), Probit, Val{(:out, :in)}, (Marginal(Bernoulli(1), false, false, nothing), Marginal(NormalMeanVariance(0.0, 1.0), false, false, nothing)), ProbitMeta()
+            AverageEnergy(), Probit, Val{(:out, :in)}(), (Marginal(Bernoulli(1), false, false, nothing), Marginal(NormalMeanVariance(0.0, 1.0), false, false, nothing)), ProbitMeta()
         ) ≈ 1.0
 
         @test score(
             AverageEnergy(),
             Probit,
-            Val{(:out, :in)},
+            Val{(:out, :in)}(),
             (Marginal(PointMass(1), false, false, nothing), Marginal(NormalMeanVariance(0.0, 1.0), false, false, nothing)),
             ProbitMeta(100)
         ) ≈ 1.0
@@ -42,7 +42,7 @@ using Random
             @test score(
                 AverageEnergy(),
                 Probit,
-                Val{(:out, :in)},
+                Val{(:out, :in)}(),
                 (Marginal(Bernoulli(k), false, false, nothing), Marginal(NormalMeanVariance(0.0, 1.0), false, false, nothing)),
                 ProbitMeta(100)
             ) ≈ 1.0

--- a/test/nodes/test_uniform.jl
+++ b/test/nodes/test_uniform.jl
@@ -29,7 +29,7 @@ import ReactiveMP: make_node
         @test score(
             AverageEnergy(),
             Uniform,
-            Val{(:out, :a, :b)},
+            Val{(:out, :a, :b)}(),
             (Marginal(Beta(α, β), false, false, nothing), Marginal(PointMass(a), false, false, nothing), Marginal(PointMass(b), false, false, nothing)),
             nothing
         ) == 0.0

--- a/test/nodes/test_wishart_inverse.jl
+++ b/test/nodes/test_wishart_inverse.jl
@@ -29,7 +29,7 @@ import ReactiveMP: make_node
             q_S   = PointMass([2.0 0.0; 0.0 2.0])
 
             marginals = (Marginal(q_out, false, false, nothing), Marginal(q_ν, false, false, nothing), Marginal(q_S, false, false, nothing))
-            @test score(AverageEnergy(), InverseWishart, Val{(:out, :ν, :S)}, marginals, nothing) ≈ 9.496544113156787
+            @test score(AverageEnergy(), InverseWishart, Val{(:out, :ν, :S)}(), marginals, nothing) ≈ 9.496544113156787
         end
 
         begin
@@ -40,7 +40,7 @@ import ReactiveMP: make_node
             q_S   = PointMass(S)
 
             marginals = (Marginal(q_out, false, false, nothing), Marginal(q_ν, false, false, nothing), Marginal(q_S, false, false, nothing))
-            @test score(AverageEnergy(), InverseWishart, Val{(:out, :ν, :S)}, marginals, nothing) ≈ 1.1299587008097587
+            @test score(AverageEnergy(), InverseWishart, Val{(:out, :ν, :S)}(), marginals, nothing) ≈ 1.1299587008097587
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,6 +209,7 @@ end
 
     addtests(testrunner, "score/test_counting.jl")
 
+    addtests(testrunner, "test_rule.jl")
     addtests(testrunner, "test_addons.jl")
 
     addtests(testrunner, "approximations/test_shared.jl")

--- a/test/test_rule.jl
+++ b/test/test_rule.jl
@@ -223,14 +223,7 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
 
         let
             err = ReactiveMP.MarginalRuleMethodError(
-                NormalMeanPrecision,
-                Val{:μ}(),
-                Val{(:out,)}(),
-                (as_vague_msg(NormalMeanVariance),),
-                Val{(:τ,)}(),
-                (as_vague_mrg(Gamma),),
-                nothing,
-                make_node(NormalMeanPrecision)
+                NormalMeanPrecision, Val{:μ}(), Val{(:out,)}(), (as_vague_msg(NormalMeanVariance),), Val{(:τ,)}(), (as_vague_mrg(Gamma),), nothing, make_node(NormalMeanPrecision)
             )
 
             io = IOBuffer()
@@ -245,14 +238,7 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
 
         let
             err = ReactiveMP.MarginalRuleMethodError(
-                NormalMeanPrecision,
-                Val{:μ}(),
-                Val{(:out,)}(),
-                (as_vague_msg(NormalMeanVariance),),
-                Val{(:τ,)}(),
-                (as_vague_mrg(Gamma),),
-                1.0,
-                make_node(NormalMeanPrecision)
+                NormalMeanPrecision, Val{:μ}(), Val{(:out,)}(), (as_vague_msg(NormalMeanVariance),), Val{(:τ,)}(), (as_vague_mrg(Gamma),), 1.0, make_node(NormalMeanPrecision)
             )
 
             io = IOBuffer()
@@ -268,14 +254,7 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
 
         let
             err = ReactiveMP.MarginalRuleMethodError(
-                NormalMeanPrecision,
-                Val{:μ}(),
-                Val{(:out, :τ)}(),
-                (as_vague_msg(NormalMeanVariance), as_vague_msg(Gamma)),
-                nothing,
-                nothing,
-                1.0,
-                make_node(NormalMeanPrecision)
+                NormalMeanPrecision, Val{:μ}(), Val{(:out, :τ)}(), (as_vague_msg(NormalMeanVariance), as_vague_msg(Gamma)), nothing, nothing, 1.0, make_node(NormalMeanPrecision)
             )
 
             io = IOBuffer()
@@ -291,14 +270,7 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
 
         let
             err = ReactiveMP.MarginalRuleMethodError(
-                NormalMeanPrecision,
-                Val{:μ}(),
-                nothing,
-                nothing,
-                Val{(:out, :τ)}(),
-                (as_vague_mrg(NormalMeanVariance), as_vague_mrg(Gamma)),
-                1.0,
-                make_node(NormalMeanPrecision)
+                NormalMeanPrecision, Val{:μ}(), nothing, nothing, Val{(:out, :τ)}(), (as_vague_mrg(NormalMeanVariance), as_vague_mrg(Gamma)), 1.0, make_node(NormalMeanPrecision)
             )
 
             io = IOBuffer()
@@ -359,7 +331,7 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
         struct DummyNode end
         struct DummyNodeMeta end
 
-        @node DummyNode Stochastic [ out, x, y ]
+        @node DummyNode Stochastic [out, x, y]
 
         @rule DummyNode(:out, Marginalisation) (m_x::NormalMeanPrecision, m_y::NormalMeanPrecision) = 1
         @rule DummyNode(:out, Marginalisation) (m_x::NormalMeanPrecision, m_y::NormalMeanPrecision, meta::Int) = meta

--- a/test/test_rule.jl
+++ b/test/test_rule.jl
@@ -8,8 +8,8 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
 
 @testset "rule" begin
     @testset "rule_macro_parse_on_tag(expression)" begin
-        @test rule_macro_parse_on_tag(:(:out)) == (:(Type{Val{:out}}), nothing, nothing)
-        @test rule_macro_parse_on_tag(:(:mean)) == (:(Type{Val{:mean}}), nothing, nothing)
+        @test rule_macro_parse_on_tag(:(:out)) == (:(Val{:out}), nothing, nothing)
+        @test rule_macro_parse_on_tag(:(:mean)) == (:(Val{:mean}), nothing, nothing)
         @test rule_macro_parse_on_tag(:(:mean, k)) == (:(Tuple{Val{:mean}, Int}), :k, :(k = on[2]))
         @test rule_macro_parse_on_tag(:(:precision, r)) == (:(Tuple{Val{:precision}, Int}), :r, :(r = on[2]))
 
@@ -22,7 +22,7 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
     @testset "rule_macro_parse_fn_args(inputs; specname, prefix, proxy)" begin
         names, types, init = rule_macro_parse_fn_args([(:m_out, :PointMass), (:m_mean, :NormalMeanPrecision)]; specname = :messages, prefix = :m_, proxy = :(ReactiveMP.Message))
 
-        @test names == :(Type{Val{(:out, :mean)}})
+        @test names == :(Val{(:out, :mean)})
         @test types == :(Tuple{ReactiveMP.Message{<:PointMass}, ReactiveMP.Message{<:NormalMeanPrecision}})
         @test init == Expr[:(m_out = getdata(messages[1])), :(m_mean = getdata(messages[2]))]
 
@@ -34,7 +34,7 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
 
         names, types, init = rule_macro_parse_fn_args([(:m_out, :PointMass), (:q_mean, :NormalMeanPrecision)]; specname = :marginals, prefix = :q_, proxy = :(ReactiveMP.Marginal))
 
-        @test names == :(Type{Val{(:mean,)}})
+        @test names == :(Val{(:mean,)})
         @test types == :(Tuple{ReactiveMP.Marginal{<:NormalMeanPrecision}})
         @test init == Expr[:(q_mean = getdata(marginals[1]))]
     end
@@ -44,8 +44,8 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
             [(:m_out, :(PointMass(1.0))), (:m_mean, :(NormalMeanPrecision(0.0, 1.0)))]; specname = :messages, prefix = :m_, proxy = :(ReactiveMP.Message)
         )
 
-        @test names == :(Val{(:out, :mean)})
-        @test values == :(ReactiveMP.Message(PointMass(1.0), false, false), ReactiveMP.Message(NormalMeanPrecision(0.0, 1.0), false, false))
+        @test names == :(Val{(:out, :mean)}())
+        @test values == :(ReactiveMP.Message(PointMass(1.0), false, false, nothing), ReactiveMP.Message(NormalMeanPrecision(0.0, 1.0), false, false, nothing))
 
         names, values = call_rule_macro_parse_fn_args(
             [(:m_out, :(PointMass(1.0))), (:m_mean, :(NormalMeanPrecision(0.0, 1.0)))]; specname = :marginals, prefix = :q_, proxy = :(ReactiveMP.Marginal)
@@ -58,23 +58,24 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
             [(:m_out, :(PointMass(1.0))), (:q_mean, :(NormalMeanPrecision(0.0, 1.0)))]; specname = :marginals, prefix = :q_, proxy = :(ReactiveMP.Marginal)
         )
 
-        @test names == :(Val{(:mean,)})
-        @test values == :((ReactiveMP.Marginal(NormalMeanPrecision(0.0, 1.0), false, false),))
+        @test names == :(Val{(:mean,)}())
+        @test values == :((ReactiveMP.Marginal(NormalMeanPrecision(0.0, 1.0), false, false, nothing),))
     end
 
     @testset "rule_method_error" begin
-        as_vague_msg(::Type{T}) where {T} = Message(vague(T), false, false)
-        as_vague_mrg(::Type{T}) where {T} = Marginal(vague(T), false, false)
+        as_vague_msg(::Type{T}) where {T} = Message(vague(T), false, false, nothing)
+        as_vague_mrg(::Type{T}) where {T} = Marginal(vague(T), false, false, nothing)
 
         let
             err = ReactiveMP.RuleMethodError(
                 NormalMeanPrecision,
-                Val{:μ},
+                Val{:μ}(),
                 Marginalisation(),
-                Val{(:out,)},
+                Val{(:out,)}(),
                 (as_vague_msg(NormalMeanVariance),),
-                Val{(:τ,)},
+                Val{(:τ,)}(),
                 (as_vague_mrg(Gamma),),
+                nothing,
                 nothing,
                 make_node(NormalMeanPrecision)
             )
@@ -93,13 +94,14 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
         let
             err = ReactiveMP.RuleMethodError(
                 NormalMeanPrecision,
-                Val{:μ},
+                Val{:μ}(),
                 Marginalisation(),
-                Val{(:out,)},
+                Val{(:out,)}(),
                 (as_vague_msg(NormalMeanVariance),),
-                Val{(:τ,)},
+                Val{(:τ,)}(),
                 (as_vague_mrg(Gamma),),
                 1.0,
+                nothing,
                 make_node(NormalMeanPrecision)
             )
 
@@ -118,13 +120,14 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
         let
             err = ReactiveMP.RuleMethodError(
                 NormalMeanPrecision,
-                Val{:μ},
+                Val{:μ}(),
                 Marginalisation(),
-                Val{(:out, :τ)},
+                Val{(:out, :τ)}(),
                 (as_vague_msg(NormalMeanVariance), as_vague_msg(Gamma)),
                 nothing,
                 nothing,
                 1.0,
+                nothing,
                 make_node(NormalMeanPrecision)
             )
 
@@ -143,13 +146,14 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
         let
             err = ReactiveMP.RuleMethodError(
                 NormalMeanPrecision,
-                Val{:μ},
+                Val{:μ}(),
                 Marginalisation(),
                 nothing,
                 nothing,
-                Val{(:out, :τ)},
+                Val{(:out, :τ)}(),
                 (as_vague_mrg(NormalMeanVariance), as_vague_mrg(Gamma)),
                 1.0,
+                nothing,
                 make_node(NormalMeanPrecision)
             )
 
@@ -168,13 +172,14 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
         let
             err = ReactiveMP.RuleMethodError(
                 NormalMeanPrecision,
-                Val{:τ},
+                Val{:τ}(),
                 Marginalisation(),
                 nothing,
                 nothing,
-                Val{(:out_μ,)},
-                (Marginal(vague(MvNormalMeanPrecision, 2), false, false),),
+                Val{(:out_μ,)}(),
+                (Marginal(vague(MvNormalMeanPrecision, 2), false, false, nothing),),
                 1.0,
+                nothing,
                 make_node(NormalMeanPrecision)
             )
 
@@ -192,13 +197,14 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
         let
             err = ReactiveMP.RuleMethodError(
                 NormalMeanPrecision,
-                Val{:τ},
+                Val{:τ}(),
                 Marginalisation(),
-                Val{(:out, :μ)},
+                Val{(:out, :μ)}(),
                 (as_vague_msg(NormalMeanVariance), as_vague_msg(NormalMeanVariance)),
-                Val{(:out_μ,)},
-                (Marginal(vague(MvNormalMeanPrecision, 2), false, false),),
+                Val{(:out_μ,)}(),
+                (Marginal(vague(MvNormalMeanPrecision, 2), false, false, nothing),),
                 1.0,
+                nothing,
                 make_node(NormalMeanPrecision)
             )
 
@@ -212,12 +218,19 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
     end
 
     @testset "marginalrule_method_error" begin
-        as_vague_msg(::Type{T}) where {T} = Message(vague(T), false, false)
-        as_vague_mrg(::Type{T}) where {T} = Marginal(vague(T), false, false)
+        as_vague_msg(::Type{T}) where {T} = Message(vague(T), false, false, nothing)
+        as_vague_mrg(::Type{T}) where {T} = Marginal(vague(T), false, false, nothing)
 
         let
             err = ReactiveMP.MarginalRuleMethodError(
-                NormalMeanPrecision, Val{:μ}, Val{(:out,)}, (as_vague_msg(NormalMeanVariance),), Val{(:τ,)}, (as_vague_mrg(Gamma),), nothing, make_node(NormalMeanPrecision)
+                NormalMeanPrecision,
+                Val{:μ}(),
+                Val{(:out,)}(),
+                (as_vague_msg(NormalMeanVariance),),
+                Val{(:τ,)}(),
+                (as_vague_mrg(Gamma),),
+                nothing,
+                make_node(NormalMeanPrecision)
             )
 
             io = IOBuffer()
@@ -232,7 +245,14 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
 
         let
             err = ReactiveMP.MarginalRuleMethodError(
-                NormalMeanPrecision, Val{:μ}, Val{(:out,)}, (as_vague_msg(NormalMeanVariance),), Val{(:τ,)}, (as_vague_mrg(Gamma),), 1.0, make_node(NormalMeanPrecision)
+                NormalMeanPrecision,
+                Val{:μ}(),
+                Val{(:out,)}(),
+                (as_vague_msg(NormalMeanVariance),),
+                Val{(:τ,)}(),
+                (as_vague_mrg(Gamma),),
+                1.0,
+                make_node(NormalMeanPrecision)
             )
 
             io = IOBuffer()
@@ -248,7 +268,14 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
 
         let
             err = ReactiveMP.MarginalRuleMethodError(
-                NormalMeanPrecision, Val{:μ}, Val{(:out, :τ)}, (as_vague_msg(NormalMeanVariance), as_vague_msg(Gamma)), nothing, nothing, 1.0, make_node(NormalMeanPrecision)
+                NormalMeanPrecision,
+                Val{:μ}(),
+                Val{(:out, :τ)}(),
+                (as_vague_msg(NormalMeanVariance), as_vague_msg(Gamma)),
+                nothing,
+                nothing,
+                1.0,
+                make_node(NormalMeanPrecision)
             )
 
             io = IOBuffer()
@@ -264,7 +291,14 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
 
         let
             err = ReactiveMP.MarginalRuleMethodError(
-                NormalMeanPrecision, Val{:μ}, nothing, nothing, Val{(:out, :τ)}, (as_vague_mrg(NormalMeanVariance), as_vague_mrg(Gamma)), 1.0, make_node(NormalMeanPrecision)
+                NormalMeanPrecision,
+                Val{:μ}(),
+                nothing,
+                nothing,
+                Val{(:out, :τ)}(),
+                (as_vague_mrg(NormalMeanVariance), as_vague_mrg(Gamma)),
+                1.0,
+                make_node(NormalMeanPrecision)
             )
 
             io = IOBuffer()
@@ -280,7 +314,14 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
 
         let
             err = ReactiveMP.MarginalRuleMethodError(
-                NormalMeanPrecision, Val{:τ}, nothing, nothing, Val{(:out_μ,)}, (Marginal(vague(MvNormalMeanPrecision, 2), false, false),), 1.0, make_node(NormalMeanPrecision)
+                NormalMeanPrecision,
+                Val{:τ}(),
+                nothing,
+                nothing,
+                Val{(:out_μ,)}(),
+                (Marginal(vague(MvNormalMeanPrecision, 2), false, false, nothing),),
+                1.0,
+                make_node(NormalMeanPrecision)
             )
 
             io = IOBuffer()
@@ -296,11 +337,11 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
         let
             err = ReactiveMP.MarginalRuleMethodError(
                 NormalMeanPrecision,
-                Val{:τ},
-                Val{(:out, :μ)},
+                Val{:τ}(),
+                Val{(:out, :μ)}(),
                 (as_vague_msg(NormalMeanVariance), as_vague_msg(NormalMeanVariance)),
-                Val{(:out_μ,)},
-                (Marginal(vague(MvNormalMeanPrecision, 2), false, false),),
+                Val{(:out_μ,)}(),
+                (Marginal(vague(MvNormalMeanPrecision, 2), false, false, nothing),),
                 1.0,
                 make_node(NormalMeanPrecision)
             )
@@ -317,6 +358,8 @@ import ReactiveMP: rule_macro_parse_on_tag, rule_macro_parse_fn_args, call_rule_
     @testset "Check that default meta is `nothing`" begin
         struct DummyNode end
         struct DummyNodeMeta end
+
+        @node DummyNode Stochastic [ out, x, y ]
 
         @rule DummyNode(:out, Marginalisation) (m_x::NormalMeanPrecision, m_y::NormalMeanPrecision) = 1
         @rule DummyNode(:out, Marginalisation) (m_x::NormalMeanPrecision, m_y::NormalMeanPrecision, meta::Int) = meta


### PR DESCRIPTION
This PR improves upon https://github.com/biaslab/ReactiveMP.jl/pull/290 and addresses https://github.com/biaslab/ReactiveMP.jl/issues/284 even further.

A better version of the #292 without breaking changes. The PR improves execution time and memory allocation profile in 100% test-cases by various degree. Particularly useful for small models and real-time inference at a high rate, but also improves the performance of variational iterations.

<details>
<summary><b>Timings</b></summary>

```
benchmark_ar_22-03-2023-19-14_v1.8.5.txt: Time  (mean ± σ):   116.908 ms ±  11.944 ms  ┊ GC (mean ± σ):  12.96% ±  6.93%
benchmark_ar_22-03-2023-19-19_v1.8.5.txt: Time  (mean ± σ):   154.613 ms ±   9.033 ms  ┊ GC (mean ± σ):  11.50% ±  4.04%
benchmark_cvi_22-03-2023-19-16_v1.8.5.txt: Time  (mean ± σ):   4.135 s ± 4.514 ms  ┊ GC (mean ± σ):  7.59% ± 0.27%
benchmark_cvi_22-03-2023-19-21_v1.8.5.txt: Time  (mean ± σ):   4.396 s ± 10.455 ms  ┊ GC (mean ± σ):  7.13% ± 0.10%
benchmark_gmm_multivariate_22-03-2023-19-14_v1.8.5.txt: Time  (mean ± σ):   190.276 ms ±  13.886 ms  ┊ GC (mean ± σ):  15.70% ±  4.46%
benchmark_gmm_multivariate_22-03-2023-19-19_v1.8.5.txt: Time  (mean ± σ):   186.198 ms ±  13.032 ms  ┊ GC (mean ± σ):  16.57% ±  4.53%
benchmark_gmm_univariate_22-03-2023-19-14_v1.8.5.txt: Time  (mean ± σ):   11.074 ms ±  3.562 ms  ┊ GC (mean ± σ):  10.65% ± 15.79%
benchmark_gmm_univariate_22-03-2023-19-19_v1.8.5.txt: Time  (mean ± σ):   11.120 ms ±  3.382 ms  ┊ GC (mean ± σ):  10.43% ± 15.56%
benchmark_hgf_22-03-2023-19-15_v1.8.5.txt: Time  (mean ± σ):   254.252 ms ±   4.763 ms  ┊ GC (mean ± σ):  7.19% ± 1.54%
benchmark_hgf_22-03-2023-19-20_v1.8.5.txt: Time  (mean ± σ):   316.044 ms ±   5.141 ms  ┊ GC (mean ± σ):  7.57% ± 1.16%
benchmark_iid_mv_covariance_22-03-2023-19-15_v1.8.5.txt: Time  (mean ± σ):   54.497 ms ±  7.338 ms  ┊ GC (mean ± σ):  10.90% ± 10.16%
benchmark_iid_mv_covariance_22-03-2023-19-20_v1.8.5.txt: Time  (mean ± σ):   67.399 ms ±  6.689 ms  ┊ GC (mean ± σ):  10.33% ±  8.46%
benchmark_iid_mv_precision_22-03-2023-19-15_v1.8.5.txt: Time  (mean ± σ):   45.121 ms ±  6.445 ms  ┊ GC (mean ± σ):  11.46% ± 11.09%
benchmark_iid_mv_precision_22-03-2023-19-20_v1.8.5.txt: Time  (mean ± σ):   58.066 ms ±  6.896 ms  ┊ GC (mean ± σ):  11.72% ±  9.91%
benchmark_iid_mv_wishart_known_mean_22-03-2023-19-15_v1.8.5.txt: Time  (mean ± σ):   23.165 ms ±  4.812 ms  ┊ GC (mean ± σ):  11.62% ± 14.38%
benchmark_iid_mv_wishart_known_mean_22-03-2023-19-20_v1.8.5.txt: Time  (mean ± σ):   30.276 ms ±  5.276 ms  ┊ GC (mean ± σ):  10.82% ± 12.71%
benchmark_lar_22-03-2023-19-14_v1.8.5.txt: Time  (mean ± σ):   234.965 ms ±  16.567 ms  ┊ GC (mean ± σ):  15.16% ±  3.30%
benchmark_lar_22-03-2023-19-19_v1.8.5.txt: Time  (mean ± σ):   238.453 ms ±  13.296 ms  ┊ GC (mean ± σ):  14.84% ±  2.98%
benchmark_linreg_22-03-2023-19-16_v1.8.5.txt: Time  (mean ± σ):   13.958 ms ±  3.618 ms  ┊ GC (mean ± σ):  8.58% ± 14.03%
benchmark_linreg_22-03-2023-19-21_v1.8.5.txt: Time  (mean ± σ):   20.549 ms ±  3.664 ms  ┊ GC (mean ± σ):  6.90% ± 11.73%
benchmark_linreg_broadcasted_22-03-2023-19-16_v1.8.5.txt: Time  (mean ± σ):   14.122 ms ±  3.813 ms  ┊ GC (mean ± σ):  8.72% ± 14.17%
benchmark_linreg_broadcasted_22-03-2023-19-21_v1.8.5.txt: Time  (mean ± σ):   20.054 ms ±  3.583 ms  ┊ GC (mean ± σ):  6.99% ± 11.83%
benchmark_mlgssm_22-03-2023-19-15_v1.8.5.txt: Time  (mean ± σ):   19.812 ms ±  4.303 ms  ┊ GC (mean ± σ):  8.82% ± 13.48%
benchmark_mlgssm_22-03-2023-19-20_v1.8.5.txt: Time  (mean ± σ):   20.083 ms ±  4.356 ms  ┊ GC (mean ± σ):  9.25% ± 13.81%
benchmark_probit_22-03-2023-19-15_v1.8.5.txt: Time  (mean ± σ):   9.169 ms ±  2.067 ms  ┊ GC (mean ± σ):  5.79% ± 11.77%
benchmark_probit_22-03-2023-19-20_v1.8.5.txt: Time  (mean ± σ):   9.676 ms ±  2.084 ms  ┊ GC (mean ± σ):  5.71% ± 11.62%
benchmark_ulgssm_22-03-2023-19-14_v1.8.5.txt: Time  (mean ± σ):   9.080 ms ±  3.266 ms  ┊ GC (mean ± σ):  9.75% ± 14.96%
benchmark_ulgssm_22-03-2023-19-19_v1.8.5.txt: Time  (mean ± σ):   9.809 ms ±  2.915 ms  ┊ GC (mean ± σ):  8.74% ± 14.35%
```

</details>

<details>
<summary><b>Memory profile</b></summary>

```
benchmark_ar_22-03-2023-19-14_v1.8.5.txt: Memory estimate: 104.76 MiB, allocs estimate: 1741637.Julia Version 1.8.5
benchmark_ar_22-03-2023-19-19_v1.8.5.txt: Memory estimate: 121.36 MiB, allocs estimate: 2216360.Julia Version 1.8.5
benchmark_cvi_22-03-2023-19-16_v1.8.5.txt: Memory estimate: 4.00 GiB, allocs estimate: 129789350.Julia Version 1.8.5
benchmark_cvi_22-03-2023-19-21_v1.8.5.txt: Memory estimate: 4.01 GiB, allocs estimate: 130044244.Julia Version 1.8.5
benchmark_gmm_multivariate_22-03-2023-19-14_v1.8.5.txt: Memory estimate: 231.92 MiB, allocs estimate: 3273546.Julia Version 1.8.5
benchmark_gmm_multivariate_22-03-2023-19-19_v1.8.5.txt: Memory estimate: 239.39 MiB, allocs estimate: 3403106.Julia Version 1.8.5
benchmark_gmm_univariate_22-03-2023-19-14_v1.8.5.txt: Memory estimate: 13.92 MiB, allocs estimate: 286684.Julia Version 1.8.5
benchmark_gmm_univariate_22-03-2023-19-19_v1.8.5.txt: Memory estimate: 14.65 MiB, allocs estimate: 297058.Julia Version 1.8.5
benchmark_hgf_22-03-2023-19-15_v1.8.5.txt: Memory estimate: 226.40 MiB, allocs estimate: 5484048.Julia Version 1.8.5
benchmark_hgf_22-03-2023-19-20_v1.8.5.txt: Memory estimate: 268.21 MiB, allocs estimate: 6464078.Julia Version 1.8.5
benchmark_iid_mv_covariance_22-03-2023-19-15_v1.8.5.txt: Memory estimate: 64.36 MiB, allocs estimate: 1108077.Julia Version 1.8.5
benchmark_iid_mv_covariance_22-03-2023-19-20_v1.8.5.txt: Memory estimate: 75.98 MiB, allocs estimate: 1432148.Julia Version 1.8.5
benchmark_iid_mv_precision_22-03-2023-19-15_v1.8.5.txt: Memory estimate: 59.14 MiB, allocs estimate: 1033058.Julia Version 1.8.5
benchmark_iid_mv_precision_22-03-2023-19-20_v1.8.5.txt: Memory estimate: 70.99 MiB, allocs estimate: 1357129.Julia Version 1.8.5
benchmark_iid_mv_wishart_known_mean_22-03-2023-19-15_v1.8.5.txt: Memory estimate: 34.89 MiB, allocs estimate: 615055.Julia Version 1.8.5
benchmark_iid_mv_wishart_known_mean_22-03-2023-19-20_v1.8.5.txt: Memory estimate: 41.10 MiB, allocs estimate: 801087.Julia Version 1.8.5
benchmark_lar_22-03-2023-19-14_v1.8.5.txt: Memory estimate: 264.62 MiB, allocs estimate: 2170307.Julia Version 1.8.5
benchmark_lar_22-03-2023-19-19_v1.8.5.txt: Memory estimate: 275.21 MiB, allocs estimate: 2406969.Julia Version 1.8.5
benchmark_linreg_22-03-2023-19-16_v1.8.5.txt: Memory estimate: 14.62 MiB, allocs estimate: 375571.Julia Version 1.8.5
benchmark_linreg_22-03-2023-19-21_v1.8.5.txt: Memory estimate: 19.19 MiB, allocs estimate: 507296.Julia Version 1.8.5
benchmark_linreg_broadcasted_22-03-2023-19-16_v1.8.5.txt: Memory estimate: 14.56 MiB, allocs estimate: 374379.Julia Version 1.8.5
benchmark_linreg_broadcasted_22-03-2023-19-21_v1.8.5.txt: Memory estimate: 19.13 MiB, allocs estimate: 506104.Julia Version 1.8.5
benchmark_mlgssm_22-03-2023-19-15_v1.8.5.txt: Memory estimate: 20.65 MiB, allocs estimate: 378579.Julia Version 1.8.5
benchmark_mlgssm_22-03-2023-19-20_v1.8.5.txt: Memory estimate: 21.58 MiB, allocs estimate: 400093.Julia Version 1.8.5
benchmark_probit_22-03-2023-19-15_v1.8.5.txt: Memory estimate: 8.39 MiB, allocs estimate: 109137.Julia Version 1.8.5
benchmark_probit_22-03-2023-19-20_v1.8.5.txt: Memory estimate: 8.82 MiB, allocs estimate: 119065.Julia Version 1.8.5
benchmark_ulgssm_22-03-2023-19-14_v1.8.5.txt: Memory estimate: 10.20 MiB, allocs estimate: 223408.Julia Version 1.8.5
benchmark_ulgssm_22-03-2023-19-19_v1.8.5.txt: Memory estimate: 11.10 MiB, allocs estimate: 241919.Julia Version 1.8.5
```

</details>

This PR also removes the `@symmetrical` macro (was unused really) and removes options from the `rule` macro (was unused too).

EDIT: This PR also adds documentation/docstrings for the `@rule`, `@call_rule`, `@marginalrule` and `@call_marginalrule`.