### PR TITLE
507 add new node implementing jaakkola jordans lower bound on sigmoid log sigmoid in bishop prml

### DIFF
--- a/src/nodes/predefined.jl
+++ b/src/nodes/predefined.jl
@@ -34,7 +34,7 @@ include("predefined/continuous_transition.jl")
 include("predefined/half_normal.jl")
 include("predefined/binomial_polya.jl")
 include("predefined/multinomial_polya.jl")
-include("predefined/Sigmoid.jl")
+include("predefined/sigmoid.jl")
 
 include("predefined/flow/flow.jl")
 include("predefined/delta/delta.jl")

--- a/src/nodes/predefined/sigmoid.jl
+++ b/src/nodes/predefined/sigmoid.jl
@@ -1,17 +1,18 @@
-struct Sigmoid end
-using StatsFuns: logistic
-
-@node Sigmoid Stochastic [out, in, ξ]
-
-@average_energy Sigmoid (q_out::Categorical, q_in::UnivariateNormalDistributionsFamily, q_ξ::PointMass) = begin
-    
-    mout = mean(q_out)
-    m_in, v_in = mean_var(q_in)
-    
-    ξ_hat = mean(q_ξ)
-
-    U = m_in * mout + log(logistic(ξ_hat)) - 0.5 * (m_in + ξ_hat) - ((logistic(ξ_hat) - 0.5)/(2*ξ_hat)) * (m_in^2 + v_in - ξ_hat^2)
-    return U
-end
+using StatsFuns: logistic, softplus
+using Distributions: pdf
 
 export Sigmoid
+
+struct Sigmoid end
+
+@node Sigmoid Stochastic [out, in, ζ]
+
+@average_energy Sigmoid (q_out::Categorical, q_in::UnivariateNormalDistributionsFamily, q_ζ::PointMass) = begin
+    m_out = pdf(q_out, 1)
+    m_in, v_in = mean_var(q_in)
+
+    ζ_hat = mean(q_ζ)
+
+    U = -(m_in * m_out - softplus(-ζ_hat) - (0.5 * (m_in + ζ_hat)) - 0.5 * ((logistic(ζ_hat) - 0.5)/ζ_hat) * (m_in^2 + v_in - ζ_hat^2))
+    return U
+end

--- a/src/rules/predefined.jl
+++ b/src/rules/predefined.jl
@@ -198,3 +198,7 @@ include("multinomial_polya/x.jl")
 
 include("dirichlet_collection/out.jl")
 include("dirichlet_collection/marginals.jl")
+
+include("sigmoid/in.jl")
+include("sigmoid/out.jl")
+include("sigmoid/zeta.jl")

--- a/src/rules/sigmoid/in.jl
+++ b/src/rules/sigmoid/in.jl
@@ -1,9 +1,19 @@
+using Distributions: pdf
+using StatsFuns: logistic
+@rule Sigmoid(:in, Marginalisation) (q_out::Categorical, q_ζ::PointMass) = begin
+    m_out = pdf(q_out, 1)
+    ζ_hat = mean(q_ζ)
+    w = (logistic(ζ_hat) - 0.5)/ζ_hat
+    ξ = (m_out - 0.5) * w
+    T = promote_type(eltype(m_out), eltype(ζ_hat))
+    return NormalWeightedMeanPrecision{T}(ξ, w)
+end
 
-@rule Sigmoid(:in, Marginalisation) (q_out::Categorical, q_ξ::PointMass) = begin
-
-    mout = mean(q_out)
-    ξ_hat = mean(q_ξ)
-    w = 2 * ((logistic(ξ_hat) - 0.5)/(2*ξ_hat))
-    mout_w = (mout - 0.5)* w
-    return NormalWeightedMeanPrecision(mout_w, w)  
+@rule Sigmoid(:in, Marginalisation) (q_out::PointMass, q_ζ::PointMass) = begin
+    m_out = mean(q_out)
+    ζ_hat = mean(q_ζ)
+    w = (logistic(ζ_hat) - 0.5)/ζ_hat
+    ξ = (m_out - 0.5) * w
+    T = promote_type(eltype(m_out), eltype(ζ_hat))
+    return NormalWeightedMeanPrecision{T}(ξ, w)
 end

