### PR TITLE
Add rules and tests for MvNormalWeightedMeanPrecision node

### DIFF
--- a/src/nodes/mv_normal_weighted_mean_precision.jl
+++ b/src/nodes/mv_normal_weighted_mean_precision.jl
@@ -5,5 +5,5 @@ import StatsFuns: log2π
 @average_energy MvNormalWeightedMeanPrecision (q_out::Any, q_ξ::Any, q_Λ::Any) = begin
     m_ξ, v_ξ     = mean_cov(q_ξ)
     m_out, v_out = mean_cov(q_out)
-    return (ndims(q_out) * log2π - mean(chollogdet, q_Λ) + tr(mean(q_Λ) * (m_out * m_out' + v_out)) - 2*dot(m_out,m_ξ) + tr(mean(cholinv, q_Λ) * (m_ξ * m_ξ' + v_ξ))) / 2
+    return (ndims(q_out) * log2π - mean(chollogdet, q_Λ) + tr(mean(q_Λ) * (m_out * m_out' + v_out)) - 2 * dot(m_out, m_ξ) + tr(mean(cholinv, q_Λ) * (m_ξ * m_ξ' + v_ξ))) / 2
 end

--- a/src/nodes/mv_normal_weighted_mean_precision.jl
+++ b/src/nodes/mv_normal_weighted_mean_precision.jl
@@ -3,17 +3,11 @@ import StatsFuns: log2π
 @node MvNormalWeightedMeanPrecision Stochastic [out, (ξ, aliases = [xi, weightedmean]), (Λ, aliases = [invcov, precision])]
 
 @average_energy MvNormalWeightedMeanPrecision (q_out::Any, q_ξ::Any, q_Λ::Any) = begin
-    m_mean, v_mean = mean_cov(q_ξ)
-    m_out, v_out   = mean_cov(q_out)
-    return @views (ndims(q_out) * log2π - mean(logdet, q_Λ) + tr(mean(q_Λ) * (v_out + v_mean + (m_out - m_mean) * (m_out - m_mean)'))) / 2
+    marginals = (Marginal(q_out, false, false, nothing), Marginal(q_ξ, false, false, nothing), Marginal(q_Λ, false, false, nothing))
+    score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}(), marginals, nothing)
 end
 
 @average_energy MvNormalWeightedMeanPrecision (q_out_ξ::Any, q_Λ::Any) = begin
-    m, V = mean_cov(q_out_ξ)
-    d = div(ndims(q_out_ξ), 2)
-    return @views (
-        d * log2π +
-        -mean(logdet, q_Λ) +
-        tr(mean(q_Λ) * (V[1:d, 1:d] - V[1:d, (d + 1):end] - V[(d + 1):end, 1:d] + V[(d + 1):end, (d + 1):end] + (m[1:d] - m[(d + 1):end]) * (m[1:d] - m[(d + 1):end])'))
-    ) / 2
+    marginals = (Marginal(q_out_ξ, false, false, nothing), Marginal(q_Λ, false, false, nothing))
+    score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out_μ, :Λ)}(), marginals, nothing)
 end

--- a/src/nodes/mv_normal_weighted_mean_precision.jl
+++ b/src/nodes/mv_normal_weighted_mean_precision.jl
@@ -3,11 +3,7 @@ import StatsFuns: log2π
 @node MvNormalWeightedMeanPrecision Stochastic [out, (ξ, aliases = [xi, weightedmean]), (Λ, aliases = [invcov, precision])]
 
 @average_energy MvNormalWeightedMeanPrecision (q_out::Any, q_ξ::Any, q_Λ::Any) = begin
