### PR TITLE
Trace ID to link before and after events

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReactiveMP"
 uuid = "a194aa59-28ba-4574-a09c-4a745416d6e3"
-version = "5.6.6"
 authors = ["Dmitry Bagaev <d.v.bagaev@tue.nl>", "Albert Podusenko <a.podusenko@tue.nl>", "Bart van Erp <b.v.erp@tue.nl>", "Ismail Senoz <i.senoz@tue.nl>"]
+version = "5.6.6"
 
 [deps]
 BayesBase = "b4ee3484-f114-42fe-b91c-797d54a0c67e"
@@ -30,6 +30,7 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 TinyHugeNumbers = "783c9a47-75a3-44ac-a16b-f1ab7b3acf04"
 Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [weakdeps]
 ExponentialFamilyProjection = "17f509fa-9a96-44ba-99b2-1c5f01f0931b"
@@ -68,6 +69,7 @@ StatsFuns = "1.3.0"
 TinyHugeNumbers = "1.0.0"
 Tullio = "0.3"
 TupleTools = "1.2.0"
+UUIDs = "1"
 julia = "1.10"
 
 [extras]
@@ -87,9 +89,9 @@ Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
-TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
 test = ["Aqua", "TestItemRunner", "Test", "Pkg", "Logging", "InteractiveUtils", "Coverage", "Dates", "Distributed", "Documenter", "BenchmarkTools", "JET", "PkgBenchmark", "StableRNGs", "Optimisers", "DiffResults", "ExponentialFamilyProjection", "REPL", "Manopt"]

--- a/src/ReactiveMP.jl
+++ b/src/ReactiveMP.jl
@@ -4,6 +4,7 @@ module ReactiveMP
 # List global dependencies here
 using TinyHugeNumbers, MatrixCorrectionTools, FastCholesky, LinearAlgebra
 using BayesBase, ExponentialFamily
+using UUIDs
 
 import MatrixCorrectionTools: AbstractCorrectionStrategy, correction!
 

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -176,6 +176,7 @@ This event fires right before computing the message and calling the correspondin
 - `mapping`: of type [`ReactiveMP.MessageMapping`](@ref), contains information about the node type, etc
 - `messages`: typically of type `Tuple` if present, `nothing` otherwise
 - `marginals`: typically of type `Tuple` if present, `nothing` otherwise
+- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.AfterMessageRuleCallEvent`](@ref)
 
 See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterMessageRuleCallEvent`](@ref)
 """
@@ -183,6 +184,7 @@ struct BeforeMessageRuleCallEvent{M, Ms, Mr} <: Event{:before_message_rule_call}
     mapping::M
     messages::Ms
     marginals::Mr
+    trace_id::UUID
 end
 
 """
@@ -196,6 +198,7 @@ This event fires right after computing the message and calling the corresponding
 - `marginals`: typically of type `Tuple` if present, `nothing` otherwise
 - `result`: the result of the rule invocation (or `rulefallback`), can be any type
 - `addons`: the result of the addons invocation, if present, can be any type
+- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.BeforeMessageRuleCallEvent`](@ref)
 
 See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeMessageRuleCallEvent`](@ref)
 """
@@ -205,6 +208,7 @@ struct AfterMessageRuleCallEvent{M, Ms, Mr, R, A} <: Event{:after_message_rule_c
     marginals::Mr
     result::R
     addons::A
+    trace_id::UUID
 end
 
 """
@@ -217,6 +221,7 @@ This event fires right before computing the product of two messages.
 - `context`: of type [`ReactiveMP.MessageProductContext`](@ref)
 - `left`: of type [`ReactiveMP.Message`](@ref), the left-hand side message in the product
 - `right`: of type [`ReactiveMP.Message`](@ref), the right-hand side message in the product
+- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.AfterProductOfTwoMessagesEvent`](@ref)
 
 See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterProductOfTwoMessagesEvent`](@ref)
 """
@@ -225,6 +230,7 @@ struct BeforeProductOfTwoMessagesEvent{V, C, L, R} <: Event{:before_product_of_t
     context::C
     left::L
     right::R
+    trace_id::UUID
 end
 
 """
