### PR TITLE
Allow rules with Missing inputs

### DIFF
--- a/src/marginal.jl
+++ b/src/marginal.jl
@@ -195,13 +195,7 @@ function (mapping::MarginalMapping)(dependencies)
     # Marginal is initial if it is not clamped and all of the inputs are either clamped or initial
     is_marginal_initial = !is_marginal_clamped && (__check_all(is_clamped_or_initial, messages) && __check_all(is_clamped_or_initial, marginals))
 
-    marginal = if !isnothing(messages) && any(ismissing, TupleTools.flatten(getdata.(messages)))
-        missing
-    elseif !isnothing(marginals) && any(ismissing, TupleTools.flatten(getdata.(marginals)))
-        missing
-    else
-        marginalrule(marginal_mapping_fform(mapping), mapping.vtag, mapping.msgs_names, messages, mapping.marginals_names, marginals, mapping.meta, mapping.factornode)
-    end
+    marginal = marginalrule(marginal_mapping_fform(mapping), mapping.vtag, mapping.msgs_names, messages, mapping.marginals_names, marginals, mapping.meta, mapping.factornode)
 
     return Marginal(marginal, is_marginal_clamped, is_marginal_initial, nothing)
 end

--- a/src/message.jl
+++ b/src/message.jl
@@ -321,24 +321,18 @@ function materialize!(mapping::MessageMapping, messages, marginals)
     # Message is initial if it is not clamped and all of the inputs are either clamped or initial
     is_message_initial = !is_message_clamped && (__check_all(is_clamped_or_initial, messages) && __check_all(is_clamped_or_initial, marginals))
 
-    result, addons = if !isnothing(messages) && any(ismissing, TupleTools.flatten(getdata.(messages)))
-        missing, mapping.addons
-    elseif !isnothing(marginals) && any(ismissing, TupleTools.flatten(getdata.(marginals)))
-        missing, mapping.addons
-    else
-        rule(
-            message_mapping_fform(mapping),
-            mapping.vtag,
-            mapping.vconstraint,
-            mapping.msgs_names,
-            messages,
-            mapping.marginals_names,
-            marginals,
-            mapping.meta,
-            mapping.addons,
-            mapping.factornode
-        )
-    end
+    result, addons = rule(
+        message_mapping_fform(mapping),
+        mapping.vtag,
+        mapping.vconstraint,
+        mapping.msgs_names,
+        messages,
+        mapping.marginals_names,
+        marginals,
+        mapping.meta,
+        mapping.addons,
+        mapping.factornode
+    )
 
     # Inject extra addons after the rule has been executed
     addons = message_mapping_addons(mapping, getdata(messages), getdata(marginals), result, addons)

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -1096,8 +1096,17 @@ struct RuleMethodError
     node
 end
 
-rule(fform, on, vconstraint, mnames, messages, qnames, marginals, meta, addons, __node) =
-    throw(RuleMethodError(fform, on, vconstraint, mnames, messages, qnames, marginals, meta, addons, __node))
+# Generic rule returns `missing` if any of the inputs is `missing`, otherwise it displays an error 
+# that suggests to define a rule with the given arguments
+function rule(fform, on, vconstraint, mnames, messages, qnames, marginals, meta, addons, __node)
+    if !isnothing(messages) && any(ismissing, TupleTools.flatten(getdata.(messages)))
+        return missing, addons
+    elseif !isnothing(marginals) && any(ismissing, TupleTools.flatten(getdata.(marginals)))
+        return missing, addons
+    else
+        throw(RuleMethodError(fform, on, vconstraint, mnames, messages, qnames, marginals, meta, addons, __node))
+    end
+end
 
 function Base.showerror(io::IO, error::RuleMethodError)
     print(io, "RuleMethodError: no method matching rule for the given arguments")
@@ -1175,7 +1184,17 @@ struct MarginalRuleMethodError
     node
 end
 
-marginalrule(fform, on, mnames, messages, qnames, marginals, meta, __node) = throw(MarginalRuleMethodError(fform, on, mnames, messages, qnames, marginals, meta, __node))
+# Generic rule returns `missing` if any of the inputs is `missing`, otherwise it displays an error 
+# that suggests to define a rule with the given arguments
+function marginalrule(fform, on, mnames, messages, qnames, marginals, meta, __node)
+    if !isnothing(messages) && any(ismissing, TupleTools.flatten(getdata.(messages)))
+        return missing
+    elseif !isnothing(marginals) && any(ismissing, TupleTools.flatten(getdata.(marginals)))
+        return missing
+    else
+        throw(MarginalRuleMethodError(fform, on, mnames, messages, qnames, marginals, meta, __node))
+    end
+end
 
 function Base.showerror(io::IO, error::MarginalRuleMethodError)
     print(io, "MarginalRuleMethodError: no method matching rule for the given arguments")

--- a/test/test_rule.jl
+++ b/test/test_rule.jl
@@ -709,6 +709,35 @@ import MacroTools: inexpr
         @test dist_and_nothing[1] isa Bernoulli
         @test dist_and_nothing[2] isa Nothing
     end
+
+    @testset "Check the generic rules with a missing argument" begin
+        struct DummyNodeMissing end
+
+        @node DummyNodeMissing Stochastic [out, in]
+
+        @test (@call_rule DummyNodeMissing(:out, Marginalisation) (m_in = missing,)) === missing
+        @test (@call_rule DummyNodeMissing(:out, Marginalisation) (q_in = missing,)) === missing
+
+        @test (@call_rule DummyNodeMissing(:in, Marginalisation) (m_out = missing,)) === missing
+        @test (@call_rule DummyNodeMissing(:in, Marginalisation) (q_out = missing,)) === missing
+    end
+
+    @testset "Check that rules with missings can be defined" begin
+        struct DummyNodeRuleWithMissing end
+
+        @node DummyNodeRuleWithMissing Stochastic [out, in]
+
+        @rule DummyNodeRuleWithMissing(:out, Marginalisation) (m_in::Missing,) = 1
+        @rule DummyNodeRuleWithMissing(:out, Marginalisation) (q_in::Missing,) = 2
+        @rule DummyNodeRuleWithMissing(:in, Marginalisation) (m_out::Missing,) = 3
+        @rule DummyNodeRuleWithMissing(:in, Marginalisation) (q_out::Missing,) = 4
+
+        @test (@call_rule DummyNodeRuleWithMissing(:out, Marginalisation) (m_in = missing,)) === 1
+        @test (@call_rule DummyNodeRuleWithMissing(:out, Marginalisation) (q_in = missing,)) === 2
+
+        @test (@call_rule DummyNodeRuleWithMissing(:in, Marginalisation) (m_out = missing,)) === 3
+        @test (@call_rule DummyNodeRuleWithMissing(:in, Marginalisation) (q_out = missing,)) === 4
+    end
 end
 
 end


### PR DESCRIPTION
Spotted by @wouterwln & @bartvanerp . New logic for the predictions did not take into account that someone would want to define a rule that accepts `Missing` as an argument. In the current logic, if we have `Missing` argument we don't even call the rule, which could be potentially defined. This PR changes this and allows users to define their rules with `Missing` arguments while preserving the previous functionality.