-    marginals = (Marginal(q_out, false, false, nothing), Marginal(q_ξ, false, false, nothing), Marginal(q_Λ, false, false, nothing))
-    score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}(), marginals, nothing)
-end
-
-@average_energy MvNormalWeightedMeanPrecision (q_out_ξ::Any, q_Λ::Any) = begin
-    marginals = (Marginal(q_out_ξ, false, false, nothing), Marginal(q_Λ, false, false, nothing))
-    score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out_μ, :Λ)}(), marginals, nothing)
+    m_ξ, v_ξ     = mean_cov(q_ξ)
+    m_out, v_out = mean_cov(q_out)
+    return (ndims(q_out) * log2π - mean(logdet, q_Λ) + tr(mean(q_Λ) * (m_out * m_out' + v_out)) - 2m_out'm_ξ + tr(mean(inv, q_Λ) * (m_ξ * m_ξ' + v_ξ))) / 2
 end

--- a/src/nodes/mv_normal_weighted_mean_precision.jl
+++ b/src/nodes/mv_normal_weighted_mean_precision.jl
@@ -5,7 +5,7 @@ import StatsFuns: log2π
 @average_energy MvNormalWeightedMeanPrecision (q_out::Any, q_ξ::Any, q_Λ::Any) = begin
     m_mean, v_mean = mean_cov(q_ξ)
     m_out, v_out   = mean_cov(q_out)
-    return (ndims(q_out) * log2π - chollogdet(mean(q_Λ)) + tr(mean(q_Λ) * (v_out + v_mean + (m_out - m_mean) * (m_out - m_mean)'))) / 2
+    return @views (ndims(q_out) * log2π - mean(logdet, q_Λ) + tr(mean(q_Λ) * (v_out + v_mean + (m_out - m_mean) * (m_out - m_mean)'))) / 2
 end
 
 @average_energy MvNormalWeightedMeanPrecision (q_out_ξ::Any, q_Λ::Any) = begin
@@ -13,7 +13,7 @@ end
     d = div(ndims(q_out_ξ), 2)
     return @views (
         d * log2π +
-        -chollogdet(mean(q_Λ)) +
+        -mean(logdet, q_Λ) +
         tr(mean(q_Λ) * (V[1:d, 1:d] - V[1:d, (d + 1):end] - V[(d + 1):end, 1:d] + V[(d + 1):end, (d + 1):end] + (m[1:d] - m[(d + 1):end]) * (m[1:d] - m[(d + 1):end])'))
     ) / 2
 end

--- a/src/nodes/mv_normal_weighted_mean_precision.jl
+++ b/src/nodes/mv_normal_weighted_mean_precision.jl
@@ -5,5 +5,5 @@ import StatsFuns: log2π
 @average_energy MvNormalWeightedMeanPrecision (q_out::Any, q_ξ::Any, q_Λ::Any) = begin
     m_ξ, v_ξ     = mean_cov(q_ξ)
     m_out, v_out = mean_cov(q_out)
-    return (ndims(q_out) * log2π - mean(logdet, q_Λ) + tr(mean(q_Λ) * (m_out * m_out' + v_out)) - 2m_out'm_ξ + tr(mean(inv, q_Λ) * (m_ξ * m_ξ' + v_ξ))) / 2
+    return (ndims(q_out) * log2π - mean(chollogdet, q_Λ) + tr(mean(q_Λ) * (m_out * m_out' + v_out)) - 2*dot(m_out,m_ξ) + tr(mean(cholinv, q_Λ) * (m_ξ * m_ξ' + v_ξ))) / 2
 end

--- a/src/rules/mv_normal_weightedmean_precision/out.jl
+++ b/src/rules/mv_normal_weightedmean_precision/out.jl
@@ -1,0 +1,3 @@
+@rule MvNormalWeightedMeanPrecision(:out, Marginalisation) (m_ξ::PointMass, m_Λ::PointMass) = MvNormalWeightedMeanPrecision(mean(m_ξ), mean(m_Λ))
+
+@rule MvNormalWeightedMeanPrecision(:out, Marginalisation) (q_ξ::Any, q_Λ::Any) = MvNormalWeightedMeanPrecision(mean(q_ξ), mean(q_Λ))

--- a/src/rules/prototypes.jl
+++ b/src/rules/prototypes.jl
@@ -73,6 +73,7 @@ include("mv_normal_mean_scale_precision/precision.jl")
 include("mv_normal_mean_scale_precision/marginals.jl")
 
 include("mv_normal_weightedmean_precision/marginals.jl")
+include("mv_normal_weightedmean_precision/out.jl")
 
 include("normal_mean_precision/out.jl")
 include("normal_mean_precision/mean.jl")

--- a/test/nodes/test_mv_normal_weightedmean_precision.jl
+++ b/test/nodes/test_mv_normal_weightedmean_precision.jl
@@ -36,54 +36,27 @@ import ReactiveMP: make_node
 
     @testset "AverageEnergy" begin
         begin
-            q_out = PointMass([1.0, 1.0])
-            q_Λ   = PointMass([1/2 0.0; 0.0 1/2])
-            q_ξ   = PointMass(mean(q_Λ) * [2.0, 2.0])
+            for i in 2:5
+                mean_in, L = randn(i), randn(i, i)
+                Cov_in = L * L'
+                mean_out = randn(i)
 
-            for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision)
-                marginals = (Marginal(q_out, false, false, nothing), Marginal(q_ξ, false, false, nothing), Marginal(q_Λ, false, false, nothing))
-                @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out, :ξ, :Λ)}(), marginals, nothing) ≈ 3.0310242469692907
+                q_out = PointMass(mean_out)
+                q_Σ = PointMass(Cov_in)
+                q_μ = PointMass(mean_in)
+
+                q_Λ = PointMass(inv(mean(q_Σ)))
+                q_ξ = PointMass(mean(q_Λ) * mean(q_μ))
+
+                for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision)
+                    marginalsξ = (Marginal(q_out, false, false, nothing), Marginal(q_ξ, false, false, nothing), Marginal(q_Λ, false, false, nothing))
+                    marginalsμ = (Marginal(q_out, false, false, nothing), Marginal(q_μ, false, false, nothing), Marginal(q_Σ, false, false, nothing))
+                    @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out, :ξ, :Λ)}(), marginalsξ, nothing) ≈
+                        score(AverageEnergy(), MvNormalMeanCovariance, Val{(:out, :μ, :Σ)}(), marginalsμ, nothing)
+                end
             end
         end
-
-        # begin
-
-        #     # q_out = MvNormalMeanCovariance([0.34777017741128646, 0.478300212208703], [0.36248838736696753 0.42718825177834396; 0.42718825177834396 0.6613345138178703])
-        #     # q_Λ   = PointMass([0.9575163948991356 0.952247049670764; 0.952247049670764 1.001998675194526])
-        #     # q_ξ   = PointMass(mean(q_Λ)*[0.28114649146383175, 0.7773140083754762])
-
-        #     q_out = PointMass([1.0, 1.0])
-        #     q_Λ   = Wishart(4, [1/2 0.0; 0.0 1/2])
-        #     # q_ξ   = PointMass(mean(q_Λ)*[2.0, 2.0])
-        #     q_μ   = PointMass([2.0, 2.0])
-
-        #     for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (Wishart,)
-        #         marginals1 = (Marginal(q_out, false, false, nothing), Marginal(q_ξ, false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing))
-        #         marginals2 = (Marginal(q_out, false, false, nothing), Marginal(q_μ, false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing))
-        #         @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out, :ξ, :Λ)}(), marginals1, nothing) ≈ score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}(), marginals2, nothing)
-        #     end
-        # end
-
-        # begin
-        #     μ_out = [0.8625589157256603, 0.6694783342639599]
-        #     Λ_out = [1.0014322413749484 0.7989099036521625; 0.7989099036521625 1.0976639268696966]
-        #     μ_ξ   = [0.9334416739853251, 0.38318522701093105]
-        #     Λ_ξ   = [0.21867945696266933 0.5704895781120056; 0.5704895781120056 1.5321190185800933]
-        #     q_out = MvNormalWeightedMeanPrecision(Λ_out * μ_out, Λ_out)
-        #     q_ξ   = MvNormalWeightedMeanPrecision(Λ_ξ * μ_ξ, Λ_ξ)
-        #     q_Λ   = Wishart(4, [1.2509510680086597 1.3662166757006484; 1.3662166757006484 1.4925451500802907])
-
-        #     for N1 in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision),
-        #         N2 in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision),
-        #         G in (Wishart,)
-
-        #         marginals = (
-        #             Marginal(convert(N1, q_out), false, false, nothing), Marginal(convert(N2, q_ξ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing)
-        #         )
-        #         @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out, :ξ, :Λ)}(), marginals, nothing) ≈ 114.57678973411974
-        #     end
-        # end
-
+        # NOTE: tests for average energy when interfaces are not PointMass are not implemented
     end
 end
 end

--- a/test/nodes/test_mv_normal_weightedmean_precision.jl
+++ b/test/nodes/test_mv_normal_weightedmean_precision.jl
@@ -1,0 +1,117 @@
+module MvNormalWeightedMeanPrecisionNodeTest
+
+using Test, ReactiveMP, Random, BayesBase, ExponentialFamily
+
+import ReactiveMP: make_node
+
+@testset "MvNormalWeightedMeanPrecisionNodeTest" begin
+    @testset "Creation" begin
+        node = make_node(MvNormalWeightedMeanPrecision)
+
+        @test functionalform(node) === MvNormalWeightedMeanPrecision
+        @test sdtype(node) === Stochastic()
+        @test name.(interfaces(node)) === (:out, :ξ, :Λ)
+        @test factorisation(node) === ((1, 2, 3),)
+        @test localmarginalnames(node) === (:out_ξ_Λ,)
+        @test metadata(node) === nothing
+
+        node = make_node(MvNormalWeightedMeanPrecision, FactorNodeCreationOptions(nothing, 1, nothing))
+
+        @test functionalform(node) === MvNormalWeightedMeanPrecision
+        @test sdtype(node) === Stochastic()
+        @test name.(interfaces(node)) === (:out, :ξ, :Λ)
+        @test factorisation(node) === ((1, 2, 3),)
+        @test localmarginalnames(node) === (:out_ξ_Λ,)
+        @test metadata(node) === 1
+
+        node = make_node(MvNormalWeightedMeanPrecision, FactorNodeCreationOptions(((1,), (2, 3)), nothing, nothing))
+
+        @test functionalform(node) === MvNormalWeightedMeanPrecision
+        @test sdtype(node) === Stochastic()
+        @test name.(interfaces(node)) === (:out, :ξ, :Λ)
+        @test factorisation(node) === ((1,), (2, 3))
+        @test localmarginalnames(node) === (:out, :ξ_Λ)
+        @test metadata(node) === nothing
+    end
+
+    @testset "AverageEnergy" begin
+        begin
+            q_out = PointMass([1.0, 1.0])
+            q_ξ   = MvNormalWeightedMeanPrecision([1.0, 1.0], [1.0 0.0; 0.0 1.0])
+            q_Λ   = Wishart(3, [2.0 0.0; 0.0 2.0])
+
+            for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (Wishart,)
+                marginals = (Marginal(q_out, false, false, nothing), Marginal(convert(N, q_ξ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing))
+                @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out, :ξ, :Λ)}(), marginals, nothing) ≈ 6.721945550750932
+            end
+        end
+
+        begin
+            q_out = PointMass([0.3873049736301686, 0.6250550344669505, 0.9865681758036855])
+            μ     = [0.21393068431529905, 0.5271266845217295, 0.0032162989237940476]
+            Λ     = [1.1178940049080035 1.004643185289189 0.5726053202206195; 1.004643185289189 0.9113807582278761 0.515956570765438; 0.5726053202206195 0.515956570765438 0.3402071079911484]
+            q_ξ   = MvNormalWeightedMeanPrecision(Λ * μ, Λ)
+            q_Λ   = Wishart(4, [0.4720138588203935 0.49760446060666863 0.4405032929933653; 0.49760446060666863 0.6757755009955487 0.636955076077564; 0.4405032929933653 0.636955076077564 0.6660144475917664])
+
+            for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (Wishart,)
+                marginals = (Marginal(q_out, false, false, nothing), Marginal(convert(N, q_ξ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing))
+                @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out, :ξ, :Λ)}(), marginals, nothing) ≈ 57.362404928342
+            end
+        end
+
+        begin
+            μ_out = [0.8625589157256603, 0.6694783342639599]
+            Λ_out = [1.0014322413749484 0.7989099036521625; 0.7989099036521625 1.0976639268696966]
+            μ_ξ   = [0.9334416739853251, 0.38318522701093105]
+            Λ_ξ   = [0.21867945696266933 0.5704895781120056; 0.5704895781120056 1.5321190185800933]
+            q_out = MvNormalWeightedMeanPrecision(Λ_out * μ_out, Λ_out)
+            q_ξ   = MvNormalWeightedMeanPrecision(Λ_ξ * μ_ξ, Λ_ξ)
+            q_Λ   = Wishart(3, [1.2509510680086597 1.3662166757006484; 1.3662166757006484 1.4925451500802907])
+
+            for N1 in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision),
+                N2 in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision),
+                G in (Wishart,)
+
+                marginals = (
+                    Marginal(convert(N1, q_out), false, false, nothing), Marginal(convert(N2, q_ξ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing)
+                )
+                @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out, :ξ, :Λ)}(), marginals, nothing) ≈ 114.57678973411974
+            end
+        end
+
+        begin
+            μ_out_ξ = [0.35156676223859784, 0.6798203100143094, 0.954485919235333, 0.9236981452828203]
+            Λ_out_ξ = [
+                1.3182839156957349 0.9159049032047119 1.170482409249098 1.132202025059748
+                0.9159049032047119 1.4737964254194567 1.4024254322343757 0.7350293025705011
+                1.170482409249098 1.4024254322343757 2.0577570913647105 1.3137472032115916
+                1.132202025059748 0.7350293025705011 1.3137472032115916 1.2083880803032556
+            ]
+            q_out_ξ = MvNormalWeightedMeanPrecision(Λ_out_ξ * μ_out_ξ, Λ_out_ξ)
+            q_Λ = PointMass([0.6202203324986401 0.6037236520027125; 0.6037236520027125 1.140352058799863])
+
+            for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision)
+                marginals = (Marginal(convert(N, q_out_ξ), false, false, nothing), Marginal(q_Λ, false, false, nothing))
+                @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out_ξ, :Λ)}(), marginals, nothing) ≈ 11.240486862933556
+            end
+        end
+
+        begin
+            μ_out_μ = [0.35156676223859784, 0.6798203100143094, 0.954485919235333, 0.9236981452828203]
+            Λ_out_μ = [
+                1.3182839156957349 0.9159049032047119 1.170482409249098 1.132202025059748
+                0.9159049032047119 1.4737964254194567 1.4024254322343757 0.7350293025705011
+                1.170482409249098 1.4024254322343757 2.0577570913647105 1.3137472032115916
+                1.132202025059748 0.7350293025705011 1.3137472032115916 1.2083880803032556
+            ]
+            q_out_μ = MvNormalWeightedMeanPrecision(Λ_out_μ * μ_out_μ, Λ_out_μ)
+            q_Λ = Wishart(3, [0.6202203324986401 0.6037236520027125; 0.6037236520027125 1.140352058799863])
+
+            for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (Wishart,)
+                marginals = (Marginal(convert(N, q_out_μ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing))
+                @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out_ξ, :Λ)}(), marginals, nothing) ≈ 28.552276936591902
+            end
+        end
+    end
+end
+end