@@ -239,6 +245,7 @@ This event fires right after computing the product of two messages.
 - `right`: of type [`ReactiveMP.Message`](@ref), the right-hand side message in the product
 - `result`: of type [`ReactiveMP.Message`](@ref), the resulting message from the product
 - `addons`: the computed addons for the result (can be `nothing`)
+- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.BeforeProductOfTwoMessagesEvent`](@ref)
 
 See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeProductOfTwoMessagesEvent`](@ref)
 """
@@ -249,6 +256,7 @@ struct AfterProductOfTwoMessagesEvent{V, C, L, R, Rs, A} <: Event{:after_product
     right::R
     result::Rs
     addons::A
+    trace_id::UUID
 end
 
 """
@@ -261,6 +269,7 @@ This event fires right before computing the product of a collection of messages
 - `variable`: of type [`ReactiveMP.AbstractVariable`](@ref)
 - `context`: of type [`ReactiveMP.MessageProductContext`](@ref)
 - `messages`: the collection of messages to be multiplied
+- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.AfterProductOfMessagesEvent`](@ref)
 
 See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterProductOfMessagesEvent`](@ref)
 """
@@ -268,6 +277,7 @@ struct BeforeProductOfMessagesEvent{V, C, Ms} <: Event{:before_product_of_messag
     variable::V
     context::C
     messages::Ms
+    trace_id::UUID
 end
 
 """
@@ -281,6 +291,7 @@ This event fires right after computing the product of a collection of messages
 - `context`: of type [`ReactiveMP.MessageProductContext`](@ref)
 - `messages`: the original collection of messages that were multiplied
 - `result`: of type [`ReactiveMP.Message`](@ref), the final result after folding and form constraint application
+- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.BeforeProductOfMessagesEvent`](@ref)
 
 See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeProductOfMessagesEvent`](@ref)
 """
@@ -289,6 +300,7 @@ struct AfterProductOfMessagesEvent{V, C, Ms, R} <: Event{:after_product_of_messa
     context::C
     messages::Ms
     result::R
+    trace_id::UUID
 end
 
 """
@@ -302,6 +314,7 @@ Fires in both [`ReactiveMP.FormConstraintCheckEach`](@ref) and [`ReactiveMP.Form
 - `context`: of type [`ReactiveMP.MessageProductContext`](@ref)
 - `strategy`: the form constraint check strategy being used (e.g. [`ReactiveMP.FormConstraintCheckEach`](@ref) or [`ReactiveMP.FormConstraintCheckLast`](@ref))
 - `distribution`: the distribution about to be constrained
+- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.AfterFormConstraintAppliedEvent`](@ref)
 
 See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterFormConstraintAppliedEvent`](@ref)
 """
@@ -310,6 +323,7 @@ struct BeforeFormConstraintAppliedEvent{V, C, S, D} <: Event{:before_form_constr
     context::C
     strategy::S
     distribution::D
+    trace_id::UUID
 end
 
 """
@@ -324,6 +338,7 @@ Fires in both [`ReactiveMP.FormConstraintCheckEach`](@ref) and [`ReactiveMP.Form
 - `strategy`: the form constraint check strategy being used (e.g. [`ReactiveMP.FormConstraintCheckEach`](@ref) or [`ReactiveMP.FormConstraintCheckLast`](@ref))
 - `distribution`: the distribution before the constraint was applied
 - `result`: the distribution after the constraint was applied
+- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.BeforeFormConstraintAppliedEvent`](@ref)
 
 See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeFormConstraintAppliedEvent`](@ref)
 """
@@ -333,6 +348,7 @@ struct AfterFormConstraintAppliedEvent{V, C, S, D, R} <: Event{:after_form_const
     strategy::S
     distribution::D
     result::R
+    trace_id::UUID
 end
 
 """