--- a/src/rules/sigmoid/out.jl
+++ b/src/rules/sigmoid/out.jl
@@ -1,7 +1,11 @@
 using StatsFuns: logistic
-@rule sigmoid(:out, Marginalisation) (q_in::UnivariateNormalDistributionsFamily,q_ξ::PointMass) = begin
+@rule Sigmoid(:out, Marginalisation) (q_in::UnivariateNormalDistributionsFamily, q_ζ::PointMass) = begin
     m_in = mean(q_in)
+    ζ_hat = mean(q_ζ)
     p = logistic(m_in)
-    return Categorical(p, 1 - p)
+    T = promote_type(eltype(m_in), eltype(ζ_hat))
+    probs = clamp.([p, 1 - p], tiny, 1 - tiny)
+    probs ./= sum(probs)
+    probs_T = convert(Vector{T}, probs)
+    return Categorical(probs_T)
 end
-

--- a/src/rules/sigmoid/xi.jl
+++ b/src/rules/sigmoid/xi.jl
@@ -1,4 +1,0 @@
-@rule Sigmoid(:ξ, Marginalisation) (q_out::Any, q_in::UnivariateNormalDistributionsFamily) = begin
-    m_in, v_in = mean_cov(q_in)
-    return sqrt(m_in^2 + v_in)
-end

--- a/src/rules/sigmoid/zeta.jl
+++ b/src/rules/sigmoid/zeta.jl
@@ -1,0 +1,5 @@
+@rule Sigmoid(:ζ, Marginalisation) (q_out::Any, q_in::UnivariateNormalDistributionsFamily) = begin
+    m_in, v_in = mean_var(q_in)
+    T = promote_type(eltype(m_in), eltype(v_in))
+    return PointMass{T}(sqrt(m_in^2 + v_in))
+end

--- a/test/nodes/predefined/sigmoid_tests.jl
+++ b/test/nodes/predefined/sigmoid_tests.jl
@@ -9,10 +9,10 @@
             @test score(
                 AverageEnergy(),
                 Sigmoid,
-                Val{(:out, :in, :ξ)}(),
+                Val{(:out, :in, :ζ)}(),
                 (Marginal(Categorical(0.5, 0.5), false, false, nothing), Marginal(q_in_adj, false, false, nothing), Marginal(PointMass(1.0), false, false, nothing)),
                 nothing
-            )≈ -0.8132616875182228
+            ) ≈ 0.8132616875182228
         end
     end
 end

--- a/test/rules/sigmoid/in_tests.jl
+++ b/test/rules/sigmoid/in_tests.jl
@@ -1,0 +1,22 @@
+@testitem "rules:Sigmoid:in" begin
+    using ReactiveMP, BayesBase, Random, ExponentialFamily, Distributions
+    using StatsFuns: logistic
+
+    import ReactiveMP: @test_rules
+
+    @testset "Mean Field: (q_out::Categorical, q_ζ::PointMass) - Float64" begin
+        @test_rules [check_type_promotion = true, atol = [Float64 => 1e-5]] Sigmoid(:in, Marginalisation) [
+            (input = (q_out = Categorical([0.5, 0.5]), q_ζ = PointMass(1.0)), output = NormalWeightedMeanPrecision(0.0, 0.2310585786300049)),
+            (input = (q_out = Categorical([1.0, 0.0]), q_ζ = PointMass(1.0)), output = NormalWeightedMeanPrecision(0.11552928931500245, 0.2310585786300049)),
+            (input = (q_out = Categorical([0.0, 1.0]), q_ζ = PointMass(1.0)), output = NormalWeightedMeanPrecision(-0.11552928931500245, 0.2310585786300049))
+        ]
+    end
+
+    @testset "Mean Field: (q_out::PointMass, q_ζ::PointMass) - Float64" begin
+        @test_rules [check_type_promotion = true, atol = [Float64 => 1e-5]] Sigmoid(:in, Marginalisation) [
+            (input = (q_out = PointMass(0.5), q_ζ = PointMass(1.0)), output = NormalWeightedMeanPrecision(0.0, 0.2310585786300049)),
+            (input = (q_out = PointMass(1.0), q_ζ = PointMass(1.0)), output = NormalWeightedMeanPrecision(0.11552928931500245, 0.2310585786300049)),
+            (input = (q_out = PointMass(0.0), q_ζ = PointMass(1.0)), output = NormalWeightedMeanPrecision(-0.11552928931500245, 0.2310585786300049))
+        ]
+    end
+end