--- a/test/nodes/test_mv_normal_weightedmean_precision.jl
+++ b/test/nodes/test_mv_normal_weightedmean_precision.jl
@@ -37,81 +37,53 @@ import ReactiveMP: make_node
     @testset "AverageEnergy" begin
         begin
             q_out = PointMass([1.0, 1.0])
-            q_ξ   = MvNormalWeightedMeanPrecision([1.0, 1.0], [1.0 0.0; 0.0 1.0])
-            q_Λ   = Wishart(3, [2.0 0.0; 0.0 2.0])
-
-            for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (Wishart,)
-                marginals = (Marginal(q_out, false, false, nothing), Marginal(convert(N, q_ξ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing))
-                @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out, :ξ, :Λ)}(), marginals, nothing) ≈ 6.721945550750932
-            end
-        end
-
-        begin
-            q_out = PointMass([0.3873049736301686, 0.6250550344669505, 0.9865681758036855])
-            μ     = [0.21393068431529905, 0.5271266845217295, 0.0032162989237940476]
-            Λ     = [1.1178940049080035 1.004643185289189 0.5726053202206195; 1.004643185289189 0.9113807582278761 0.515956570765438; 0.5726053202206195 0.515956570765438 0.3402071079911484]
-            q_ξ   = MvNormalWeightedMeanPrecision(Λ * μ, Λ)
-            q_Λ   = Wishart(4, [0.4720138588203935 0.49760446060666863 0.4405032929933653; 0.49760446060666863 0.6757755009955487 0.636955076077564; 0.4405032929933653 0.636955076077564 0.6660144475917664])
-
-            for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (Wishart,)
-                marginals = (Marginal(q_out, false, false, nothing), Marginal(convert(N, q_ξ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing))
-                @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out, :ξ, :Λ)}(), marginals, nothing) ≈ 57.362404928342
-            end
-        end
-
-        begin
-            μ_out = [0.8625589157256603, 0.6694783342639599]
-            Λ_out = [1.0014322413749484 0.7989099036521625; 0.7989099036521625 1.0976639268696966]
-            μ_ξ   = [0.9334416739853251, 0.38318522701093105]
-            Λ_ξ   = [0.21867945696266933 0.5704895781120056; 0.5704895781120056 1.5321190185800933]
-            q_out = MvNormalWeightedMeanPrecision(Λ_out * μ_out, Λ_out)
-            q_ξ   = MvNormalWeightedMeanPrecision(Λ_ξ * μ_ξ, Λ_ξ)
-            q_Λ   = Wishart(3, [1.2509510680086597 1.3662166757006484; 1.3662166757006484 1.4925451500802907])
-
-            for N1 in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision),
-                N2 in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision),
-                G in (Wishart,)
-
-                marginals = (
-                    Marginal(convert(N1, q_out), false, false, nothing), Marginal(convert(N2, q_ξ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing)
-                )
-                @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out, :ξ, :Λ)}(), marginals, nothing) ≈ 114.57678973411974
-            end
-        end
-
-        begin
-            μ_out_ξ = [0.35156676223859784, 0.6798203100143094, 0.954485919235333, 0.9236981452828203]
-            Λ_out_ξ = [
-                1.3182839156957349 0.9159049032047119 1.170482409249098 1.132202025059748
-                0.9159049032047119 1.4737964254194567 1.4024254322343757 0.7350293025705011
-                1.170482409249098 1.4024254322343757 2.0577570913647105 1.3137472032115916
-                1.132202025059748 0.7350293025705011 1.3137472032115916 1.2083880803032556
-            ]
-            q_out_ξ = MvNormalWeightedMeanPrecision(Λ_out_ξ * μ_out_ξ, Λ_out_ξ)
-            q_Λ = PointMass([0.6202203324986401 0.6037236520027125; 0.6037236520027125 1.140352058799863])
+            q_Λ   = PointMass([1/2 0.0; 0.0 1/2])
+            q_ξ   = PointMass(mean(q_Λ) * [2.0, 2.0])
 
             for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision)
