### PR TITLE
#432: Check if probvec of Categorical q_out is one-hot encoded vector 

### DIFF
--- a/docs/src/lib/algebra.md
+++ b/docs/src/lib/algebra.md
@@ -16,4 +16,5 @@ ReactiveMP.rank1update
 ReactiveMP.v_a_vT
 ReactiveMP.powerset
 ReactiveMP.besselmod
+ReactiveMP.isonehot
 ```

--- a/src/helpers/algebra/common.jl
+++ b/src/helpers/algebra/common.jl
@@ -130,3 +130,28 @@ function powerset(iterator)
     end
     return filter(!isempty, result)
 end
+
+"""
+    isonehot(vec::AbstractVector)
+
+Checks if the given vector `vec` is a one-hot vector, i.e., a vector with exactly one entry equal to `one(eltype(vec))` and all other entries equal to `zero(eltype(vec))`.
+
+Returns `true` if `vec` is one-hot, otherwise returns `false`.
+"""
+function isonehot(vec::AbstractVector)
+    number_of_ones::Int = 0
+    for e in vec
+        if isequal(e, one(e))
+            if number_of_ones > 1
+                return false
+            end
+            number_of_ones += 1
+        elseif !isequal(e, zero(e))
+            return false
+        end
+    end
+    return number_of_ones == 1
+end
+
+isonehot(::Real) = false
+isonehot(::AbstractMatrix) = false

--- a/src/rules/categorical/p.jl
+++ b/src/rules/categorical/p.jl
@@ -1,29 +1,24 @@
-export rule
-
-# Check if a vector is one-hot
-_isonehot(vec::AbstractVector) = sum(vec .== 1.0) == 1 && all(x -> x == 0.0 || x == 1.0, vec)
-
-function _validated_dirichlet(q_out; logscale::Bool = false)
-    probs = probvec(q_out)
-    if !_isonehot(probs)
-        throw(ArgumentError("q_out must be one-hot encoded. Got: $probs"))
-    end
-    if logscale
-        @logscale -logfactorial(length(probs))
-    end
-    return Dirichlet(probs .+ one(eltype(probs)))
-end
 
 using SpecialFunctions: logfactorial
+
 # https://github.com/JuliaStats/Distributions.jl/blob/master/src/univariate/discrete/categorical.jl#L27
-@rule Categorical(:p, Marginalisation) (q_out::Categorical{P, Ps},) where {P <: Real, Ps <: AbstractVector{P}} = _validated_dirichlet(q_out)
-# https://github.com/ReactiveBayes/BayesBase.jl/blob/main/src/densities/pointmass.jl
-@rule Categorical(:p, Marginalisation) (q_out::PointMass{V},) where {T <: Real, V <: AbstractVector{T}} = begin
+@rule Categorical(:p, Marginalisation) (q_out::Categorical,) = begin
     probs = probvec(q_out)
-    if !_isonehot(probs)
+    if !isonehot(probs)
         throw(ArgumentError("q_out must be one-hot encoded. Got: $probs"))
     end
     @logscale -logfactorial(length(probs))
     return Dirichlet(probs .+ one(eltype(probs)))
 end
+
+# https://github.com/ReactiveBayes/BayesBase.jl/blob/main/src/densities/pointmass.jl
+@rule Categorical(:p, Marginalisation) (q_out::PointMass{V},) where {T <: Real, V <: AbstractVector{T}} = begin
+    probs = probvec(q_out)
+    if !isonehot(probs)
+        throw(ArgumentError("q_out must be one-hot encoded. Got: $probs"))
+    end
+    @logscale -logfactorial(length(probs))
+    return Dirichlet(probs .+ one(eltype(probs)))
+end
+
 @rule Categorical(:p, Marginalisation) (q_out::Any,) = throw(ArgumentError("q_out is only defined for PointMass or Categorical over a one-hot vector. Got: $(typeof(q_out))"))

--- a/test/helpers/algebra/common_tests.jl
+++ b/test/helpers/algebra/common_tests.jl
@@ -89,3 +89,25 @@
         end
     end
 end
+
+@testitem "isonehot" begin
+    import ReactiveMP: isonehot
+
+    for T in [Float64, Float32, Float16, BigFloat]
+        @test isonehot(T.([0.0, 1.0])) == true
+        @test isonehot(T.([0.0, 1.0, 0.0])) == true
+        @test isonehot(T.([1.0, 0.0, 0.0])) == true
+        @test isonehot(T.([0.0, 0.0, 1.0])) == true
+
+        @test isonehot(T.([0.0, 0.0, 0.0])) == false
+        @test isonehot(T.([1.0, 1.0, 1.0])) == false
+
+        @test isonehot(T.([0.0, 0.1, 1.0])) == false
+        @test isonehot(T.([0.1, 0.1, 0.8])) == false
+
+        if T !== BigFloat
+            v = T.([0.0, 1.0])
+            @test @allocated(isonehot(v)) == 0
+        end
+    end
+end

--- a/test/rules/categorical/p_tests.jl
+++ b/test/rules/categorical/p_tests.jl
@@ -1,14 +1,15 @@
+
 @testitem "rules:Categorical:p" begin
     using ReactiveMP, BayesBase, Random, ExponentialFamily, Distributions
 
     import ReactiveMP: @test_rules
 
     @testset "Variational Message Passing: (q_out::PointMass)" begin
-        @test_rules [check_type_promotion = true] Categorical(:p, Marginalisation) [(input = (q_out = PointMass([0.0, 1.0]),), output = Dirichlet([1.0, 2.0])),]
+        @test_rules [check_type_promotion = true] Categorical(:p, Marginalisation) [(input = (q_out = PointMass([0.0, 1.0]),), output = Dirichlet([1.0, 2.0]))]
     end
 
     @testset "Variational Message Passing: (q_out::Categorical)" begin
-        @test_rules [check_type_promotion = false] Categorical(:p, Marginalisation) [(input = (q_out = Categorical([0.0, 1.0]),), output = Dirichlet([1.0, 2.0])),]
+        @test_rules [check_type_promotion = false] Categorical(:p, Marginalisation) [(input = (q_out = Categorical([0.0, 1.0]),), output = Dirichlet([1.0, 2.0]))]
     end
 
     # Test if the input q_out for the outgoing message towards p edge is not a scalar


### PR DESCRIPTION
I assume the issue only relates to the `p` rule; to check if the input (`q_out`)  is a one-hot encoded vector.
I introduced two helper functions - one to check if a vector is one-hot encoded, and another one that moved to functionality of both rules (which were almost the same except a `@logscale` macro call for the `PointMass` case). However, I had to stay with a separate logic for the `PointMass` case since I got the following error: `UndefVarError: "_addons" not defined`