--- a/test/rules/sigmoid/out_tests.jl
+++ b/test/rules/sigmoid/out_tests.jl
@@ -1,0 +1,19 @@
+@testitem "rules:Sigmoid:out" begin
+    using ReactiveMP, BayesBase, Random, ExponentialFamily, Distributions
+    using StatsFuns: logistic
+
+    import ReactiveMP: @test_rules
+
+    @testset "Mean Field: (q_in::UnivariateNormalDistributionsFamily, q_ζ::PointMass)" begin
+        q_in = [NormalMeanVariance(0.0, 1.0), NormalMeanVariance(-1.0, 1.0), NormalMeanVariance(10.0, 1.0)]
+        results = [[0.5, 0.5], [0.2689414213699951, 0.7310585786300049], [0.9999546021312976, 4.5397868702390376e-5]]
+        for (i, result) in enumerate(results)
+            for normal_fam in (NormalMeanVariance, NormalMeanPrecision, NormalWeightedMeanPrecision)
+                q_in_adj = convert(normal_fam, q_in[i])
+                @test_rules [check_type_promotion = true, atol = [Float64 => 1e-5]] Sigmoid(:out, Marginalisation) [(
+                    input = (q_in = q_in_adj, q_ζ = PointMass(2.0)), output = Categorical(result)
+                )]
+            end
+        end
+    end
+end

--- a/test/rules/sigmoid/zeta_tests.jl
+++ b/test/rules/sigmoid/zeta_tests.jl
@@ -1,0 +1,19 @@
+@testitem "rules:Sigmoid:zeta" begin
+    using ReactiveMP, BayesBase, Random, ExponentialFamily, Distributions
+    using StatsFuns: logistic
+
+    import ReactiveMP: @test_rules
+
+    @testset "Mean Field: (q_out::Any, q_in::UnivariateNormalDistributionsFamily)" begin
+        q_in = [NormalMeanVariance(0.0, 1.0), NormalMeanVariance(-1.0, 1.0), NormalMeanVariance(10.0, 1.0)]
+        results = [1.0, 1.4142135623730951, 10.04987562112089]
+        for (i, result) in enumerate(results)
+            for normal_fam in (NormalMeanVariance, NormalMeanPrecision, NormalWeightedMeanPrecision)
+                q_in_adj = convert(normal_fam, q_in[i])
+                @test_rules [check_type_promotion = false, atol = [Float64 => 1e-5]] Sigmoid(:ζ, Marginalisation) [(
+                    input = (q_out = 2.0, q_in = q_in_adj), output = PointMass(result)
+                )]
+            end
+        end
+    end
+end


### PR DESCRIPTION
Add Jaakkola-Jordan Lower Bound Implementation for Sigmoid Node

This PR implements the Jaakkola-Jordan lower bound approximation for the sigmoid function as described in Bishop's "Pattern Recognition and Machine Learning" (PRML). 

**New Sigmoid Node Implementation:**

- Added a new `Sigmoid` node with three interfaces: `out`, `in`, and `ζ` (zeta)
- Implemented the Jaakkola-Jordan lower bound using a variational parameter `ζ`
- Added corresponding average energy computation for the sigmoid node

**Updated Message Passing Rules:**

- **`ζ` (zeta) rule**: Computes the optimal variational parameter as `ζ = √(μ² + σ²)` where μ and σ are the mean and standard deviation of the input
-  **`in` rule**: Updated to handle both `Categorical` and `PointMass` output distributions, computing weighted mean and precision using the Jaakkola-Jordan approximation
- **`out` rule**: Computes the output categorical distribution using the logistic function with the variational parameter

**Mathematical Foundation:**
- The lower bound uses: `σ(x) ≥ σ(ζ) * exp((x-ζ)/2 - λ(ζ)(x²-ζ²))`
- Where `λ(ζ) = (σ(ζ) - 0.5)/(2ζ)` and `σ(ζ)` is the logistic function
- The optimal `ζ` is computed as `ζ = √(μ² + σ²)` for maximum bound tightness