### PR TITLE
do not override Base.nameof

### DIFF
--- a/src/marginal.jl
+++ b/src/marginal.jl
@@ -5,7 +5,7 @@ using Distributions
 using Rocket
 
 import Rocket: getrecent
-import Base: ==, ndims, precision, length, size, nameof, iterate
+import Base: ==, ndims, precision, length, size, iterate
 
 struct Marginal{D, A}
     data       :: D

--- a/src/message.jl
+++ b/src/message.jl
@@ -6,7 +6,7 @@ using Distributions
 using Rocket
 
 import Rocket: getrecent
-import Base: ==, *, +, ndims, precision, length, size, show, nameof
+import Base: ==, *, +, ndims, precision, length, size, show
 
 """
     AbstractMessage

--- a/src/node.jl
+++ b/src/node.jl
@@ -344,8 +344,8 @@ is_clamped(many::ManyOf) = is_clamped(many.collection)
 is_initial(many::ManyOf) = is_initial(many.collection)
 typeofdata(many::ManyOf) = typeof(ManyOf(many.collection))
 
-Base.nameof(::Type{T}) where {N, R, V <: NTuple{N, <:R}, T <: ManyOf{V}}           = string("ManyOf{", N, ", ", nameof(dropproxytype(R)), "}")
-Base.nameof(::Type{T}) where {N, V <: Tuple{Vararg{R, N} where R}, T <: ManyOf{V}} = string("ManyOf{", N, ", Union{", join(map(r -> nameof(dropproxytype(r)), fieldtypes(V)), ","), "}}")
+rule_method_error_type_nameof(::Type{T}) where {N, R, V <: NTuple{N, <:R}, T <: ManyOf{V}}           = string("ManyOf{", N, ", ", rule_method_error_type_nameof(dropproxytype(R)), "}")
+rule_method_error_type_nameof(::Type{T}) where {N, V <: Tuple{Vararg{R, N} where R}, T <: ManyOf{V}} = string("ManyOf{", N, ", Union{", join(map(r -> rule_method_error_type_nameof(dropproxytype(r)), fieldtypes(V)), ","), "}}")
 
 Base.iterate(many::ManyOf)        = iterate(many.collection)
 Base.iterate(many::ManyOf, state) = iterate(many.collection, state)

--- a/src/nodes/delta/delta.jl
+++ b/src/nodes/delta/delta.jl
@@ -77,7 +77,7 @@ function marginalrule(::F, on, mnames, messages, qnames, marginals, meta::DeltaM
 end
 
 # For missing rules error msg
-rule_method_error_extract_fform(f::Type{<:DeltaFn}) = "DeltaFn{f}"
+rule_method_error_extract_fform(::Type{<:DeltaFn}) = "DeltaFn"
 
 # `DeltaFn` requires an access to the node function, hence, node reference is required
 call_rule_is_node_required(::Type{<:DeltaFn}) = CallRuleNodeRequired()

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -869,8 +869,10 @@ rule_method_error_extract_vconstraint(something) = typeof(something)
 rule_method_error_extract_names(::Val{T}) where {T} = map(sT -> __extract_val_type(split_underscored_symbol(Val{sT}())), T)
 rule_method_error_extract_names(::Nothing)          = ()
 
-rule_method_error_extract_types(t::Tuple)   = map(e -> nameof(typeofdata(e)), t)
+rule_method_error_extract_types(t::Tuple)   = map(e -> rule_method_error_type_nameof(typeofdata(e)), t)
 rule_method_error_extract_types(t::Nothing) = ()
+
+rule_method_error_type_nameof(something) = nameof(something)
 
 rule_method_error_extract_meta(something) = string("meta::", typeof(something))
 rule_method_error_extract_meta(::Nothing) = ""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,7 @@ end
 
 # Makes it hard to use your computer if Julia occupies all cpus, so we max at 4
 # GitHub actions has 2 cores in most of the cases 
-addprocs(max(Sys.CPU_THREADS, 4))
+addprocs(min(Sys.CPU_THREADS, 4))
 
 @everywhere using Test, Documenter, ReactiveMP, Distributions
 @everywhere using TestSetExtensions
@@ -182,7 +182,7 @@ using Aqua
 
 if isempty(testrunner.enabled_tests)
     println("Running all tests...")
-    # `piracy` is broken on CI, see https://github.com/JuliaTesting/Aqua.jl/issues/95, revise at some point
+    # We `pirate` `mean` methods for distributions in `Distributions.jl`
     Aqua.test_all(ReactiveMP; ambiguities = false, piracy = false)
     # doctest(ReactiveMP)
 else


### PR DESCRIPTION
This PR removes the code that overrides the default behaviour of the `Base.nameof` as suggested in https://github.com/JuliaTesting/Aqua.jl/issues/95#issuecomment-1486526905 .

This makes it possible to test if `ReactiveMP` pirate some methods from other packages, which it actually does for methods like

```julia
mean(::typeof(log), distribution::Gamma) = ...
```

We need this methods and its technically the piracy, but should be safe. So I still keep `piracy = false` check from the `Aqua`.