### PR TITLE
Add debug addons

### DIFF
--- a/src/ReactiveMP.jl
+++ b/src/ReactiveMP.jl
@@ -35,6 +35,7 @@ include("marginal.jl")
 include("distributions.jl")
 include("addons.jl")
 
+include("addons/debug.jl")
 include("addons/logscale.jl")
 include("addons/memory.jl")
 

--- a/src/addons/debug.jl
+++ b/src/addons/debug.jl
@@ -1,0 +1,84 @@
+export AddonDebug
+
+
+"""
+    AddonDebug(f :: Function)
+
+This addon calls the function `f` over the output of the message mapping and products. The result is expected to be boolean and when returning true, it will throw an error with the debug information. Common applications of this addon are to check for NaNs and Infs in the messages and marginals. 
+
+## Example
+```julia
+
+    checkfornans(x) = isnan(x)
+    checkfornans(x::AbstractArray) = any(checkfornans.(x))
+    checkfornans(x::Tuple) = any(checkfornans.(x))
+
+    inference(
+        ...
+        addons = (AddonDebug(dist -> checkfornans(params(dist))),)
+    )
+```
+"""
+struct AddonDebug <: AbstractAddon
+    f :: Function
+end
+
+AddonDebug() = AddonDebug(nothing)
+
+getdebugaddon(addons::NTuple{N, AbstractAddon}) where {N} = first(filter(x -> typeof(x) <: AddonDebug, addons))
+
+(addon::AddonDebug)(x) = addon.f(x)
+
+function message_mapping_addon(addon::AddonDebug, mapping, messages, marginals, result)
+    if addon(result)
+        
+        #  create error message
+        msg = "Debug addon triggered:\n"
+        msg *= "Mapping:\n"
+        msg *= "At the node: " * string(message_mapping_fform(mapping)) *"\n"
+        msg *= "Towards interface: " * string(mapping.vtag) * "\n"
+        msg *= "With local constraint: " * string(mapping.vconstraint) * "\n"
+        if !isnothing(mapping.meta)
+            msg *= "With meta: ", string(mapping.meta) * "\n"
+        end
+        if !isnothing(mapping.addons)
+            msg *= "With addons: " * string(mapping.addons) * "\n"
+        end
+        if !isnothing(messages)
+            msg *= "Incoming messages:\n"
+            for message in messages
+                msg *= string(message) * "\n"
+            end
+        end
+        if !isnothing(marginals)
+            msg *= "Incoming marginals:\n"
+            for marginal in marginals
+                msg *= string(marginal) * "\n"
+            end
+        end
+        msg *= "Result:\n"
+        msg *= string(result)
+
+        #  throw error
+        return error(msg)
+        
+    end
+    return addon
+end
+
+function multiply_addons(left_addon::AddonDebug, right_addon::AddonDebug, new_dist, left_dist, right_dist)
+    if left_addon(new_dist)
+
+        # create error message
+        msg = "Debug addon triggered:\n"
+        msg *= "Incoming distributions: \n"
+        msg *= string(left_dist) * "\n"
+        msg *= string(right_dist) * "\n"
+        msg *= "Resulting distribution: \n"
+        msg *= string(new_dist)
+
+        # throw error
+        return error(msg)
+    end
+    return left_addon
+end

--- a/src/addons/debug.jl
+++ b/src/addons/debug.jl
@@ -1,6 +1,5 @@
 export AddonDebug
 
-
 """
     AddonDebug(f :: Function)
 
@@ -20,7 +19,7 @@ This addon calls the function `f` over the output of the message mapping and pro
 ```
 """
 struct AddonDebug <: AbstractAddon
-    f :: Function
+    f::Function
 end
 
 AddonDebug() = AddonDebug(nothing)
@@ -31,11 +30,11 @@ getdebugaddon(addons::NTuple{N, AbstractAddon}) where {N} = first(filter(x -> ty
 
 function message_mapping_addon(addon::AddonDebug, mapping, messages, marginals, result)
     if addon(result)
-        
+
         #  create error message
         msg = "Debug addon triggered:\n"
         msg *= "Mapping:\n"
-        msg *= "At the node: " * string(message_mapping_fform(mapping)) *"\n"
+        msg *= "At the node: " * string(message_mapping_fform(mapping)) * "\n"
         msg *= "Towards interface: " * string(mapping.vtag) * "\n"
         msg *= "With local constraint: " * string(mapping.vconstraint) * "\n"
         if !isnothing(mapping.meta)
@@ -61,7 +60,6 @@ function message_mapping_addon(addon::AddonDebug, mapping, messages, marginals, 
 
         #  throw error
         return error(msg)
-        
     end
     return addon
 end

--- a/src/variables/variable.jl
+++ b/src/variables/variable.jl
@@ -127,7 +127,7 @@ end
 
 name(variable::AbstractVariable)        = variable.name
 isanonymous(variable::AbstractVariable) = false
-isanonymous(variables::AbstractVector)  = all(isanonymous, variables)
+isanonymous(variables::AbstractArray)  = all(isanonymous, variables)
 
 ##
 

--- a/src/variables/variable.jl
+++ b/src/variables/variable.jl
@@ -127,7 +127,7 @@ end
 
 name(variable::AbstractVariable)        = variable.name
 isanonymous(variable::AbstractVariable) = false
-isanonymous(variables::AbstractArray)  = all(isanonymous, variables)
+isanonymous(variables::AbstractArray)   = all(isanonymous, variables)
 
 ##
 

--- a/test/addons/test_debug.jl
+++ b/test/addons/test_debug.jl
@@ -1,0 +1,26 @@
+module ReactiveMPAddonsDebugTest
+
+using Test
+using ReactiveMP
+using Distributions
+
+@testset "Debug addon" begin
+    import ReactiveMP: AddonDebug
+
+    @testset "Creation" begin
+        addon = AddonDebug(x -> x == π)
+
+        @test addon(π)
+        @test addon(3.14) == false
+    end
+
+    @testset "Simple application and printing" begin
+        import ReactiveMP: multiply_addons
+
+        addon = AddonDebug(x -> any(params(x) .== 3.14))
+        @test_throws ErrorException multiply_addons(addon, addon, NormalMeanVariance(0.0, 3.14), Missing(), Missing())
+        @test multiply_addons(addon, addon, NormalMeanVariance(0.0, 3.00), Missing(), Missing()) == addon
+    end
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -212,6 +212,9 @@ end
     addtests(testrunner, "test_rule.jl")
     addtests(testrunner, "test_addons.jl")
 
+    addtests(testrunner, "addons/test_debug.jl")
+    addtests(testrunner, "addons/test_memory.jl")
+
     addtests(testrunner, "approximations/test_shared.jl")
     addtests(testrunner, "approximations/test_unscented.jl")
     addtests(testrunner, "approximations/test_linearization.jl")


### PR DESCRIPTION
This PR adds a new addon, which evaluates a function over the output of a rule or product. It can be used to effectively track down the first occurences of NaN's or Inf's.

For example, the code below will throw an error, when the parameters of the output distribution become NaN for some reason, and will describe the location where this occurs.
```julia

    checkfornans(x) = isnan(x)
    checkfornans(x::AbstractArray) = any(checkfornans.(x))
    checkfornans(x::Tuple) = any(checkfornans.(x))

    inference(
        ...
        addons = (AddonDebug(dist -> checkfornans(params(dist))),)
    )
```

This PR might also be relevant for #162. @Sepideh-Adamiat @wmkouw .

This PR closes https://github.com/biaslab/RxInfer.jl/issues/116