### PR TITLE
Better trace ids

### DIFF
--- a/docs/src/lib/callbacks.md
+++ b/docs/src/lib/callbacks.md
@@ -38,6 +38,21 @@ To see which fields an event carries, use the standard Julia introspection:
 julia> ?ReactiveMP.BeforeProductOfTwoMessagesEvent
 ```
 
+## Event spans
+
+Certain events create a "span". For example all "before" and "after" events 
+can be considered together. To track these relationships ReactiveMP uses the 
+`span_id` field in such events and uses the [`ReactiveMP.generate_span_id`](@ref)
+function to generate shared ids.
+
+```@docs 
+ReactiveMP.generate_span_id
+```
+
+Custom callbacks can overwrite the `ReactiveMP.generate_span_id` to return `nothing`
+if necessary. Note, however, that [`ReactiveMP.MergedCallbacks`](@ref) would still 
+use the default implementation.
+
 ## All defined events
 
 Here is the list of predefined event types, to which a custom callback handler can react to.

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -1,3 +1,4 @@
+using UUIDs
 
 """
     Event{E}
@@ -79,9 +80,7 @@ julia> event.count
 
 If the `NamedTuple` does not have a field corresponding to the event name, the event will be ignored.
 """
-function invoke_callback(
-    callbacks::NamedTuple{K}, event::Event{E}
-) where {K, E}
+function invoke_callback(callbacks::NamedTuple{K}, event::Event{E}) where {K, E}
     if E in K
         callbacks[E](event)
     end
@@ -165,6 +164,23 @@ function invoke_callback(merged::MergedCallbacks, event::Event)
     return event
 end
 
+"""
+    generate_span_id(callbacks)
+
+Generates a unique identifier used for "before" and "after" events (see for example [`BeforeMessageRuleCallEvent`](@ref) and [`AfterMessageRuleCallEvent]`](@ref)). If callbacks are not set (e.g. `callbacks` is `nothing`), returns `nothing`.
+
+The current implementation uses `UUIDs.uuid4` to generate span IDs, but that may change in the future.
+"""
+function generate_span_id end
+
+function generate_span_id(::Nothing)
+    return nothing
+end
+
+function generate_span_id(callbacks)
+    return uuid4()
+end
+
 # All defined events go here, so its easier to document them all in one place
 
 """
@@ -176,15 +192,16 @@ This event fires right before computing the message and calling the correspondin
 - `mapping`: of type [`ReactiveMP.MessageMapping`](@ref), contains information about the node type, etc
 - `messages`: typically of type `Tuple` if present, `nothing` otherwise
 - `marginals`: typically of type `Tuple` if present, `nothing` otherwise
-- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.AfterMessageRuleCallEvent`](@ref)
+- `span_id`: an id shared with the corresponding [`ReactiveMP.AfterMessageRuleCallEvent`](@ref)
 
-See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterMessageRuleCallEvent`](@ref)
+See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterMessageRuleCallEvent`](@ref), [`ReactiveMP.generate_span_id`](@ref)
 """
-struct BeforeMessageRuleCallEvent{M, Ms, Mr} <: Event{:before_message_rule_call}
+struct BeforeMessageRuleCallEvent{M, Ms, Mr, S} <:
+       Event{:before_message_rule_call}
     mapping::M
     messages::Ms
     marginals::Mr
-    trace_id::UUID
+    span_id::S
 end
 
 """
@@ -198,17 +215,18 @@ This event fires right after computing the message and calling the corresponding
 - `marginals`: typically of type `Tuple` if present, `nothing` otherwise
 - `result`: the result of the rule invocation (or `rulefallback`), can be any type
 - `addons`: the result of the addons invocation, if present, can be any type
-- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.BeforeMessageRuleCallEvent`](@ref)
+- `span_id`: an id shared with the corresponding [`ReactiveMP.BeforeMessageRuleCallEvent`](@ref)
 
-See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeMessageRuleCallEvent`](@ref)
+See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeMessageRuleCallEvent`](@ref), [`ReactiveMP.generate_span_id`](@ref)
 """
-struct AfterMessageRuleCallEvent{M, Ms, Mr, R, A} <: Event{:after_message_rule_call}
+struct AfterMessageRuleCallEvent{M, Ms, Mr, R, A, S} <:
+       Event{:after_message_rule_call}
     mapping::M
     messages::Ms
     marginals::Mr
     result::R
     addons::A
-    trace_id::UUID
+    span_id::S
 end
 
 """
@@ -221,16 +239,17 @@ This event fires right before computing the product of two messages.
 - `context`: of type [`ReactiveMP.MessageProductContext`](@ref)
 - `left`: of type [`ReactiveMP.Message`](@ref), the left-hand side message in the product
 - `right`: of type [`ReactiveMP.Message`](@ref), the right-hand side message in the product
-- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.AfterProductOfTwoMessagesEvent`](@ref)
+- `span_id`: an id shared with the corresponding [`ReactiveMP.AfterProductOfTwoMessagesEvent`](@ref)
 
-See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterProductOfTwoMessagesEvent`](@ref)
+See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterProductOfTwoMessagesEvent`](@ref), [`ReactiveMP.generate_span_id`](@ref)
 """
-struct BeforeProductOfTwoMessagesEvent{V, C, L, R} <: Event{:before_product_of_two_messages}
+struct BeforeProductOfTwoMessagesEvent{V, C, L, R, S} <:
+       Event{:before_product_of_two_messages}
     variable::V
     context::C
     left::L
     right::R
-    trace_id::UUID
+    span_id::S
 end
 
 """
@@ -245,18 +264,19 @@ This event fires right after computing the product of two messages.
 - `right`: of type [`ReactiveMP.Message`](@ref), the right-hand side message in the product
 - `result`: of type [`ReactiveMP.Message`](@ref), the resulting message from the product
 - `addons`: the computed addons for the result (can be `nothing`)
-- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.BeforeProductOfTwoMessagesEvent`](@ref)
+- `span_id`: an id shared with the corresponding [`ReactiveMP.BeforeProductOfTwoMessagesEvent`](@ref)
 
-See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeProductOfTwoMessagesEvent`](@ref)
+See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeProductOfTwoMessagesEvent`](@ref), [`ReactiveMP.generate_span_id`](@ref)
 """
-struct AfterProductOfTwoMessagesEvent{V, C, L, R, Rs, A} <: Event{:after_product_of_two_messages}
+struct AfterProductOfTwoMessagesEvent{V, C, L, R, Rs, A, S} <:
+       Event{:after_product_of_two_messages}
     variable::V
     context::C
     left::L
     right::R
     result::Rs
     addons::A
-    trace_id::UUID
+    span_id::S
 end
 
 """
@@ -269,15 +289,16 @@ This event fires right before computing the product of a collection of messages
 - `variable`: of type [`ReactiveMP.AbstractVariable`](@ref)
 - `context`: of type [`ReactiveMP.MessageProductContext`](@ref)
 - `messages`: the collection of messages to be multiplied
-- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.AfterProductOfMessagesEvent`](@ref)
+- `span_id`: an id shared with the corresponding [`ReactiveMP.AfterProductOfMessagesEvent`](@ref)
 
-See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterProductOfMessagesEvent`](@ref)
+See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterProductOfMessagesEvent`](@ref), [`ReactiveMP.generate_span_id`](@ref)
 """
-struct BeforeProductOfMessagesEvent{V, C, Ms} <: Event{:before_product_of_messages}
+struct BeforeProductOfMessagesEvent{V, C, Ms, S} <:
+       Event{:before_product_of_messages}
     variable::V
     context::C
     messages::Ms
-    trace_id::UUID
+    span_id::S
 end
 
 """
@@ -291,16 +312,17 @@ This event fires right after computing the product of a collection of messages
 - `context`: of type [`ReactiveMP.MessageProductContext`](@ref)
 - `messages`: the original collection of messages that were multiplied
 - `result`: of type [`ReactiveMP.Message`](@ref), the final result after folding and form constraint application
-- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.BeforeProductOfMessagesEvent`](@ref)
+- `span_id`: an id shared with the corresponding [`ReactiveMP.BeforeProductOfMessagesEvent`](@ref)
 
-See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeProductOfMessagesEvent`](@ref)
+See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeProductOfMessagesEvent`](@ref), [`ReactiveMP.generate_span_id`](@ref)
 """
-struct AfterProductOfMessagesEvent{V, C, Ms, R} <: Event{:after_product_of_messages}
+struct AfterProductOfMessagesEvent{V, C, Ms, R, S} <:
+       Event{:after_product_of_messages}
     variable::V
     context::C
     messages::Ms
     result::R
-    trace_id::UUID
+    span_id::S
 end
 
 """
@@ -314,16 +336,17 @@ Fires in both [`ReactiveMP.FormConstraintCheckEach`](@ref) and [`ReactiveMP.Form
 - `context`: of type [`ReactiveMP.MessageProductContext`](@ref)
 - `strategy`: the form constraint check strategy being used (e.g. [`ReactiveMP.FormConstraintCheckEach`](@ref) or [`ReactiveMP.FormConstraintCheckLast`](@ref))
 - `distribution`: the distribution about to be constrained
-- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.AfterFormConstraintAppliedEvent`](@ref)
+- `span_id`: an id shared with the corresponding [`ReactiveMP.AfterFormConstraintAppliedEvent`](@ref)
 
-See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterFormConstraintAppliedEvent`](@ref)
+See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterFormConstraintAppliedEvent`](@ref), [`ReactiveMP.generate_span_id`](@ref)
 """
-struct BeforeFormConstraintAppliedEvent{V, C, S, D} <: Event{:before_form_constraint_applied}
+struct BeforeFormConstraintAppliedEvent{V, C, S, D, I} <:
+       Event{:before_form_constraint_applied}
     variable::V
     context::C
     strategy::S
     distribution::D
-    trace_id::UUID
+    span_id::I
 end
 
 """
@@ -338,17 +361,18 @@ Fires in both [`ReactiveMP.FormConstraintCheckEach`](@ref) and [`ReactiveMP.Form
 - `strategy`: the form constraint check strategy being used (e.g. [`ReactiveMP.FormConstraintCheckEach`](@ref) or [`ReactiveMP.FormConstraintCheckLast`](@ref))
 - `distribution`: the distribution before the constraint was applied
 - `result`: the distribution after the constraint was applied
-- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.BeforeFormConstraintAppliedEvent`](@ref)
+- `span_id`: an id shared with the corresponding [`ReactiveMP.BeforeFormConstraintAppliedEvent`](@ref)
 
-See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeFormConstraintAppliedEvent`](@ref)
+See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeFormConstraintAppliedEvent`](@ref), [`ReactiveMP.generate_span_id`](@ref)
 """
-struct AfterFormConstraintAppliedEvent{V, C, S, D, R} <: Event{:after_form_constraint_applied}
+struct AfterFormConstraintAppliedEvent{V, C, S, D, R, I} <:
+       Event{:after_form_constraint_applied}
     variable::V
     context::C
     strategy::S
     distribution::D
     result::R
-    trace_id::UUID
+    span_id::I
 end
 
 """
@@ -360,15 +384,16 @@ This event fires right before computing the marginal for a [`ReactiveMP.RandomVa
 - `variable`: of type [`ReactiveMP.RandomVariable`](@ref)
 - `context`: of type [`ReactiveMP.MessageProductContext`](@ref)
 - `messages`: the collection of incoming messages used to compute the marginal
-- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.AfterMarginalComputationEvent`](@ref)
+- `span_id`: an id shared with the corresponding [`ReactiveMP.AfterMarginalComputationEvent`](@ref)
 
-See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterMarginalComputationEvent`](@ref)
+See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.AfterMarginalComputationEvent`](@ref), [`ReactiveMP.generate_span_id`](@ref)
 """
-struct BeforeMarginalComputationEvent{V, C, Ms} <: Event{:before_marginal_computation}
+struct BeforeMarginalComputationEvent{V, C, Ms, S} <:
+       Event{:before_marginal_computation}
     variable::V
     context::C
     messages::Ms
-    trace_id::UUID
+    span_id::S
 end
 
 """
@@ -380,15 +405,16 @@ This event fires right after computing the marginal for a [`ReactiveMP.RandomVar
 - `variable`: of type [`ReactiveMP.RandomVariable`](@ref)
 - `context`: of type [`ReactiveMP.MessageProductContext`](@ref)
 - `messages`: the collection of incoming messages used to compute the marginal
-- `trace_id`: a `UUID` shared with the corresponding [`ReactiveMP.BeforeMarginalComputationEvent`](@ref)
+- `span_id`: an id shared with the corresponding [`ReactiveMP.BeforeMarginalComputationEvent`](@ref)
 - `result`: the computed marginal
 
-See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeMarginalComputationEvent`](@ref)
+See also: [`ReactiveMP.invoke_callback`](@ref), [`ReactiveMP.BeforeMarginalComputationEvent`](@ref), [`ReactiveMP.generate_span_id`](@ref)
 """
-struct AfterMarginalComputationEvent{V, C, Ms, R} <: Event{:after_marginal_computation}
+struct AfterMarginalComputationEvent{V, C, Ms, R, S} <:
+       Event{:after_marginal_computation}
     variable::V
     context::C
     messages::Ms
-    trace_id::UUID
     result::R
+    span_id::S
 end

--- a/src/message.jl
+++ b/src/message.jl
@@ -166,7 +166,9 @@ function compute_product_of_two_messages(
     span_id = generate_span_id(context.callbacks)
     invoke_callback(
         context.callbacks,
-        BeforeProductOfTwoMessagesEvent(variable, context, left, right, span_id),
+        BeforeProductOfTwoMessagesEvent(
+            variable, context, left, right, span_id
+        ),
     )
 
     # We propagate clamped message, in case if both are clamped
@@ -187,7 +189,11 @@ function compute_product_of_two_messages(
         invoke_callback(
             context.callbacks,
             BeforeFormConstraintAppliedEvent(
-                variable, context, FormConstraintCheckEach(), new_dist, form_span_id
+                variable,
+                context,
+                FormConstraintCheckEach(),
+                new_dist,
+                form_span_id,
             ),
         )
         unconstrained_dist = new_dist
@@ -195,7 +201,12 @@ function compute_product_of_two_messages(
         invoke_callback(
             context.callbacks,
             AfterFormConstraintAppliedEvent(
-                variable, context, FormConstraintCheckEach(), unconstrained_dist, new_dist, form_span_id
+                variable,
+                context,
+                FormConstraintCheckEach(),
+                unconstrained_dist,
+                new_dist,
+                form_span_id,
             ),
         )
     end
@@ -264,7 +275,12 @@ function compute_product_of_messages(
         invoke_callback(
             context.callbacks,
             AfterFormConstraintAppliedEvent(
-                variable, context, FormConstraintCheckLast(), dist, constrained_dist, form_span_id
+                variable,
+                context,
+                FormConstraintCheckLast(),
+                dist,
+                constrained_dist,
+                form_span_id,
             ),
         )
         result = Message(
@@ -277,7 +293,9 @@ function compute_product_of_messages(
 
     invoke_callback(
         context.callbacks,
-        AfterProductOfMessagesEvent(variable, context, messages, result, span_id),
+        AfterProductOfMessagesEvent(
+            variable, context, messages, result, span_id
+        ),
     )
 
     return result
@@ -668,7 +686,9 @@ function (mapping::MessageMapping)(messages, marginals)
     )
     invoke_callback(
         mapping.callbacks,
-        AfterMessageRuleCallEvent(mapping, messages, marginals, result, addons, span_id),
+        AfterMessageRuleCallEvent(
+            mapping, messages, marginals, result, addons, span_id
+        ),
     )
 
     return Message(result, is_message_clamped, is_message_initial, addons)

--- a/src/message.jl
+++ b/src/message.jl
@@ -163,10 +163,10 @@ function compute_product_of_two_messages(
     left::Message,
     right::Message,
 )
-    trace_id = uuid4()
+    span_id = generate_span_id(context.callbacks)
     invoke_callback(
         context.callbacks,
-        BeforeProductOfTwoMessagesEvent(variable, context, left, right, trace_id),
+        BeforeProductOfTwoMessagesEvent(variable, context, left, right, span_id),
     )
 
     # We propagate clamped message, in case if both are clamped
@@ -183,11 +183,11 @@ function compute_product_of_two_messages(
     new_dist   = prod(context.prod_constraint, left_dist, right_dist)
 
     if context.form_constraint_check_strategy === FormConstraintCheckEach()
-        form_trace_id = uuid4()
+        form_span_id = generate_span_id(context.callbacks)
         invoke_callback(
             context.callbacks,
             BeforeFormConstraintAppliedEvent(
-                variable, context, FormConstraintCheckEach(), new_dist, form_trace_id
+                variable, context, FormConstraintCheckEach(), new_dist, form_span_id
             ),
         )
         unconstrained_dist = new_dist
@@ -195,7 +195,7 @@ function compute_product_of_two_messages(
         invoke_callback(
             context.callbacks,
             AfterFormConstraintAppliedEvent(
-                variable, context, FormConstraintCheckEach(), unconstrained_dist, new_dist, form_trace_id
+                variable, context, FormConstraintCheckEach(), unconstrained_dist, new_dist, form_span_id
             ),
         )
     end
@@ -213,7 +213,7 @@ function compute_product_of_two_messages(
     invoke_callback(
         context.callbacks,
         AfterProductOfTwoMessagesEvent(
-            variable, context, left, right, result, new_addons, trace_id
+            variable, context, left, right, result, new_addons, span_id
         ),
     )
 
@@ -239,10 +239,10 @@ See also: [`ReactiveMP.compute_product_of_two_messages`](@ref), [`ReactiveMP.Mes
 function compute_product_of_messages(
     variable::AbstractVariable, context::MessageProductContext, messages
 )
