### PR TITLE
Temporary fix for incompatibility @call_rule with addons

### DIFF
--- a/src/rules/transition/out.jl
+++ b/src/rules/transition/out.jl
@@ -30,5 +30,6 @@ end
 end
 
 @rule Transition(:out, Marginalisation) (m_in::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin
+    @logscale 0
     return @call_rule Transition(:out, Marginalisation) (m_in = m_in, m_a = q_a, meta = meta, addons = getaddons())
 end

--- a/test/rules/multiplication/test_A.jl
+++ b/test/rules/multiplication/test_A.jl
@@ -30,7 +30,7 @@ import ReactiveMP: make_inversedist_message
         end
     end
     @testset "messages of type Any" begin
-        rng = StableRNG(42)
+        rng         = StableRNG(42)
         d1          = LogNormal(1.5, 1)
         d2          = NormalMeanVariance(0.0, 1.0)
         num_samples = 3000

--- a/test/rules/multiplication/test_A.jl
+++ b/test/rules/multiplication/test_A.jl
@@ -2,11 +2,12 @@ module RulesMultiplicationATest
 
 using Test
 using ReactiveMP
-using Random, Distributions
+using Random, Distributions, StableRNGs
 import ReactiveMP: make_inversedist_message
 
 @testset "rule:typeof(*):A" begin
     @testset "Univariate Gaussian messages" begin
+        rng = StableRNG(42)
         d1 = NormalMeanVariance(0.0, 1.0)
         d2 = NormalMeanVariance(0.5, 1.5)
         d3 = NormalMeanVariance(2.0, 0.5)
@@ -21,7 +22,7 @@ import ReactiveMP: make_inversedist_message
         @test typeof(OutMessage_2) <: ContinuousUnivariateLogPdf
         @test typeof(OutMessage_3) <: ContinuousUnivariateLogPdf
 
-        samples = rand(Uniform(0.5, 4), 10)
+        samples = rand(rng, Uniform(0.5, 4), 10)
         for i in samples
             @test OutMessage_1(i) ≈ groundtruthOutMessage_1(i)
             @test OutMessage_2(i) ≈ groundtruthOutMessage_2(i)
@@ -29,10 +30,11 @@ import ReactiveMP: make_inversedist_message
         end
     end
     @testset "messages of type Any" begin
+        rng = StableRNG(42)
         d1          = LogNormal(1.5, 1)
         d2          = NormalMeanVariance(0.0, 1.0)
         num_samples = 3000
-        samples_d2  = rand(d2, num_samples)
+        samples_d2  = rand(rng, d2, num_samples)
 
         OutMessage = @call_rule typeof(*)(:A, Marginalisation) (m_out = d1, m_in = d2, meta = TinyCorrection())
 

--- a/test/rules/multiplication/test_out.jl
+++ b/test/rules/multiplication/test_out.jl
@@ -30,7 +30,7 @@ import ReactiveMP: @test_rules, besselmod, make_productdist_message
         end
     end
     @testset "messages of type Any" begin
-        rng = StableRNG(42)
+        rng         = StableRNG(42)
         d1          = NormalMeanVariance(0.0, 1.0)
         d2          = LogNormal(0.0, 1.0)
         num_samples = 3000

--- a/test/rules/multiplication/test_out.jl
+++ b/test/rules/multiplication/test_out.jl
@@ -2,11 +2,12 @@ module RulesMultiplicationOutTest
 
 using Test
 using ReactiveMP
-using Random, Distributions
+using Random, Distributions, StableRNGs
 import ReactiveMP: @test_rules, besselmod, make_productdist_message
 
 @testset "rule:typeof(*):out" begin
     @testset "Univariate Gaussian messages" begin
+        rng = StableRNG(42)
         d1 = NormalMeanVariance(0.0, 1.0)
         d2 = NormalMeanVariance(0.5, 1.5)
         d3 = NormalMeanVariance(2.0, 0.5)
@@ -21,7 +22,7 @@ import ReactiveMP: @test_rules, besselmod, make_productdist_message
         @test typeof(OutMessage_2) <: ContinuousUnivariateLogPdf
         @test typeof(OutMessage_3) <: ContinuousUnivariateLogPdf
 
-        samples = rand(Uniform(0.5, 4), 10)
+        samples = rand(rng, Uniform(0.5, 4), 10)
         for i in samples
             @test OutMessage_1(i) ≈ groundtruthOutMessage_1(i)
             @test OutMessage_2(i) ≈ groundtruthOutMessage_2(i)
@@ -29,10 +30,11 @@ import ReactiveMP: @test_rules, besselmod, make_productdist_message
         end
     end
     @testset "messages of type Any" begin
+        rng = StableRNG(42)
         d1          = NormalMeanVariance(0.0, 1.0)
         d2          = LogNormal(0.0, 1.0)
         num_samples = 3000
-        samples_d1  = rand(d1, num_samples)
+        samples_d1  = rand(rng, d1, num_samples)
 
         OutMessage = @call_rule typeof(*)(:out, Marginalisation) (m_A = d1, m_in = d2, meta = TinyCorrection())
 


### PR DESCRIPTION
This PR adds a temporary fix for the transition node, as sf's don't play nicely with @call_rule