### PR TITLE
fix: improve AddonMemory deprecation error message with migration example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Improved `AddonMemory` deprecation error message to include a before/after migration example and a direct link to the v5-to-v6 migration guide ([#600](https://github.com/ReactiveBayes/RxInfer.jl/issues/600))
+- Improved `AddonLogScale` deprecation error message to include a before/after migration example and a direct link to the v5-to-v6 migration guide
 
 ## [6.1.0] - 04-05-2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Improved `AddonMemory` deprecation error message to include a before/after migration example and a direct link to the v5-to-v6 migration guide ([#600](https://github.com/ReactiveBayes/RxInfer.jl/issues/600))
+
 ## [6.1.0] - 04-05-2026
 
 ### Added

--- a/src/annotations/input_arguments.jl
+++ b/src/annotations/input_arguments.jl
@@ -183,7 +183,7 @@ function AddonMemory(args...; kwargs...)
         """To migrate, replace:\n""" *
         """  addons = (AddonMemory(),)\n""" *
         """with:\n""" *
-        """  addons = (InputArgumentsAnnotations(),)\n""" *
+        """  annotations = (InputArgumentsAnnotations(),)\n""" *
         """See the migration guide: https://reactivebayes.github.io/ReactiveMP.jl/stable/migration-guides/v5-to-v6/""",
     )
 end

--- a/src/annotations/input_arguments.jl
+++ b/src/annotations/input_arguments.jl
@@ -178,7 +178,12 @@ Use [`InputArgumentsAnnotations`](@ref) instead. See the migration guide in the 
 """
 function AddonMemory(args...; kwargs...)
     error(
-        """`AddonMemory` has been removed in ReactiveMP v6 and replaced by `InputArgumentsAnnotations`. """ *
-        """See the migration guide in the documentation for details.""",
+        """`AddonMemory` has been removed in ReactiveMP v6 """ *
+        """and replaced by `InputArgumentsAnnotations`.\n""" *
+        """To migrate, replace:\n""" *
+        """  addons = (AddonMemory(),)\n""" *
+        """with:\n""" *
+        """  addons = (InputArgumentsAnnotations(),)\n""" *
+        """See the migration guide: https://reactivebayes.github.io/ReactiveMP.jl/stable/migration-guides/v5-to-v6/""",
     )
 end

--- a/src/annotations/logscale.jl
+++ b/src/annotations/logscale.jl
@@ -84,7 +84,7 @@ function AddonLogScale(args...; kwargs...)
         """and replaced by `LogScaleAnnotations`.\n""" *
         """\n""" *
         """To migrate, replace:\n""" *
-        """  annotations = (AddonLogScale(),)\n""" *
+        """  addons = (AddonLogScale(),)\n""" *
         """with:\n""" *
         """  annotations = (LogScaleAnnotations(),)\n""" *
         """See the migration guide: https://reactivebayes.github.io/ReactiveMP.jl/stable/migration-guides/v5-to-v6/""",

--- a/src/annotations/logscale.jl
+++ b/src/annotations/logscale.jl
@@ -80,7 +80,13 @@ Use [`LogScaleAnnotations`](@ref) instead. See the migration guide in the docume
 """
 function AddonLogScale(args...; kwargs...)
     error(
-        """`AddonLogScale` has been removed in ReactiveMP v6 and replaced by `LogScaleAnnotations`. """ *
-        """See the migration guide in the documentation for details.""",
+        """`AddonLogScale` has been removed in ReactiveMP v6 """ *
+        """and replaced by `LogScaleAnnotations`.\n""" *
+        """\n""" *
+        """To migrate, replace:\n""" *
+        """  annotations = (AddonLogScale(),)\n""" *
+        """with:\n""" *
+        """  annotations = (LogScaleAnnotations(),)\n""" *
+        """See the migration guide: https://reactivebayes.github.io/ReactiveMP.jl/stable/migration-guides/v5-to-v6/""",
     )
 end


### PR DESCRIPTION
### What

Made the AddonMemory deprecation error message in
src/annotations/input_arguments.jl easier to understand.

Now it shows:

A simple example of what to change before/after
A direct link to the v5-to-v6 migration guide

### Why

Before, the error message was confusing and didn’t tell users what to do (like in RxInfer.jl issue #600).
Now it clearly shows what code to replace and where to find help.

### Changes
src/annotations/input_arguments.jl: updated the error message

1)  Tests pass locally
2)  Code formatted
3) CHANGELOG.md updated