@@ -344,6 +360,7 @@ This event fires right before computing the marginal for a [`ReactiveMP.RandomVa
 - `variable`: of type [`ReactiveMP.RandomVariable`](@ref)
 - `context`: of type [`ReactiveMP.MessageProductContext`](@ref)
 - `messages`: the collection of incoming messages used to compute the marginal
+- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.AfterMarginalComputationEvent`](@ref)
 
 See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterMarginalComputationEvent`](@ref)
 """
@@ -351,6 +368,7 @@ struct BeforeMarginalComputationEvent{V, C, Ms} <: Event{:before_marginal_comput
     variable::V
     context::C
     messages::Ms
+    trace_id::UUID
 end
 
 """
@@ -362,6 +380,7 @@ This event fires right after computing the marginal for a [`ReactiveMP.RandomVar
 - `variable`: of type [`ReactiveMP.RandomVariable`](@ref)
 - `context`: of type [`ReactiveMP.MessageProductContext`](@ref)
 - `messages`: the collection of incoming messages used to compute the marginal
+- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.BeforeMarginalComputationEvent`](@ref)
 - `result`: the computed marginal
 
 See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeMarginalComputationEvent`](@ref)
@@ -370,5 +389,6 @@ struct AfterMarginalComputationEvent{V, C, Ms, R} <: Event{:after_marginal_compu
     variable::V
     context::C
     messages::Ms
+    trace_id::UUID
     result::R
 end

--- a/src/message.jl
+++ b/src/message.jl
@@ -163,9 +163,10 @@ function compute_product_of_two_messages(
     left::Message,
     right::Message,
 )
+    trace_id = uuid4()
     invoke_callback(
         context.callbacks,
-        BeforeProductOfTwoMessagesEvent(variable, context, left, right),
+        BeforeProductOfTwoMessagesEvent(variable, context, left, right, trace_id),
     )
 
     # We propagate clamped message, in case if both are clamped
@@ -182,10 +183,11 @@ function compute_product_of_two_messages(
     new_dist   = prod(context.prod_constraint, left_dist, right_dist)
 
     if context.form_constraint_check_strategy === FormConstraintCheckEach()
+        form_trace_id = uuid4()
         invoke_callback(
             context.callbacks,
             BeforeFormConstraintAppliedEvent(
-                variable, context, FormConstraintCheckEach(), new_dist
+                variable, context, FormConstraintCheckEach(), new_dist, form_trace_id
             ),
         )
         unconstrained_dist = new_dist
@@ -193,7 +195,7 @@ function compute_product_of_two_messages(
         invoke_callback(
             context.callbacks,
             AfterFormConstraintAppliedEvent(
-                variable, context, FormConstraintCheckEach(), unconstrained_dist, new_dist
+                variable, context, FormConstraintCheckEach(), unconstrained_dist, new_dist, form_trace_id
             ),
         )
     end
@@ -211,7 +213,7 @@ function compute_product_of_two_messages(
     invoke_callback(
         context.callbacks,
         AfterProductOfTwoMessagesEvent(
-            variable, context, left, right, result, new_addons
+            variable, context, left, right, result, new_addons, trace_id
         ),
     )
 
@@ -237,9 +239,10 @@ See also: [`ReactiveMP.compute_product_of_two_messages`](@ref), [`ReactiveMP.Mes
 function compute_product_of_messages(
     variable::AbstractVariable, context::MessageProductContext, messages
 )
+    trace_id = uuid4()
     invoke_callback(
         context.callbacks,
-        BeforeProductOfMessagesEvent(variable, context, messages),
+        BeforeProductOfMessagesEvent(variable, context, messages, trace_id),
     )
 
     result = as_message(
@@ -250,17 +253,18 @@ function compute_product_of_messages(
 
     if context.form_constraint_check_strategy === FormConstraintCheckLast()
         dist = getdata(result)
+        form_trace_id = uuid4()
         invoke_callback(
             context.callbacks,
             BeforeFormConstraintAppliedEvent(
-                variable, context, FormConstraintCheckLast(), dist
+                variable, context, FormConstraintCheckLast(), dist, form_trace_id
             ),
         )
         constrained_dist = constrain_form(context.form_constraint, dist)
         invoke_callback(
             context.callbacks,
             AfterFormConstraintAppliedEvent(
-                variable, context, FormConstraintCheckLast(), dist, constrained_dist
+                variable, context, FormConstraintCheckLast(), dist, constrained_dist, form_trace_id
             ),
         )
         result = Message(
@@ -273,7 +277,7 @@ function compute_product_of_messages(
 
     invoke_callback(
         context.callbacks,
-        AfterProductOfMessagesEvent(variable, context, messages, result),
+        AfterProductOfMessagesEvent(variable, context, messages, result, trace_id),
     )
 
     return result
@@ -619,9 +623,10 @@ function (mapping::MessageMapping)(messages, marginals)
             __check_all(is_clamped_or_initial, marginals)
         )
 
+    trace_id = uuid4()
     invoke_callback(
         mapping.callbacks,
-        BeforeMessageRuleCallEvent(mapping, messages, marginals),
+        BeforeMessageRuleCallEvent(mapping, messages, marginals, trace_id),
     )
     result, addons =
         if !isnothing(messages) &&
@@ -663,7 +668,7 @@ function (mapping::MessageMapping)(messages, marginals)
     )
     invoke_callback(
         mapping.callbacks,
-        AfterMessageRuleCallEvent(mapping, messages, marginals, result, addons),
+        AfterMessageRuleCallEvent(mapping, messages, marginals, result, addons, trace_id),
     )
 
     return Message(result, is_message_clamped, is_message_initial, addons)

--- a/src/variables/random.jl
+++ b/src/variables/random.jl
@@ -115,17 +115,18 @@ function _compute_marginal_from_messages(
     options::RandomVariableActivationOptions,
     messages,
 )
+    trace_id = uuid4()
     context = options.prod_context_for_marginal_computation
     invoke_callback(
         context.callbacks,
-        BeforeMarginalComputationEvent(randomvar, context, messages),
+        BeforeMarginalComputationEvent(randomvar, context, messages, trace_id),
     )
     result = as_marginal(
         compute_product_of_messages(randomvar, context, messages)
     )
     invoke_callback(
         context.callbacks,
-        AfterMarginalComputationEvent(randomvar, context, messages, result),
+        AfterMarginalComputationEvent(randomvar, context, messages, trace_id, result),
     )
     return result
 end

--- a/test/callbacks_tests.jl
+++ b/test/callbacks_tests.jl
@@ -97,33 +97,35 @@ end
     @test @allocated(bar4(callback_handler)) === 0
     
     
-    # Test that trace_id does not cause allocations
-    struct BeforeSuperCoolEvent <: Event{:my_custom_event_243}
-        trace_id::UUID
-    end
-    struct AfterSuperCoolEvent <: Event{:my_custom_event_534}
-        result::Float64
-        trace_id::UUID
-    end
-    
-    function bar5(callback_handler, input::Float64)
-        trace_id = uuid4()
+    if VERSION >= v"1.12.0"
+        # Test that trace_id does not cause allocations
+        struct BeforeSuperCoolEvent <: Event{:my_custom_event_243}
+            trace_id::UUID
+        end
+        struct AfterSuperCoolEvent <: Event{:my_custom_event_534}
+            result::Float64
+            trace_id::UUID
+        end
         
-        invoke_callback(callback_handler,
-            BeforeSuperCoolEvent(trace_id)
-        )
-        
-        result = input + 4.0
-        
-        invoke_callback(callback_handler,
-            AfterSuperCoolEvent(result, trace_id)
-        )
-        
-        return result
-    end
+        function bar5(callback_handler, input::Float64)
+            trace_id = uuid4()
+            
+            invoke_callback(callback_handler,
+                BeforeSuperCoolEvent(trace_id)
+            )
+            
+            result = input + 4.0
+            
+            invoke_callback(callback_handler,
+                AfterSuperCoolEvent(result, trace_id)
+            )
+            
+            return result
+        end
 
-    @test bar5(callback_handler, 9.0) == 13.0
-    @test @allocated(bar5(callback_handler, 9.0)) === 0
+        @test bar5(callback_handler, 9.0) == 13.0
+        @test @allocated(bar5(callback_handler, 9.0)) === 0
+    end
     
 end
 

--- a/test/callbacks_tests.jl
+++ b/test/callbacks_tests.jl
@@ -25,6 +25,7 @@ end
     CallbacksTestUtils
 ] begin
     import ReactiveMP: invoke_callback, Event
+    using UUIDs
 
     # We use here a type stable structure to achieve 0 allocations
     struct MyCustomEvent{T} <: Event{:my_custom_event}
@@ -92,6 +93,37 @@ end
     bar4(callback_handler)
 
     @test @allocated(bar4(callback_handler)) === 0
+    
+    
+    
+    # Test that trace_id does not cause allocations
+    struct BeforeSuperCoolEvent <: Event{:my_custom_event_243}
+        trace_id::UUID
+    end
+    struct AfterSuperCoolEvent <: Event{:my_custom_event_534}
+        result::Float64
+        trace_id::UUID
+    end
+    
+    function bar5(callback_handler, input::Float64)
+        trace_id = uuid4()
+        
+        invoke_callback(callback_handler,
+            BeforeSuperCoolEvent(trace_id)
+        )
+        
+        result = sqrt(input)
+        
+        invoke_callback(callback_handler,
+            AfterSuperCoolEvent(result, trace_id)
+        )
+        
+        return result
+    end
+
+    @test bar5(callback_handler, 9.0) == 3.0
+
+    @test @allocated(bar5(callback_handler, 9.0)) === 0
 end
 
 @testitem "invoke_callback should return the event" setup = [

--- a/test/callbacks_tests.jl
+++ b/test/callbacks_tests.jl
@@ -97,35 +97,33 @@ end
     @test @allocated(bar4(callback_handler)) === 0
     
     
-    if VERSION >= v"1.12.0"
-        # Test that trace_id does not cause allocations
-        struct BeforeSuperCoolEvent <: Event{:my_custom_event_243}
-            trace_id::UUID
-        end
-        struct AfterSuperCoolEvent <: Event{:my_custom_event_534}
-            result::Float64
-            trace_id::UUID
-        end
-        
-        function bar5(callback_handler, input::Float64)
-            trace_id = uuid4()
-            
-            invoke_callback(callback_handler,
-                BeforeSuperCoolEvent(trace_id)
-            )
-            
-            result = sqrt(input)
-            
-            invoke_callback(callback_handler,
-                AfterSuperCoolEvent(result, trace_id)
-            )
-            
-            return result
-        end
-
-        @test bar5(callback_handler, 9.0) == 3.0
-        @test @allocated(bar5(callback_handler, 9.0)) === 0
+    # Test that trace_id does not cause allocations
+    struct BeforeSuperCoolEvent <: Event{:my_custom_event_243}
+        trace_id::UUID
     end
+    struct AfterSuperCoolEvent <: Event{:my_custom_event_534}
+        result::Float64
+        trace_id::UUID
+    end
+    
+    function bar5(callback_handler, input::Float64)
+        trace_id = uuid4()
+        
+        invoke_callback(callback_handler,
+            BeforeSuperCoolEvent(trace_id)
+        )
+        
+        result = input + 4.0
+        
+        invoke_callback(callback_handler,
+            AfterSuperCoolEvent(result, trace_id)
+        )
+        
+        return result
+    end
+
+    @test bar5(callback_handler, 9.0) == 13.0
+    @test @allocated(bar5(callback_handler, 9.0)) === 0
     
 end
 

--- a/test/callbacks_tests.jl
+++ b/test/callbacks_tests.jl
@@ -48,17 +48,19 @@ end
     @test @inferred(bar(callback_handler, event)) === nothing
     @test @allocated(bar(callback_handler, event)) === 0
 
-    function bar2(callback_handler)
-        invoke_callback(
-            callback_handler, CustomEvent(:event1, 1, 2, "asd", [2])
-        )
-        return 1 + 2
+    if VERSION >= v"1.12.0"
+        function bar2(callback_handler)
+            invoke_callback(
+                callback_handler, CustomEvent(:event1, 1, 2, "asd", [2])
+            )
+            return 1 + 2
+        end
+
+        bar2(callback_handler)
+
+        @test @inferred(bar2(callback_handler)) === 3
+        @test @allocated(bar2(callback_handler)) === 0
     end
-
-    bar2(callback_handler)
-
-    @test @inferred(bar2(callback_handler)) === 3
-    @test @allocated(bar2(callback_handler)) === 0
 
     mutable struct EventWithTypeStableState <:
                    Event{:event_with_typestable_state}
@@ -95,35 +97,36 @@ end
     @test @allocated(bar4(callback_handler)) === 0
     
     
-    
-    # Test that trace_id does not cause allocations
-    struct BeforeSuperCoolEvent <: Event{:my_custom_event_243}
-        trace_id::UUID
-    end
-    struct AfterSuperCoolEvent <: Event{:my_custom_event_534}
-        result::Float64
-        trace_id::UUID
-    end
-    
-    function bar5(callback_handler, input::Float64)
-        trace_id = uuid4()
+    if VERSION >= v"1.12.0"
+        # Test that trace_id does not cause allocations
+        struct BeforeSuperCoolEvent <: Event{:my_custom_event_243}
+            trace_id::UUID
+        end
+        struct AfterSuperCoolEvent <: Event{:my_custom_event_534}
+            result::Float64
+            trace_id::UUID
+        end
         
-        invoke_callback(callback_handler,
-            BeforeSuperCoolEvent(trace_id)
-        )
-        
-        result = sqrt(input)
-        
-        invoke_callback(callback_handler,
-            AfterSuperCoolEvent(result, trace_id)
-        )
-        
-        return result
-    end
+        function bar5(callback_handler, input::Float64)
+            trace_id = uuid4()
+            
+            invoke_callback(callback_handler,
+                BeforeSuperCoolEvent(trace_id)
+            )
+            
+            result = sqrt(input)
+            
+            invoke_callback(callback_handler,
+                AfterSuperCoolEvent(result, trace_id)
+            )
+            
+            return result
+        end
 
-    @test bar5(callback_handler, 9.0) == 3.0
-
-    @test @allocated(bar5(callback_handler, 9.0)) === 0
+        @test bar5(callback_handler, 9.0) == 3.0
+        @test @allocated(bar5(callback_handler, 9.0)) === 0
+    end
+    
 end
 
 @testitem "invoke_callback should return the event" setup = [


### PR DESCRIPTION
I think it is useful to link before and after events. Here is one implementation, using a field `trace_id` added to events. This also needs to be done to the events defined in RxInfer.jl.

It works, but maybe we can do better?

# Alternative 1: `before` field in `AfterSomething` events
We can add a field `.before` that stores the counterpart of an `AfterSomething` event. Instead of `trace_id`. (Then the 'before' objectID functions the trace ID.)

# Aternative 2: `Before{...}` and `After{...}` types
We could change the types to eg:

```
Before{ProductOfMessagesEvent{V, C, Ms, R}} <: After{Event{:product_of_messages}}
```

The `After` type can have a `.result` field.


Then we can replace this:

```julia
# Before
trace_id = uuid4()
invoke_callback(
    context.callbacks,
    BeforeProductOfMessagesEvent(variable, context, messages, trace_id),
)

result = as_message(...)

invoke_callback(
    context.callbacks,
    AfterProductOfMessagesEvent(variable, context, messages, trace_id),
)
```

with:

```julia
# After
result = with_span(
	BeforeProductOfMessagesEvent(variable, context, messages, trace_id)
) do
	as_message(...)
end
```

