### PR TITLE
Make the sample list approximation more generic

### DIFF
--- a/src/constraints/prod/prod_generic.jl
+++ b/src/constraints/prod/prod_generic.jl
@@ -149,6 +149,14 @@ function Base.push!(product::GenericLogPdfVectorisedProduct{F}, item::F) where {
     return GenericLogPdfVectorisedProduct(push!(vector, item), vlength + 1)
 end
 
+getdomain(product::GenericLogPdfVectorisedProduct) = getdomain(first(product.vector))
+getlogpdf(product::GenericLogPdfVectorisedProduct) = getlogpdf(first(product.vector))
+
+Base.eltype(product::GenericLogPdfVectorisedProduct) = eltype(first(product.vector))
+
+paramfloattype(product::GenericLogPdfVectorisedProduct) = paramfloattype(first(product.vector))
+samplefloattype(product::GenericLogPdfVectorisedProduct) = samplefloattype(first(product.vector))
+
 variate_form(::Type{<:GenericLogPdfVectorisedProduct{F}}) where {F} = variate_form(F)
 variate_form(::GenericLogPdfVectorisedProduct{F}) where {F}         = variate_form(F)
 

--- a/src/distributions/function.jl
+++ b/src/distributions/function.jl
@@ -47,7 +47,8 @@ Base.precision(dist::AbstractContinuousGenericLogPdf) = __error_not_defined(dist
 
 Base.eltype(dist::AbstractContinuousGenericLogPdf) = eltype(getdomain(dist))
 
-paramfloattype(dist::AbstractContinuousGenericLogPdf) = eltype(dist)
+paramfloattype(dist::AbstractContinuousGenericLogPdf) = deep_eltype(eltype(dist))
+samplefloattype(dist::AbstractContinuousGenericLogPdf) = paramfloattype(dist)
 
 (dist::AbstractContinuousGenericLogPdf)(x::Real)                   = logpdf(dist, x)
 (dist::AbstractContinuousGenericLogPdf)(x::AbstractVector{<:Real}) = logpdf(dist, x)
@@ -225,12 +226,12 @@ function culogpdf__isapprox(domain::DomainSets.VcatDomain, left::AbstractContinu
     a = clamp.(DomainSets.infimum(domain), -1e5, 1e5)
     b = clamp.(DomainSets.supremum(domain), -1e5, 1e5)
     (I, E) = HCubature.hcubature((x) -> abs(left(x) - right(x)), a, b)
-    return isapprox(zero(deep_eltype(domain)), I; kwargs...) && isapprox(zero(deep_eltype(domain)), E; kwargs...)
+    return isapprox(zero(promote_paramfloattype(left, right)), I; kwargs...) && isapprox(zero(promote_paramfloattype(left, right)), E; kwargs...)
 end
 
 function culogpdf__isapprox(domain::DomainSets.FixedIntervalProduct, left::AbstractContinuousGenericLogPdf, right::AbstractContinuousGenericLogPdf; kwargs...)
     a = clamp.(DomainSets.infimum(domain), -1e5, 1e5)
     b = clamp.(DomainSets.supremum(domain), -1e5, 1e5)
     (I, E) = HCubature.hcubature((x) -> abs(left(x) - right(x)), a, b)
-    return isapprox(zero(deep_eltype(domain)), I; kwargs...) && isapprox(zero(deep_eltype(domain)), E; kwargs...)
+    return isapprox(zero(promote_paramfloattype(left, right)), I; kwargs...) && isapprox(zero(promote_paramfloattype(left, right)), E; kwargs...)
 end

--- a/src/distributions/sample_list.jl
+++ b/src/distributions/sample_list.jl
@@ -252,12 +252,12 @@ end
 # `x` is proposal distribution
 # `y` is integrand distribution
 function approximate_prod_with_sample_list(rng::AbstractRNG, ::BootstrapImportanceSampling, x::Any, y::Any, nsamples::Int = DEFAULT_SAMPLE_LIST_N_SAMPLES)
-    @assert nsamples >= 1 "Number of samples should be non-positive"
+    @assert nsamples >= 1 "Number of samples should be greater than 1"
 
     xlogpdf, xsample = logpdf_sample_friendly(x)
     ylogpdf, ysample = logpdf_sample_friendly(y)
 
-    T            = promote_type(eltype(x), eltype(y))
+    T            = promote_samplefloattype(x, y)
     U            = variate_form(x)
     xsize        = size(x)
     preallocated = preallocate_samples(T, xsize, nsamples)

--- a/test/distributions/test_function.jl
+++ b/test/distributions/test_function.jl
@@ -305,10 +305,8 @@ import DomainSets
                 d2 = ContinuousMultivariateLogPdf(DomainSets.HalfLine()^dim, (x) -> -x'x)
 
                 # This also throws a warning in stdout
-                @test_warn r".*incompatible combination.*" begin
-                    @test_throws AssertionError logpdf(d1, ones(dim + 1))
-                    @test_throws AssertionError logpdf(d2, ones(dim + 1))
-                end
+                @test_logs (:warn, r".*incompatible combination.*") @test_throws AssertionError logpdf(d1, ones(dim + 1))
+                @test_logs (:warn, r".*incompatible combination.*") @test_throws AssertionError logpdf(d2, ones(dim + 1))
             end
         end
 

--- a/test/distributions/test_function.jl
+++ b/test/distributions/test_function.jl
@@ -219,7 +219,6 @@ import DomainSets
                 @test pdf(pr1, point) ≈ pdf(d3, point)
                 @test logpdf(pr1, point) ≈ logpdf(d3, point)
             end
-
         end
 
         @testset "convert" begin
@@ -378,7 +377,7 @@ import DomainSets
             @test support(pr1) === support(d1)
             @test support(pr1) === support(d2)
 
-            for point in [ rand(Float64, 2) for _ in 1:10 ]
+            for point in [rand(Float64, 2) for _ in 1:10]
                 @test pdf(pr1, point) ≈ pdf(d3, point)
                 @test logpdf(pr1, point) ≈ logpdf(d3, point)
             end

--- a/test/distributions/test_function.jl
+++ b/test/distributions/test_function.jl
@@ -4,8 +4,10 @@ using Test
 using ReactiveMP
 using Distributions
 using Random
+using StableRNGs
 
-import ReactiveMP: getdomain, AbstractContinuousGenericLogPdf
+import ReactiveMP: getdomain, AbstractContinuousGenericLogPdf, GenericLogPdfVectorisedProduct
+import ReactiveMP: paramfloattype, samplefloattype
 
 import DomainIntegrals
 import DomainSets
@@ -21,6 +23,10 @@ import DomainSets
             @test d1 ≈ d2
             @test eltype(d1) === Float64
             @test eltype(d2) === Float64
+            @test paramfloattype(d1) === Float64
+            @test samplefloattype(d1) === Float64
+            @test paramfloattype(d2) === Float64
+            @test samplefloattype(d2) === Float64
 
             @test_throws AssertionError ContinuousUnivariateLogPdf(DomainSets.FullSpace()^2, f)
         end
@@ -199,7 +205,7 @@ import DomainSets
 
             pr1 = prod(ProdAnalytical(), d1, d2)
 
-            @test pr1 isa ContinuousGenericLogPdfVectorisedProduct
+            @test pr1 isa GenericLogPdfVectorisedProduct
             @test getdomain(pr1) === getdomain(d1)
             @test getdomain(pr1) === getdomain(d2)
             @test variate_form(typeof(pr1)) === variate_form(typeof(d1))
@@ -208,7 +214,12 @@ import DomainSets
             @test value_support(typeof(pr1)) === value_support(typeof(d2))
             @test support(pr1) === support(d1)
             @test support(pr1) === support(d2)
-            @test isapprox(pr1, d3, atol = 1e-12)
+
+            for point in rand(StableRNG(42), Float64, 10)
+                @test pdf(pr1, point) ≈ pdf(d3, point)
+                @test logpdf(pr1, point) ≈ logpdf(d3, point)
+            end
+
         end
 
         @testset "convert" begin
@@ -233,6 +244,10 @@ import DomainSets
 
             @test typeof(d1) === typeof(d2)
             @test d1 ≈ d2
+            @test paramfloattype(d1) === Float64
+            @test samplefloattype(d1) === Float64
+            @test paramfloattype(d2) === Float64
+            @test samplefloattype(d2) === Float64
 
             @test_throws AssertionError ContinuousMultivariateLogPdf(DomainSets.FullSpace(), f)
             @test_throws MethodError ContinuousMultivariateLogPdf(f)
@@ -291,8 +306,10 @@ import DomainSets
                 d2 = ContinuousMultivariateLogPdf(DomainSets.HalfLine()^dim, (x) -> -x'x)
 
                 # This also throws a warning in stdout
-                @test_throws AssertionError logpdf(d1, ones(dim + 1))
-                @test_throws AssertionError logpdf(d2, ones(dim + 1))
+                @test_warn r".*incompatible combination.*" begin
+                    @test_throws AssertionError logpdf(d1, ones(dim + 1))
+                    @test_throws AssertionError logpdf(d2, ones(dim + 1))
+                end
             end
         end
 
@@ -351,7 +368,7 @@ import DomainSets
 
             pr1 = prod(ProdAnalytical(), d1, d2)
 
-            @test pr1 isa ContinuousGenericLogPdfVectorisedProduct
+            @test pr1 isa GenericLogPdfVectorisedProduct
             @test getdomain(pr1) === getdomain(d1)
             @test getdomain(pr1) === getdomain(d2)
             @test variate_form(typeof(pr1)) === variate_form(typeof(d1))
@@ -360,7 +377,11 @@ import DomainSets
             @test value_support(typeof(pr1)) === value_support(typeof(d2))
             @test support(pr1) === support(d1)
             @test support(pr1) === support(d2)
-            @test isapprox(pr1, d3, atol = 1e-12)
+
+            for point in [ rand(Float64, 2) for _ in 1:10 ]
+                @test pdf(pr1, point) ≈ pdf(d3, point)
+                @test logpdf(pr1, point) ≈ logpdf(d3, point)
+            end
         end
 
         @testset "convert" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -244,6 +244,7 @@ end
     addtests(testrunner, "distributions/test_wishart.jl")
     addtests(testrunner, "distributions/test_wishart_inverse.jl")
     addtests(testrunner, "distributions/test_sample_list.jl")
+    addtests(testrunner, "distributions/test_function.jl")
     addtests(testrunner, "distributions/test_mixture_distribution.jl")
 
     addtests(testrunner, "test_message.jl")


### PR DESCRIPTION
This PR fixes #323 and adds non-included tests for the `function.jl` (which were failing btw, oops).