### PR TITLE
generalize bernoulli update rule and improve robustness

### DIFF
--- a/src/rules/bernoulli/out.jl
+++ b/src/rules/bernoulli/out.jl
@@ -1,9 +1,13 @@
 export rule
 
-@rule Bernoulli(:out, Marginalisation) (m_p::Any,) = begin
+@rule Bernoulli(:out, Marginalisation) (m_p::Beta,) = begin
     @logscale 0
     return Bernoulli(mean(m_p))
 end
+
+@rule Bernoulli(:out, Marginalisation) (m_p::PointMass,) = Bernoulli(mean(m_p))
+
+@rule Bernoulli(:out, Marginalisation) (q_p::PointMass,) = Bernoulli(mean(q_p))
 
 @rule Bernoulli(:out, Marginalisation) (q_p::Any,) = begin
     rho_1 = mean(log, q_p)          # E[ln(x)]
@@ -13,5 +17,3 @@ end
     p = clamp(tmp / (tmp + exp(rho_2 - m)), tiny, one(m))
     return Bernoulli(p)
 end
-
-@rule Bernoulli(:out, Marginalisation) (q_p::PointMass,) = Bernoulli(mean(q_p))

--- a/src/rules/bernoulli/out.jl
+++ b/src/rules/bernoulli/out.jl
@@ -9,6 +9,7 @@ end
 
 @rule Bernoulli(:out, Marginalisation) (q_p::PointMass,) = Bernoulli(mean(q_p))
 
+# q_p::Any s.t. domain = [0, 1]
 @rule Bernoulli(:out, Marginalisation) (q_p::Any,) = begin
     rho_1 = mean(log, q_p)          # E[ln(x)]
     rho_2 = mean(mirrorlog, q_p)    # E[log(1-x)]

--- a/src/rules/bernoulli/out.jl
+++ b/src/rules/bernoulli/out.jl
@@ -1,16 +1,17 @@
 export rule
 
-@rule Bernoulli(:out, Marginalisation) (m_p::Beta,) = begin
+@rule Bernoulli(:out, Marginalisation) (m_p::Any,) = begin
     @logscale 0
     return Bernoulli(mean(m_p))
 end
 
-@rule Bernoulli(:out, Marginalisation) (m_p::PointMass,) = Bernoulli(mean(m_p))
+@rule Bernoulli(:out, Marginalisation) (q_p::Any,) = begin
+    rho_1 = mean(log, q_p)          # E[ln(x)]
+    rho_2 = mean(mirrorlog, q_p)    # E[log(1-x)]
+    m = max(rho_1, rho_2)
+    tmp = exp(rho_1 - m)
+    p = clamp(tmp / (tmp + exp(rho_2 - m)), tiny, one(m))
+    return Bernoulli(p)
+end
 
 @rule Bernoulli(:out, Marginalisation) (q_p::PointMass,) = Bernoulli(mean(q_p))
-
-@rule Bernoulli(:out, Marginalisation) (q_p::Beta,) = begin
-    rho_1 = clamp(exp(mean(log, q_p)), tiny, huge)
-    rho_2 = clamp(exp(mean(mirrorlog, q_p)), tiny, huge)
-    return Bernoulli(rho_1 / (rho_1 + rho_2))
-end


### PR DESCRIPTION
This PR does 2 things:
1. It generalizes the dispatching of the Bernoulli rules 
2. I believe it also increases robustness of the actual computations

With respect to 1, I am not sure whether this generalization is formally allowed, because there is no check for the domain of the variable over which we integrate. However, we currently also do not constrain the `PointMass` distribution.