### PR TITLE
Fix KeyError in InputArgumentsAnnotations for clamped messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `InputArgumentsAnnotations`'s `post_product_annotations!` no longer throws `KeyError: key :rule_input_arguments not found` when one side of a message product is a clamped/constant message (e.g. a prior passed into a model as a `Distribution` object) that never went through a rule ([#600](https://github.com/ReactiveBayes/RxInfer.jl/issues/600), [#614](https://github.com/ReactiveBayes/ReactiveMP.jl/pull/614))
+
 ## [6.3.0] - 2026-06-19
 
 ### Added

--- a/src/annotations/input_arguments.jl
+++ b/src/annotations/input_arguments.jl
@@ -115,13 +115,21 @@ function post_product_annotations!(
     left_dist,
     right_dist,
 )
-    left_record  = get_rule_input_arguments(left_ann)
-    right_record = get_rule_input_arguments(right_ann)
-    annotate!(
-        merged,
-        :rule_input_arguments,
-        _merge_input_arguments(left_record, right_record),
-    )
+    has_left  = has_annotation(left_ann, :rule_input_arguments)
+    has_right = has_annotation(right_ann, :rule_input_arguments)
+    if has_left && has_right
+        left_record  = get_rule_input_arguments(left_ann)
+        right_record = get_rule_input_arguments(right_ann)
+        annotate!(
+            merged,
+            :rule_input_arguments,
+            _merge_input_arguments(left_record, right_record),
+        )
+    elseif has_left
+        annotate!(merged, :rule_input_arguments, get_rule_input_arguments(left_ann))
+    elseif has_right
+        annotate!(merged, :rule_input_arguments, get_rule_input_arguments(right_ann))
+    end
     return nothing
 end
 

--- a/test/annotations/input_arguments_tests.jl
+++ b/test/annotations/input_arguments_tests.jl
@@ -218,6 +218,78 @@ end
     @test prod.mappings[4] === r4
 end
 
+@testitem "post_product_annotations! copies the right record through when the left side never ran a rule (e.g. a clamped constant)" setup=[
+    RuleInputArgumentsTestUtils
+] begin
+    import ReactiveMP:
+        AnnotationDict,
+        annotate!,
+        post_product_annotations!,
+        InputArgumentsAnnotations,
+        RuleInputArgumentsRecord,
+        get_rule_input_arguments,
+        has_annotation
+
+    right_record = RuleInputArgumentsRecord(
+        RuleInputArgumentsTestUtils.MockMapping(:right), nothing, nothing, :right_result
+    )
+
+    left_ann  = AnnotationDict() # empty: represents a clamped/constant message, which never runs a rule
+    right_ann = AnnotationDict()
+    annotate!(right_ann, :rule_input_arguments, right_record)
+
+    merged = post_product_annotations!(
+        (InputArgumentsAnnotations(),), left_ann, right_ann, nothing, nothing, nothing
+    )
+
+    @test has_annotation(merged, :rule_input_arguments)
+    @test get_rule_input_arguments(merged) === right_record
+end
+
+@testitem "post_product_annotations! copies the left record through when the right side never ran a rule (e.g. a clamped constant)" setup=[
+    RuleInputArgumentsTestUtils
+] begin
+    import ReactiveMP:
+        AnnotationDict,
+        annotate!,
+        post_product_annotations!,
+        InputArgumentsAnnotations,
+        RuleInputArgumentsRecord,
+        get_rule_input_arguments,
+        has_annotation
+
+    left_record = RuleInputArgumentsRecord(
+        RuleInputArgumentsTestUtils.MockMapping(:left), nothing, nothing, :left_result
+    )
+
+    left_ann  = AnnotationDict()
+    right_ann = AnnotationDict() # empty: represents a clamped/constant message, which never runs a rule
+    annotate!(left_ann, :rule_input_arguments, left_record)
+
+    merged = post_product_annotations!(
+        (InputArgumentsAnnotations(),), left_ann, right_ann, nothing, nothing, nothing
+    )
+
+    @test has_annotation(merged, :rule_input_arguments)
+    @test get_rule_input_arguments(merged) === left_record
+end
+
+@testitem "post_product_annotations! leaves the merged annotation empty when neither side ran a rule (product of two clamped constants)" setup=[
+    RuleInputArgumentsTestUtils
+] begin
+    import ReactiveMP:
+        AnnotationDict, post_product_annotations!, InputArgumentsAnnotations, has_annotation
+
+    left_ann  = AnnotationDict()
+    right_ann = AnnotationDict()
+
+    merged = post_product_annotations!(
+        (InputArgumentsAnnotations(),), left_ann, right_ann, nothing, nothing, nothing
+    )
+
+    @test !has_annotation(merged, :rule_input_arguments)
+end
+
 @testitem "Base.show for RuleInputArgumentsRecord" begin
     import ReactiveMP: RuleInputArgumentsRecord, MessageMapping, Marginalisation
     import BayesBase: PointMass


### PR DESCRIPTION
## Summary

Fixes `KeyError: key :rule_input_arguments not found` thrown by `InputArgumentsAnnotations`'s `post_product_annotations!` when one side of a message product is a clamped/constant message (e.g. a prior passed directly into a model as a `Distribution` object). See ReactiveBayes/RxInfer.jl#600.

## Root cause

A clamped/constant message never runs through a `@rule`, so it gets an empty `AnnotationDict` (`message.jl:57`) . `post_product_annotations!` for `InputArgumentsAnnotations` (`input_arguments.jl:118`) unconditionally assumed both sides of a product have a `:rule_input_arguments` record, so it threw whenever one side was clamped.

`:rule_input_arguments` exists to record which rule produced a message. A clamped side contributes no provenance (there is none), so copying through whichever side *does* have a record is the only choice consistent with what the annotation is for, discarding it would silently lose real information for no reason. When neither side has a record (product of two clamped constants), the merged annotation correctly ends up empty, consistent with annotations being optional metadata elsewhere in the framework.

Existing unit tests for this function always pre-populate both sides manually, so this case had no coverage .

## Fix

Single-file change in `src/annotations/input_arguments.jl`: guard on `has_annotation` for each side before merging, instead of assuming both are always present.

## Testing

- Added 3 new test items to `test/annotations/input_arguments_tests.jl` covering the cases the existing tests didn't: left-side missing, right-side missing, both missing.
- Full existing test suite passes unchanged, including all pre-existing annotation tests.
- Verified end-to-end via `RxInfer.jl`'s `infer()` with a `Distribution`-valued prior + `InputArgumentsAnnotations` previously crashed, now returns posteriors.
- Confirmed the fix is metadata-only: identical posterior with vs. without the annotation active.
- Also stress-tested against a model with multiple clamped priors and a 10-iteration structured VMP loop.

Found a related, independent, pre-existing issue in `LogScaleAnnotations` with the same underlying assumptio, confirmed unrelated to this change (reproduces identically on an unpatched checkout), will open another PR for it, if this works.