-                marginals = (Marginal(convert(N, q_out_ξ), false, false, nothing), Marginal(q_Λ, false, false, nothing))
-                @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out_ξ, :Λ)}(), marginals, nothing) ≈ 11.240486862933556
+                marginals = (Marginal(q_out, false, false, nothing), Marginal(q_ξ, false, false, nothing), Marginal(q_Λ, false, false, nothing))
+                @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out, :ξ, :Λ)}(), marginals, nothing) ≈ 3.0310242469692907
             end
         end
 
-        begin
-            μ_out_μ = [0.35156676223859784, 0.6798203100143094, 0.954485919235333, 0.9236981452828203]
-            Λ_out_μ = [
-                1.3182839156957349 0.9159049032047119 1.170482409249098 1.132202025059748
-                0.9159049032047119 1.4737964254194567 1.4024254322343757 0.7350293025705011
-                1.170482409249098 1.4024254322343757 2.0577570913647105 1.3137472032115916
-                1.132202025059748 0.7350293025705011 1.3137472032115916 1.2083880803032556
-            ]
-            q_out_μ = MvNormalWeightedMeanPrecision(Λ_out_μ * μ_out_μ, Λ_out_μ)
-            q_Λ = Wishart(3, [0.6202203324986401 0.6037236520027125; 0.6037236520027125 1.140352058799863])
+        # begin
 
