### PR TITLE
Robust invS in outgoing Λ-rule of MvNormalMeanPrecision-node

### DIFF
--- a/src/rules/mv_normal_mean_precision/precision.jl
+++ b/src/rules/mv_normal_mean_precision/precision.jl
@@ -1,25 +1,24 @@
 # Variational                       # 
 # --------------------------------- #
-@rule MvNormalMeanPrecision(:Λ, Marginalisation) (q_out::Any, q_μ::Any) = begin
+@rule MvNormalMeanPrecision(:Λ, Marginalisation) (q_out::Any, q_μ::Any, meta::Union{<:AbstractCorrectionStrategy, Nothing}) = begin
     m_out, v_out   = mean_cov(q_out)
     m_mean, v_mean = mean_cov(q_μ)
     d = ndims(q_μ)
 
     df   = d + 2
-    invS_raw = v_mean + v_out + (m_mean - m_out) * (m_mean - m_out)'
-    invS = invS_raw + 1e-6 * diagm(ones(d))
+    invS = correction!(meta, v_mean + v_out + (m_mean - m_out) * (m_mean - m_out)')
     
     return WishartFast(df, invS)
 end
 
-@rule MvNormalMeanPrecision(:Λ, Marginalisation) (q_out_μ::Any,) = begin
+@rule MvNormalMeanPrecision(:Λ, Marginalisation) (q_out_μ::Any, meta::Union{<:AbstractCorrectionStrategy, Nothing}) = begin
     m_out_μ, v_out_μ = mean_cov(q_out_μ)
 
     d = div(ndims(q_out_μ), 2)
 
     mdiff = @views m_out_μ[1:d] - m_out_μ[(d + 1):end]
     vdiff = @views v_out_μ[1:d, 1:d] - v_out_μ[1:d, (d + 1):end] - v_out_μ[(d + 1):end, 1:d] + v_out_μ[(d + 1):end, (d + 1):end]
-    invS  = vdiff + mdiff * mdiff'
+    invS  = correction!(meta, vdiff + mdiff * mdiff')
 
     return WishartFast(d + 2, invS)
 end


### PR DESCRIPTION
I stumbled upon this small edge case during inference. check if you think it is helpful, inference also worked without it, but i thought it might add more stability.
### Description
when the incoming messages ($q_{\text{out}}$ and $q_{\mu}$) are identical point masses, the invS became a singularity, **zero matrix**, leading to an **undefined Wishart distribution**.
To prevent this, this PR introduces a small regularization term ($\epsilon \mathbf{I}$) to the calculation of the inverse scale matrix ($\mathbf{invS}$) in the $\mathbf{\Lambda}$ VMP update.
### Changes

The `invS` calculation now adds $10^{-6}$ times the identity matrix ($\mathbf{I}$) for robustness.

```julia
invS_raw = v_mean + v_out + (m_mean - m_out) * (m_mean - m_out)'
invS = invS_raw + 1e-6 * diagm(ones(D))
```

This regularization **guarantees $\mathbf{invS}$ is positive definite**, ensuring the resulting Wishart distribution for the precision matrix is always proper.