-    trace_id = uuid4()
+    span_id = generate_span_id(context.callbacks)
     invoke_callback(
         context.callbacks,
-        BeforeProductOfMessagesEvent(variable, context, messages, trace_id),
+        BeforeProductOfMessagesEvent(variable, context, messages, span_id),
     )
 
     result = as_message(
@@ -253,18 +253,18 @@ function compute_product_of_messages(
 
     if context.form_constraint_check_strategy === FormConstraintCheckLast()
         dist = getdata(result)
-        form_trace_id = uuid4()
+        form_span_id = generate_span_id(context.callbacks)
         invoke_callback(
             context.callbacks,
             BeforeFormConstraintAppliedEvent(
-                variable, context, FormConstraintCheckLast(), dist, form_trace_id
+                variable, context, FormConstraintCheckLast(), dist, form_span_id
             ),
         )
         constrained_dist = constrain_form(context.form_constraint, dist)
         invoke_callback(
             context.callbacks,
             AfterFormConstraintAppliedEvent(
-                variable, context, FormConstraintCheckLast(), dist, constrained_dist, form_trace_id
+                variable, context, FormConstraintCheckLast(), dist, constrained_dist, form_span_id
             ),
         )
         result = Message(
@@ -277,7 +277,7 @@ function compute_product_of_messages(
 
     invoke_callback(
         context.callbacks,
-        AfterProductOfMessagesEvent(variable, context, messages, result, trace_id),
+        AfterProductOfMessagesEvent(variable, context, messages, result, span_id),
     )
 
     return result
@@ -623,10 +623,10 @@ function (mapping::MessageMapping)(messages, marginals)
             __check_all(is_clamped_or_initial, marginals)
         )
 
-    trace_id = uuid4()
+    span_id = generate_span_id(mapping.callbacks)
     invoke_callback(
         mapping.callbacks,
-        BeforeMessageRuleCallEvent(mapping, messages, marginals, trace_id),
+        BeforeMessageRuleCallEvent(mapping, messages, marginals, span_id),
     )
     result, addons =
         if !isnothing(messages) &&
@@ -668,7 +668,7 @@ function (mapping::MessageMapping)(messages, marginals)
     )
     invoke_callback(
         mapping.callbacks,
-        AfterMessageRuleCallEvent(mapping, messages, marginals, result, addons, trace_id),
+        AfterMessageRuleCallEvent(mapping, messages, marginals, result, addons, span_id),
     )
 
     return Message(result, is_message_clamped, is_message_initial, addons)

--- a/src/variables/random.jl
+++ b/src/variables/random.jl
@@ -126,7 +126,9 @@ function _compute_marginal_from_messages(
     )
     invoke_callback(
         context.callbacks,
-        AfterMarginalComputationEvent(randomvar, context, messages, result, span_id),
+        AfterMarginalComputationEvent(
+            randomvar, context, messages, result, span_id
+        ),
     )
     return result
 end

--- a/src/variables/random.jl
+++ b/src/variables/random.jl
@@ -115,18 +115,18 @@ function _compute_marginal_from_messages(
     options::RandomVariableActivationOptions,
     messages,
 )
-    trace_id = uuid4()
     context = options.prod_context_for_marginal_computation
+    span_id = generate_span_id(context.callbacks)
     invoke_callback(
         context.callbacks,
-        BeforeMarginalComputationEvent(randomvar, context, messages, trace_id),
+        BeforeMarginalComputationEvent(randomvar, context, messages, span_id),
     )
     result = as_marginal(
         compute_product_of_messages(randomvar, context, messages)
     )
     invoke_callback(
         context.callbacks,
-        AfterMarginalComputationEvent(randomvar, context, messages, trace_id, result),
+        AfterMarginalComputationEvent(randomvar, context, messages, result, span_id),
     )
     return result
 end

--- a/test/callbacks_tests.jl
+++ b/test/callbacks_tests.jl
@@ -99,12 +99,12 @@ end
     
     if VERSION >= v"1.12.0"
         # Test that span_id does not cause allocations
-        struct BeforeSuperCoolEvent <: Event{:my_custom_event_243}
-            span_id::UUID
+        struct BeforeSuperCoolEvent{I} <: Event{:my_custom_event_243}
+            span_id::I
         end
-        struct AfterSuperCoolEvent <: Event{:my_custom_event_534}
+        struct AfterSuperCoolEvent{I} <: Event{:my_custom_event_534}
             result::Float64
-            span_id::UUID
+            span_id::I
         end
         
         function bar5(callback_handler, input::Float64)

--- a/test/callbacks_tests.jl
+++ b/test/callbacks_tests.jl
@@ -24,7 +24,7 @@ end
 @testitem "Callbacks handler should do absolutely nothing if no handler exists" setup = [
     CallbacksTestUtils
 ] begin
-    import ReactiveMP: invoke_callback, Event
+    import ReactiveMP: invoke_callback, Event, generate_span_id
     using UUIDs
 
     # We use here a type stable structure to achieve 0 allocations
@@ -98,26 +98,26 @@ end
     
     
     if VERSION >= v"1.12.0"
-        # Test that trace_id does not cause allocations
+        # Test that span_id does not cause allocations
         struct BeforeSuperCoolEvent <: Event{:my_custom_event_243}
-            trace_id::UUID
+            span_id::UUID
         end
         struct AfterSuperCoolEvent <: Event{:my_custom_event_534}
             result::Float64
-            trace_id::UUID
+            span_id::UUID
         end
         
         function bar5(callback_handler, input::Float64)
-            trace_id = uuid4()
+            span_id = generate_span_id(callback_handler)
             
             invoke_callback(callback_handler,
-                BeforeSuperCoolEvent(trace_id)
+                BeforeSuperCoolEvent(span_id)
             )
             
             result = input + 4.0
             
             invoke_callback(callback_handler,
-                AfterSuperCoolEvent(result, trace_id)
+                AfterSuperCoolEvent(result, span_id)
             )
             
             return result

--- a/test/callbacks_tests.jl
+++ b/test/callbacks_tests.jl
@@ -95,8 +95,7 @@ end
     bar4(callback_handler)
 
     @test @allocated(bar4(callback_handler)) === 0
-    
-    
+
     if VERSION >= v"1.12.0"
         # Test that span_id does not cause allocations
         struct BeforeSuperCoolEvent{I} <: Event{:my_custom_event_243}
@@ -106,32 +105,27 @@ end
             result::Float64
             span_id::I
         end
-        
+
         function bar5(callback_handler, input::Float64)
             span_id = generate_span_id(callback_handler)
-            
-            invoke_callback(callback_handler,
-                BeforeSuperCoolEvent(span_id)
-            )
-            
+
+            invoke_callback(callback_handler, BeforeSuperCoolEvent(span_id))
+
             result = input + 4.0
-            
-            invoke_callback(callback_handler,
-                AfterSuperCoolEvent(result, span_id)
+
+            invoke_callback(
+                callback_handler, AfterSuperCoolEvent(result, span_id)
             )
-            
+
             return result
         end
 
         @test bar5(callback_handler, 9.0) == 13.0
         @test @allocated(bar5(callback_handler, 9.0)) === 0
     end
-    
 end
 
-@testitem "invoke_callback should return the event" setup = [
-    CallbacksTestUtils
-] begin
+@testitem "invoke_callback should return the event" setup = [CallbacksTestUtils] begin
     import ReactiveMP: invoke_callback
 
     event = CustomEvent(:event1, 1, 2)
@@ -148,7 +142,8 @@ end
     @test invoke_callback(dict_callbacks, event) === event
 
     # Unmatched event still returns the event
-    @test invoke_callback(callbacks, CustomEvent(:other, 1)) === CustomEvent(:other, 1)
+    @test invoke_callback(callbacks, CustomEvent(:other, 1)) ===
+        CustomEvent(:other, 1)
 end
 
 @testitem "event_name should work on both types and instances" setup = [
@@ -237,11 +232,9 @@ end
 ] begin
     import ReactiveMP: invoke_callback
 
-    callbacks = (
-        my_event = (event) -> begin
-            event.state = sum(event.data)
-        end,
-    )
+    callbacks = (my_event = (event) -> begin
+        event.state = sum(event.data)
+    end,)
 
     event = MutableCustomEvent(:my_event, 3, 4; state = nothing)
     returned_event = invoke_callback(callbacks, event)
@@ -250,15 +243,13 @@ end
     @test event.state === 7
 end
 
-@testitem "Dict callback can mutate event state" setup = [
-    CallbacksTestUtils
-] begin
+@testitem "Dict callback can mutate event state" setup = [CallbacksTestUtils] begin
     import ReactiveMP: invoke_callback
 
     callbacks = Dict{Symbol, Any}(
         :my_event => (event) -> begin
             event.state = prod(event.data)
-        end,
+        end
     )
 
     event = MutableCustomEvent(:my_event, 3, 5; state = nothing)
@@ -336,8 +327,7 @@ end
     import ReactiveMP: invoke_callback
 
     callback_handler = (
-        sum_event = (event) -> nothing,
-        prod_event = (event) -> nothing,
+        sum_event = (event) -> nothing, prod_event = (event) -> nothing
     )
 
     @test invoke_callback(callback_handler, CustomEvent(:sum_event, 1, 2)) isa
@@ -356,8 +346,7 @@ end
     import ReactiveMP: invoke_callback
 
     callback_handler = Dict{Symbol, Any}(
-        :sum_event => (event) -> nothing,
-        :prod_event => (event) -> nothing,
+        :sum_event => (event) -> nothing, :prod_event => (event) -> nothing
     )
 
     @test invoke_callback(callback_handler, CustomEvent(:sum_event, 1, 2)) isa
@@ -394,9 +383,9 @@ end
     end
 
     ReactiveMP.handle_event(::MyCustomHandler, ::Event) = nothing
-    ReactiveMP.handle_event(
-        handler::MyCustomHandler, ::CustomEvent{:event2}
-    ) = push!(handler.events, :event2)
+    ReactiveMP.handle_event(handler::MyCustomHandler, ::CustomEvent{:event2}) = push!(
+        handler.events, :event2
+    )
 
     custom_handler = MyCustomHandler([])
 

--- a/test/message_tests.jl
+++ b/test/message_tests.jl
@@ -14,8 +14,7 @@
 
     @testset "Default methods" begin
         for clamped in (true, false),
-            initial in (true, false),
-            addons in (1, 2),
+            initial in (true, false), addons in (1, 2),
             data in (1, 1.0, Normal(0, 1), Gamma(1, 1), PointMass(1))
 
             msg = Message(data, clamped, initial, addons)
@@ -33,8 +32,7 @@
         dist2 = MvNormalMeanCovariance([0.0, 1.0], [1.0 0.0; 0.0 1.0])
 
         for clamped1 in (true, false),
-            clamped2 in (true, false),
-            initial1 in (true, false),
+            clamped2 in (true, false), initial1 in (true, false),
             initial2 in (true, false)
 
             msg1 = Message(dist1, clamped1, initial1, nothing)
@@ -228,8 +226,9 @@
             end
         end
 
-        _getpoint(rng, distribution) =
-            _getpoint(rng, variate_form(typeof(distribution)), distribution)
+        _getpoint(rng, distribution) = _getpoint(
+            rng, variate_form(typeof(distribution)), distribution
+        )
         _getpoint(rng, ::Type{<:Univariate}, distribution) = 10rand(rng)
         _getpoint(rng, ::Type{<:Multivariate}, distribution) =
             10 .* rand(rng, 2)
@@ -436,8 +435,9 @@ end
     # A simple form constraint that adds +1 to the mean of a Normal distribution
     struct AddOneToMeanConstraint <: AbstractFormConstraint end
 
-    constrain_form(::AddOneToMeanConstraint, dist::Normal) =
-        Normal(dist.mean + 1, dist.var)
+    constrain_form(::AddOneToMeanConstraint, dist::Normal) = Normal(
+        dist.mean + 1, dist.var
+    )
 
     # A callback handler that only records events from a specified set
     struct SaveOrderOfComputationCallbacks
@@ -488,8 +488,7 @@ end
     context = MessageProductContext()
 
     for left_is_clamped in (true, false),
-        right_is_clamped in (true, false),
-        left_is_initial in (true, false),
+        right_is_clamped in (true, false), left_is_initial in (true, false),
         right_is_initial in (true, false)
 
         msg1 = Message(Normal(0, 1), left_is_clamped, left_is_initial, nothing)

--- a/test/variables/random_tests.jl
+++ b/test/variables/random_tests.jl
@@ -165,7 +165,8 @@ end
     function ReactiveMP.invoke_callback(
         handler::MarginalCallbackHandler, event::ReactiveMP.Event{E}
     ) where {E}
-        E ∈ handler.listen_to && push!(handler.events, (event = E, data = event))
+        E ∈ handler.listen_to &&
+            push!(handler.events, (event = E, data = event))
     end
 
     @testset "Fires before and after marginal computation with 3 messages" begin


### PR DESCRIPTION
This PR changes the generation of trace ids (also renamed to span ids) in order to remove massive performance hit for certain models. In my benchmark, the generation of trace IDs affected benchmarks by a factor of 7! And this was even without enabling the callbacks. The current PR changes the implementation a bit by calling an auxiliary function `ReactiveMP.generate_span_id` that would simply return `nothing` if callbacks are also `nothing`. That fixes the performance hit in case when callbacks are not set, but otherwise it still uses `uuid4` (definitely **the** culprit). We may want to use a simple global Int counter for that? Not sure if it would be faster though since this counter would need to be guarded with semaphores to protect from two threads generating the same span ID. 

@fonsp wdyt?