-            for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (Wishart,)
-                marginals = (Marginal(convert(N, q_out_μ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing))
-                @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out_ξ, :Λ)}(), marginals, nothing) ≈ 28.552276936591902
-            end
-        end
+        #     # q_out = MvNormalMeanCovariance([0.34777017741128646, 0.478300212208703], [0.36248838736696753 0.42718825177834396; 0.42718825177834396 0.6613345138178703])
+        #     # q_Λ   = PointMass([0.9575163948991356 0.952247049670764; 0.952247049670764 1.001998675194526])
+        #     # q_ξ   = PointMass(mean(q_Λ)*[0.28114649146383175, 0.7773140083754762])
+
+        #     q_out = PointMass([1.0, 1.0])
+        #     q_Λ   = Wishart(4, [1/2 0.0; 0.0 1/2])
+        #     # q_ξ   = PointMass(mean(q_Λ)*[2.0, 2.0])
+        #     q_μ   = PointMass([2.0, 2.0])
+
+        #     for N in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision), G in (Wishart,)
+        #         marginals1 = (Marginal(q_out, false, false, nothing), Marginal(q_ξ, false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing))
+        #         marginals2 = (Marginal(q_out, false, false, nothing), Marginal(q_μ, false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing))
+        #         @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out, :ξ, :Λ)}(), marginals1, nothing) ≈ score(AverageEnergy(), MvNormalMeanPrecision, Val{(:out, :μ, :Λ)}(), marginals2, nothing)
+        #     end
+        # end
+
+        # begin
+        #     μ_out = [0.8625589157256603, 0.6694783342639599]
+        #     Λ_out = [1.0014322413749484 0.7989099036521625; 0.7989099036521625 1.0976639268696966]
+        #     μ_ξ   = [0.9334416739853251, 0.38318522701093105]
+        #     Λ_ξ   = [0.21867945696266933 0.5704895781120056; 0.5704895781120056 1.5321190185800933]
+        #     q_out = MvNormalWeightedMeanPrecision(Λ_out * μ_out, Λ_out)
+        #     q_ξ   = MvNormalWeightedMeanPrecision(Λ_ξ * μ_ξ, Λ_ξ)
+        #     q_Λ   = Wishart(4, [1.2509510680086597 1.3662166757006484; 1.3662166757006484 1.4925451500802907])
+
+        #     for N1 in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision),
+        #         N2 in (MvNormalMeanPrecision, MvNormalMeanCovariance, MvNormalWeightedMeanPrecision),
+        #         G in (Wishart,)
+
+        #         marginals = (
+        #             Marginal(convert(N1, q_out), false, false, nothing), Marginal(convert(N2, q_ξ), false, false, nothing), Marginal(convert(G, q_Λ), false, false, nothing)
+        #         )
+        #         @test score(AverageEnergy(), MvNormalWeightedMeanPrecision, Val{(:out, :ξ, :Λ)}(), marginals, nothing) ≈ 114.57678973411974
+        #     end
+        # end
+
     end
 end
 end

