### PR TITLE
541 missing average energy for mixture node

### DIFF
--- a/src/nodes/predefined/mixture.jl
+++ b/src/nodes/predefined/mixture.jl
@@ -208,4 +208,3 @@ end
     """
     return 0.0
 end
-


### PR DESCRIPTION
Should resolve #541 

The Mixture node performs model comparison via scale factors, so its contribution to the Bethe Free Energy (BFE) is not well-defined.
To avoid runtime errors and make BFE computations robust, we now define a placeholder @average_energy method for Mixture that:

* emits a clear warning,
* returns 0.0 as a safe default.

This ensures that global BFE evaluation does not fail when mixtures are present, while still alerting users that the term is undefined conceptually.