### PR TITLE
#538 Allow for different numeric types for GammaShapeLikelihood

### DIFF
--- a/src/nodes/predefined/gamma_mixture.jl
+++ b/src/nodes/predefined/gamma_mixture.jl
@@ -189,7 +189,7 @@ Distributions.params(distribution::GammaShapeLikelihood) = (distribution.p, dist
 
 Distributions.@distr_support GammaShapeLikelihood 0.0 Inf
 
-BayesBase.support(distribution::GammaShapeLikelihood{T}) where {T} = Distributions.RealInterval(zero(T), T(Inf))
+BayesBase.support(distribution::GammaShapeLikelihood{T}) where {T} = Distributions.RealInterval(zero(T), typemax(T))
 
 BayesBase.logpdf(distribution::GammaShapeLikelihood{T}, x::Real) where {T} = distribution.γ * x - distribution.p * loggamma(x)
 


### PR DESCRIPTION
Should resolve #538 