### PR TITLE
add cholinv-family methods for UniformScaling

### DIFF
--- a/src/helpers/algebra/cholesky.jl
+++ b/src/helpers/algebra/cholesky.jl
@@ -5,9 +5,10 @@ using PositiveFactorizations
 
 import LinearAlgebra: BlasInt
 
-cholinv(x)           = inv(fastcholesky(x))
+cholinv(x) = inv(fastcholesky(x))
+cholinv(x::UniformScaling) = inv(x.λ) * I
 cholinv(x::Diagonal) = Diagonal(inv.(diag(x)))
-cholinv(x::Real)     = inv(x)
+cholinv(x::Real) = inv(x)
 
 function cholinv(x::AbstractMatrix{T}) where {T <: LinearAlgebra.BlasFloat}
     y = fastcholesky(x)
@@ -15,13 +16,15 @@ function cholinv(x::AbstractMatrix{T}) where {T <: LinearAlgebra.BlasFloat}
     return y.factors
 end
 
-cholsqrt(x)           = Matrix(fastcholesky(x).L)
+cholsqrt(x) = Matrix(fastcholesky(x).L)
+cholsqrt(x::UniformScaling) = sqrt(x.λ) * I
 cholsqrt(x::Diagonal) = Diagonal(sqrt.(diag(x)))
-cholsqrt(x::Real)     = sqrt(x)
+cholsqrt(x::Real) = sqrt(x)
 
-chollogdet(x)           = logdet(fastcholesky(x))
+chollogdet(x) = logdet(fastcholesky(x))
+chollogdet(x::UniformScaling) = error("logdet is not defined for `UniformScaling`")
 chollogdet(x::Diagonal) = logdet(x)
-chollogdet(x::Real)     = logdet(x)
+chollogdet(x::Real) = logdet(x)
 
 function cholinv_logdet(x)
     # calculate cholesky decomposition
@@ -30,6 +33,7 @@ function cholinv_logdet(x)
     # return inverse and log-determinant
     return inv(y), logdet(y)
 end
+
 function cholinv_logdet(x::AbstractMatrix{T}) where {T <: LinearAlgebra.BlasFloat}
     # calculate cholesky decomposition
     y = fastcholesky(x)
@@ -43,8 +47,12 @@ function cholinv_logdet(x::AbstractMatrix{T}) where {T <: LinearAlgebra.BlasFloa
     # return inverse and log-determinant
     return y.factors, ly
 end
+
 cholinv_logdet(x::Diagonal) = Diagonal(inv.(diag(x))), mapreduce(z -> log(z), +, diag(x))
 cholinv_logdet(x::Real)     = inv(x), log(abs(x))
+
+fastcholesky(x::UniformScaling) = error("`fastcholesky` is not defined for `UniformScaling`. The shape is not determined.")
+fastcholesky!(x::UniformScaling) = error("`fastcholesky!` is not defined for `UniformScaling`. The shape is not determined.")
 
 function fastcholesky(mat::AbstractMatrix)
     A = copy(mat)

--- a/src/helpers/algebra/cholesky.jl
+++ b/src/helpers/algebra/cholesky.jl
@@ -22,7 +22,7 @@ cholsqrt(x::Diagonal) = Diagonal(sqrt.(diag(x)))
 cholsqrt(x::Real) = sqrt(x)
 
 chollogdet(x) = logdet(fastcholesky(x))
-chollogdet(x::UniformScaling) = error("logdet is not defined for `UniformScaling`")
+chollogdet(x::UniformScaling) = logdet(x)
 chollogdet(x::Diagonal) = logdet(x)
 chollogdet(x::Real) = logdet(x)
 

--- a/test/algebra/test_cholesky.jl
+++ b/test/algebra/test_cholesky.jl
@@ -10,6 +10,15 @@ using LinearAlgebra
     @testset "cholesky related" begin
         rng = MersenneTwister(1234)
 
+        for scalar in (1, 1.0, 2.0, 2, 0.1, 10.0)
+            A = scalar * I
+
+            @test A isa UniformScaling
+            @test ReactiveMP.cholinv(A) ≈ inv(scalar) * I
+            @test ReactiveMP.cholsqrt(A) ≈ sqrt(scalar) * I
+            @test_throws ErrorException ReactiveMP.chollogdet(A)
+        end
+
         for size in (2, 3, 4, 5, 10, 100, 1000)
             L = rand(rng, size, size)
             A = L * L'

--- a/test/algebra/test_cholesky.jl
+++ b/test/algebra/test_cholesky.jl
@@ -16,7 +16,13 @@ using LinearAlgebra
             @test A isa UniformScaling
             @test ReactiveMP.cholinv(A) ≈ inv(scalar) * I
             @test ReactiveMP.cholsqrt(A) ≈ sqrt(scalar) * I
-            @test_throws ErrorException ReactiveMP.chollogdet(A)
+
+            # By default `logdet` is defined only for `λ = 0 or 1`
+            if isone(scalar) || iszero(scalar)
+                @test ReactiveMP.chollogdet(A) ≈ logdet(A)
+            else
+                @test_throws ArgumentError ReactiveMP.chollogdet(A)
+            end
         end
 
         for size in (2, 3, 4, 5, 10, 100, 1000)


### PR DESCRIPTION
This PR adds `cholinv` and `cholsqrt` methods for `UniformScaling`. I noticed during some experiments, where some rules failed to take `cholinv`.