--- a/test/rules/mv_normal_weightedmean_precision/test_out.jl
+++ b/test/rules/mv_normal_weightedmean_precision/test_out.jl
@@ -1,0 +1,46 @@
+module RulesMvNormalWeightedMeanPrecisionOutTest
+
+using Test, ReactiveMP, BayesBase, Random, ExponentialFamily, Distributions
+
+import ReactiveMP: @test_rules
+
+@testset "rules:MvNormalWeightedMeanPrecision:out" begin
+    @testset "Belief Propagation: (m_ξ::PointMass, m_Λ::PointMass)" begin
+        @test_rules [check_type_promotion = true] MvNormalWeightedMeanPrecision(:out, Marginalisation) [
+            (input = (m_ξ = PointMass([-1.0]), m_Λ = PointMass([2.0])), output = MvNormalWeightedMeanPrecision([-1.0], [2.0])),
+            (input = (m_ξ = PointMass([1.0]), m_Λ = PointMass([2.0])), output = MvNormalWeightedMeanPrecision([1.0], [2.0])),
+            (input = (m_ξ = PointMass([2.0]), m_Λ = PointMass([1.0])), output = MvNormalWeightedMeanPrecision([2.0], [1.0])),
+            (input = (m_ξ = PointMass([1.0, 3.0]), m_Λ = PointMass([3.0 2.0; 2.0 4.0])), output = MvNormalWeightedMeanPrecision([1.0, 3.0], [3.0 2.0; 2.0 4.0])),
+            (input = (m_ξ = PointMass([-1.0, 2.0]), m_Λ = PointMass([7.0 -1.0; -1.0 9.0])), output = MvNormalWeightedMeanPrecision([-1.0, 2.0], [7.0 -1.0; -1.0 9.0])),
+            (input = (m_ξ = PointMass([0.0, 0.0]), m_Λ = PointMass([1.0 0.0; 0.0 1.0])), output = MvNormalWeightedMeanPrecision([0.0, 0.0], [1.0 0.0; 0.0 1.0]))
+        ]
+    end
+
+    @testset "Variational: (q_ξ::Any, q_Λ::Any)" begin
+        @test_rules [check_type_promotion = true] MvNormalWeightedMeanPrecision(:out, Marginalisation) [
+            (input = (q_ξ = PointMass([-1.0]), q_Λ = PointMass([2.0])), output = MvNormalWeightedMeanPrecision([-1.0], [2.0])),
+            (input = (q_ξ = PointMass([1.0]), q_Λ = PointMass([2.0])), output = MvNormalWeightedMeanPrecision([1.0], [2.0])),
+            (input = (q_ξ = PointMass([2.0]), q_Λ = PointMass([1.0])), output = MvNormalWeightedMeanPrecision([2.0], [1.0])),
+            (input = (q_ξ = PointMass([1.0, 3.0]), q_Λ = PointMass([3.0 2.0; 2.0 4.0])), output = MvNormalWeightedMeanPrecision([1.0, 3.0], [3.0 2.0; 2.0 4.0])),
+            (input = (q_ξ = PointMass([-1.0, 2.0]), q_Λ = PointMass([7.0 -1.0; -1.0 9.0])), output = MvNormalWeightedMeanPrecision([-1.0, 2.0], [7.0 -1.0; -1.0 9.0])),
+            (input = (q_ξ = PointMass([0.0, 0.0]), q_Λ = PointMass([1.0 0.0; 0.0 1.0])), output = MvNormalWeightedMeanPrecision([0.0, 0.0], [1.0 0.0; 0.0 1.0]))
+        ]
+
+        @test_rules [check_type_promotion = true] MvNormalWeightedMeanPrecision(:out, Marginalisation) [
+            (
+                input = (q_ξ = MvNormalWeightedMeanPrecision([3.0 2.0; 2.0 4.0] * [2.0, 1.0], [3.0 2.0; 2.0 4.0]), q_Λ = Wishart(2.0, [6.0 4.0; 4.0 8.0] ./ 2.0)),
+                output = MvNormalWeightedMeanPrecision([2.0, 1.0], [6.0 4.0; 4.0 8.0])
+            ),
+            (
+                input = (q_ξ = MvNormalWeightedMeanPrecision([0.0, 0.0], [7.0 -1.0; -1.0 9.0]), q_Λ = Wishart(3.0, [12.0 -2.0; -2.0 7.0] ./ 3.0)),
+                output = MvNormalWeightedMeanPrecision([0.0, 0.0], [12.0 -2.0; -2.0 7.0])
+            ),
+            (
+                input = (q_ξ = MvNormalWeightedMeanPrecision([3.0, -1.0], [1.0 0.0; 0.0 1.0]), q_Λ = Wishart(4.0, [1.0 0.0; 0.0 1.0] ./ 4.0)),
+                output = MvNormalWeightedMeanPrecision([3.0, -1.0], [1.0 0.0; 0.0 1.0])
+            )
+        ]
+    end
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -242,6 +242,7 @@ end
     addtests(testrunner, "nodes/test_normal_mean_variance.jl")
     addtests(testrunner, "nodes/test_mv_normal_mean_precision.jl")
     addtests(testrunner, "nodes/test_mv_normal_mean_scale_precision.jl")
+    addtests(testrunner, "nodes/test_mv_normal_weightedmean_precision.jl")
     addtests(testrunner, "nodes/test_mv_normal_mean_covariance.jl")
     addtests(testrunner, "nodes/test_poisson.jl")
     addtests(testrunner, "nodes/test_wishart_inverse.jl")
@@ -346,6 +347,8 @@ end
     addtests(testrunner, "rules/mv_normal_mean_scale_precision/test_out.jl")
     addtests(testrunner, "rules/mv_normal_mean_scale_precision/test_mean.jl")
     addtests(testrunner, "rules/mv_normal_mean_scale_precision/test_precision.jl")
+
+    addtests(testrunner, "rules/mv_normal_weightedmean_precision/test_out.jl")
 
     addtests(testrunner, "rules/probit/test_out.jl")
     addtests(testrunner, "rules/probit/test_in.jl")


### PR DESCRIPTION
This PR encompasses the following contributions for the `MvNormalWeightedMeanPrecision` node:

1. Fix for average energy.
2. Addition of rules for the out interface (particularly useful for priors).
3. Inclusion of missing tests.