### PR TITLE
Fix bug average energy of Uninformative type

### DIFF
--- a/src/nodes/predefined/uninformative.jl
+++ b/src/nodes/predefined/uninformative.jl
@@ -4,7 +4,7 @@ struct Uninformative end
 
 @node Uninformative Stochastic [out]
 
-@average_energy Uninformative (q_out::Any,) = entropy(q_out)
+@average_energy Uninformative (q_out::Any,) = zero(paramfloattype(q_out))
 
 function BayesBase.default_prod_rule(::Type{<:Uninformative}, ::Type{T}) where {T}
     return PreserveTypeProd(T)


### PR DESCRIPTION
Fixing  small bug thanks to @wouterwln in the average energy computation on the uninformative mode. 