### PR TITLE
#515: Actually filter tests when doing make test test_args=...

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,10 +18,7 @@ else
         candidate = join(split(arg, ":"), "/")
 
         # Build possible test paths relative to the package test directory
-        paths = [
-            joinpath(test_root, candidate),
-            joinpath(test_root, candidate * ".jl")
-        ]
+        paths = [joinpath(test_root, candidate), joinpath(test_root, candidate * ".jl")]
 
         path = findfirst(ispath, paths)
 
@@ -34,4 +31,3 @@ else
         end
     end
 end
-


### PR DESCRIPTION
Should resolve #515 - we now provide test filtering to the [`ReTestItems.runtests`](https://github.com/JuliaTesting/ReTestItems.jl) function by selecting specific paths. Filtering by test names using the `name=...` parameter instead of paths to tests should be fixed in another update.