### PR TITLE
ci: add 60-minute timeout to the test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
   test:
     name: Tests ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     continue-on-error: ${{ contains(matrix.version, 'nightly') }}
     permissions:
       actions: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CI: the `test` job now runs with a 60-minute timeout so a hung dependency fails fast instead of consuming GitHub's default 6-hour limit ([#618](https://github.com/ReactiveBayes/ReactiveMP.jl/pull/618))
+
 ## [6.3.1] - 2026-07-06
 
 ### Fixed

--- a/src/annotations/input_arguments.jl
+++ b/src/annotations/input_arguments.jl
@@ -126,9 +126,13 @@ function post_product_annotations!(
             _merge_input_arguments(left_record, right_record),
         )
     elseif has_left
-        annotate!(merged, :rule_input_arguments, get_rule_input_arguments(left_ann))
+        annotate!(
+            merged, :rule_input_arguments, get_rule_input_arguments(left_ann)
+        )
     elseif has_right
-        annotate!(merged, :rule_input_arguments, get_rule_input_arguments(right_ann))
+        annotate!(
+            merged, :rule_input_arguments, get_rule_input_arguments(right_ann)
+        )
     end
     return nothing
 end

--- a/src/helpers/macrohelpers.jl
+++ b/src/helpers/macrohelpers.jl
@@ -115,8 +115,9 @@ macro test_inferred(T, expression)
         quote
             let
                 local result = Test.@inferred($expression)
-                if !(ReactiveMP.MacroHelpers.__test_inferred_typeof(result) <:
-                     $T)
+                if !(
+                    ReactiveMP.MacroHelpers.__test_inferred_typeof(result) <: $T
+                )
                     error(
                         "Result type $(ReactiveMP.MacroHelpers.__test_inferred_typeof(result)) does not match allowed type $T",
                     )

--- a/src/nodes/predefined/continuous_transition.jl
+++ b/src/nodes/predefined/continuous_transition.jl
@@ -95,7 +95,7 @@ default_meta(::Type{CTMeta}) =
     error("ContinuousTransition node requires meta flag explicitly specified")
 
 default_functional_dependencies(::Type{<:ContinuousTransition}) =
-    RequireMarginalFunctionalDependencies(a = nothing)
+    RequireMarginalFunctionalDependencies(; a = nothing)
 
 """
     `ctcompanion_matrix` casts a vector `a` into a matrix `A` by means of linearization of the transformation function `f` around the expansion point `a0`.

--- a/src/nodes/predefined/probit.jl
+++ b/src/nodes/predefined/probit.jl
@@ -17,7 +17,7 @@ ProbitMeta(; p = 32) = ProbitMeta(p)
 default_meta(::Type{Probit}) = ProbitMeta(32)
 
 default_functional_dependencies(::Type{<:Probit}) =
-    RequireMessageFunctionalDependencies(in = NormalMeanPrecision(0.0, 100.0))
+    RequireMessageFunctionalDependencies(; in = NormalMeanPrecision(0.0, 100.0))
 
 @average_energy Probit (
     q_out::Union{PointMass, Bernoulli},

--- a/test/annotations/input_arguments_tests.jl
+++ b/test/annotations/input_arguments_tests.jl
@@ -231,7 +231,10 @@ end
         has_annotation
 
     right_record = RuleInputArgumentsRecord(
-        RuleInputArgumentsTestUtils.MockMapping(:right), nothing, nothing, :right_result
+        RuleInputArgumentsTestUtils.MockMapping(:right),
+        nothing,
+        nothing,
+        :right_result,
     )
 
     left_ann  = AnnotationDict() # empty: represents a clamped/constant message, which never runs a rule
@@ -239,7 +242,12 @@ end
     annotate!(right_ann, :rule_input_arguments, right_record)
 
     merged = post_product_annotations!(
-        (InputArgumentsAnnotations(),), left_ann, right_ann, nothing, nothing, nothing
+        (InputArgumentsAnnotations(),),
+        left_ann,
+        right_ann,
+        nothing,
+        nothing,
+        nothing,
     )
 
     @test has_annotation(merged, :rule_input_arguments)
@@ -259,7 +267,10 @@ end
         has_annotation
 
     left_record = RuleInputArgumentsRecord(
-        RuleInputArgumentsTestUtils.MockMapping(:left), nothing, nothing, :left_result
+        RuleInputArgumentsTestUtils.MockMapping(:left),
+        nothing,
+        nothing,
+        :left_result,
     )
 
     left_ann  = AnnotationDict()
@@ -267,7 +278,12 @@ end
     annotate!(left_ann, :rule_input_arguments, left_record)
 
     merged = post_product_annotations!(
-        (InputArgumentsAnnotations(),), left_ann, right_ann, nothing, nothing, nothing
+        (InputArgumentsAnnotations(),),
+        left_ann,
+        right_ann,
+        nothing,
+        nothing,
+        nothing,
     )
 
     @test has_annotation(merged, :rule_input_arguments)
@@ -278,13 +294,21 @@ end
     RuleInputArgumentsTestUtils
 ] begin
     import ReactiveMP:
-        AnnotationDict, post_product_annotations!, InputArgumentsAnnotations, has_annotation
+        AnnotationDict,
+        post_product_annotations!,
+        InputArgumentsAnnotations,
+        has_annotation
 
     left_ann  = AnnotationDict()
     right_ann = AnnotationDict()
 
     merged = post_product_annotations!(
-        (InputArgumentsAnnotations(),), left_ann, right_ann, nothing, nothing, nothing
+        (InputArgumentsAnnotations(),),
+        left_ann,
+        right_ann,
+        nothing,
+        nothing,
+        nothing,
     )
 
     @test !has_annotation(merged, :rule_input_arguments)


### PR DESCRIPTION
## What

Adds `timeout-minutes: 60` to the CI `test` job.

## Why

The job had no timeout, so GitHub applied its default 360-minute cap. A recent upstream regression (Roots.jl v3.0.2, surfacing via `Distributions.quantile` in the `BinomialPolya` PolyaGamma rule) hung the test suite, wasting 6h x 3 Julia versions per run before the jobs were killed. A 60-minute cap fails such hangs quickly; the suite normally finishes in about 25 minutes.

The upstream bug is fixed in Roots v3.0.3+ (the Jul 13 scheduled run on `main` is green again), so this is a guard against future hangs, not a fix for the original one.

Refs:
- JuliaMath/Roots.jl#515
- JuliaStats/Distributions.jl#2080

🤖 Generated with [Claude Code](https://claude.com/claude-code)
